### PR TITLE
feat: rating dialog added to album page

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/RatingDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/RatingDialog.java
@@ -63,7 +63,11 @@ public class RatingDialog extends DialogFragment {
                 bind.ratingBar.setRating(song.getUserRating() != null ? song.getUserRating() : 0);
             });
         } else if (ratingViewModel.getAlbum() != null) {
-            ratingViewModel.getLiveAlbum().observe(this, album -> bind.ratingBar.setRating(/*album.getRating()*/ 0));
+            ratingViewModel.getLiveAlbum().observe(this, album -> {
+                    if (album != null) {
+                    bind.ratingBar.setRating(album.getUserRating() != null ? album.getUserRating() : 0);
+                }
+            });
         } else if (ratingViewModel.getArtist() != null) {
             ratingViewModel.getLiveArtist().observe(this, artist -> bind.ratingBar.setRating(/*artist.getRating()*/ 0));
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
@@ -4,6 +4,7 @@ import android.content.ComponentName;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Parcelable;
 import android.view.LayoutInflater;
 import android.view.Menu;
 import android.view.MenuInflater;
@@ -27,11 +28,13 @@ import com.cappielloantonio.tempo.databinding.FragmentAlbumPageBinding;
 import com.cappielloantonio.tempo.glide.CustomGlideRequest;
 import com.cappielloantonio.tempo.interfaces.ClickCallback;
 import com.cappielloantonio.tempo.model.Download;
+import com.cappielloantonio.tempo.subsonic.models.AlbumID3;
 import com.cappielloantonio.tempo.service.MediaManager;
 import com.cappielloantonio.tempo.service.MediaService;
 import com.cappielloantonio.tempo.ui.activity.MainActivity;
 import com.cappielloantonio.tempo.ui.adapter.SongHorizontalAdapter;
 import com.cappielloantonio.tempo.ui.dialog.PlaylistChooserDialog;
+import com.cappielloantonio.tempo.ui.dialog.RatingDialog;
 import com.cappielloantonio.tempo.util.Constants;
 import com.cappielloantonio.tempo.util.DownloadUtil;
 import com.cappielloantonio.tempo.util.MappingUtil;
@@ -104,6 +107,16 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
 
     @Override
     public boolean onOptionsItemSelected(@NonNull MenuItem item) {
+        if (item.getItemId() == R.id.action_rate_album) {
+            Bundle bundle = new Bundle();
+            AlbumID3 album = albumPageViewModel.getAlbum().getValue();
+            bundle.putParcelable(Constants.ALBUM_OBJECT, (Parcelable) album);
+            RatingDialog dialog = new RatingDialog();
+            dialog.setArguments(bundle);
+            dialog.show(requireActivity().getSupportFragmentManager(), null);
+            return true;
+        }
+
         if (item.getItemId() == R.id.action_download_album) {
             albumPageViewModel.getAlbumSongLiveList().observe(getViewLifecycleOwner(), songs -> {
                 DownloadUtil.getDownloadTracker(requireContext()).download(MappingUtil.mapDownloads(songs), songs.stream().map(Download::new).collect(Collectors.toList()));

--- a/app/src/main/res/menu/album_page_menu.xml
+++ b/app/src/main/res/menu/album_page_menu.xml
@@ -11,4 +11,9 @@
         android:icon="@drawable/ic_add"
         android:title="@string/menu_add_to_playlist_button"
         app:showAsAction="never" />
+    <item
+        android:id="@+id/action_rate_album"
+        android:icon="@drawable/ic_add"
+        android:title="@string/menu_rate_album"
+        app:showAsAction="never" />
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -164,6 +164,7 @@
     <string name="menu_add_button">Add</string>
     <string name="menu_add_to_playlist_button">Add to playlist</string>
     <string name="menu_download_all_button">Download all</string>
+    <string name="menu_rate_album">Rate album</string>
     <string name="menu_download_label">Download</string>
     <string name="menu_filter_all">All</string>
     <string name="menu_filter_download">Downloaded</string>


### PR DESCRIPTION
closes #18 

Adding this in the album page view as the quickest way to get this in. 
<img width="377" height="437" alt="Image" src="https://github.com/user-attachments/assets/93c88a41-6e3e-4ed8-af10-f53a9922a9a0" />
Leverages the existing rating dialog. 

<img width="377" height="528" alt="Image" src="https://github.com/user-attachments/assets/e3d14df2-70ae-4029-8fdd-112b8bb2c11f" />

Will get this in the next release after a little more testing. 