### PR TITLE
style: increased "Offline mode" text size, changed its color in dark theme

### DIFF
--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -47,6 +47,8 @@
         android:layout_height="wrap_content"
         android:gravity="center"
         android:text="@string/activity_info_offline_mode"
-        android:textSize="6sp"
+        android:textSize="12sp"
+        android:textStyle="bold"
         android:visibility="gone" />
+
 </LinearLayout>

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -41,7 +41,7 @@
     </style>
 
     <style name="NoConnectionTextView">
-        <item name="background">?attr/colorError</item>
-        <item name="android:textColor">?attr/colorOnError</item>
+        <item name="background">?attr/colorErrorContainer</item>
+        <item name="android:textColor">?attr/colorOnErrorContainer</item>
     </style>
 </resources>


### PR DESCRIPTION
This PR fixes the style of the "Offline mode" text which was too small, and changes its color in dark mode to a clearer one.

Before:
<img width="380" src="https://github.com/user-attachments/assets/38ade1a7-4a30-430e-9287-713fc98818c9" />

After:
<img width="380" src="https://github.com/user-attachments/assets/6869578e-6935-41d2-9830-78a40762edeb" />