### PR TITLE
feat: Enable downloading of song lyrics for offline viewing

### DIFF
--- a/app/schemas/com.cappielloantonio.tempo.database.AppDatabase/12.json
+++ b/app/schemas/com.cappielloantonio.tempo.database.AppDatabase/12.json
@@ -1,0 +1,1151 @@
+{
+    "formatVersion": 1,
+    "database": {
+        "version": 12,
+        "identityHash": "2d26471ae15a1cdaf996261b72f81613",
+        "entities": [
+            {
+                "tableName": "queue",
+                "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `track_order` INTEGER NOT NULL, `last_play` INTEGER NOT NULL, `playing_changed` INTEGER NOT NULL, `stream_id` TEXT, `parent_id` TEXT, `is_dir` INTEGER NOT NULL, `title` TEXT, `album` TEXT, `artist` TEXT, `track` INTEGER, `year` INTEGER, `genre` TEXT, `cover_art_id` TEXT, `size` INTEGER, `content_type` TEXT, `suffix` TEXT, `transcoding_content_type` TEXT, `transcoded_suffix` TEXT, `duration` INTEGER, `bitrate` INTEGER, `sampling_rate` INTEGER, `bit_depth` INTEGER, `path` TEXT, `is_video` INTEGER NOT NULL, `user_rating` INTEGER, `average_rating` REAL, `play_count` INTEGER, `disc_number` INTEGER, `created` INTEGER, `starred` INTEGER, `album_id` TEXT, `artist_id` TEXT, `type` TEXT, `bookmark_position` INTEGER, `original_width` INTEGER, `original_height` INTEGER, PRIMARY KEY(`track_order`))",
+                "fields": [
+                    {
+                        "fieldPath": "id",
+                        "columnName": "id",
+                        "affinity": "TEXT",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "trackOrder",
+                        "columnName": "track_order",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "lastPlay",
+                        "columnName": "last_play",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "playingChanged",
+                        "columnName": "playing_changed",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "streamId",
+                        "columnName": "stream_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "parentId",
+                        "columnName": "parent_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "isDir",
+                        "columnName": "is_dir",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "title",
+                        "columnName": "title",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "album",
+                        "columnName": "album",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "artist",
+                        "columnName": "artist",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "track",
+                        "columnName": "track",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "year",
+                        "columnName": "year",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "genre",
+                        "columnName": "genre",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "coverArtId",
+                        "columnName": "cover_art_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "size",
+                        "columnName": "size",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "contentType",
+                        "columnName": "content_type",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "suffix",
+                        "columnName": "suffix",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "transcodedContentType",
+                        "columnName": "transcoding_content_type",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "transcodedSuffix",
+                        "columnName": "transcoded_suffix",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "duration",
+                        "columnName": "duration",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "bitrate",
+                        "columnName": "bitrate",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "samplingRate",
+                        "columnName": "sampling_rate",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "bitDepth",
+                        "columnName": "bit_depth",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "path",
+                        "columnName": "path",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "isVideo",
+                        "columnName": "is_video",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "userRating",
+                        "columnName": "user_rating",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "averageRating",
+                        "columnName": "average_rating",
+                        "affinity": "REAL",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "playCount",
+                        "columnName": "play_count",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "discNumber",
+                        "columnName": "disc_number",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "created",
+                        "columnName": "created",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "starred",
+                        "columnName": "starred",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "albumId",
+                        "columnName": "album_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "artistId",
+                        "columnName": "artist_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "type",
+                        "columnName": "type",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "bookmarkPosition",
+                        "columnName": "bookmark_position",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "originalWidth",
+                        "columnName": "original_width",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "originalHeight",
+                        "columnName": "original_height",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    }
+                ],
+                "primaryKey": {
+                    "autoGenerate": false,
+                    "columnNames": [
+                        "track_order"
+                    ]
+                },
+                "indices": [],
+                "foreignKeys": []
+            },
+            {
+                "tableName": "server",
+                "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `server_name` TEXT NOT NULL, `username` TEXT NOT NULL, `password` TEXT NOT NULL, `address` TEXT NOT NULL, `local_address` TEXT, `timestamp` INTEGER NOT NULL, `low_security` INTEGER NOT NULL DEFAULT false, PRIMARY KEY(`id`))",
+                "fields": [
+                    {
+                        "fieldPath": "serverId",
+                        "columnName": "id",
+                        "affinity": "TEXT",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "serverName",
+                        "columnName": "server_name",
+                        "affinity": "TEXT",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "username",
+                        "columnName": "username",
+                        "affinity": "TEXT",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "password",
+                        "columnName": "password",
+                        "affinity": "TEXT",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "address",
+                        "columnName": "address",
+                        "affinity": "TEXT",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "localAddress",
+                        "columnName": "local_address",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "timestamp",
+                        "columnName": "timestamp",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "isLowSecurity",
+                        "columnName": "low_security",
+                        "affinity": "INTEGER",
+                        "notNull": true,
+                        "defaultValue": "false"
+                    }
+                ],
+                "primaryKey": {
+                    "autoGenerate": false,
+                    "columnNames": [
+                        "id"
+                    ]
+                },
+                "indices": [],
+                "foreignKeys": []
+            },
+            {
+                "tableName": "recent_search",
+                "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`search` TEXT NOT NULL, PRIMARY KEY(`search`))",
+                "fields": [
+                    {
+                        "fieldPath": "search",
+                        "columnName": "search",
+                        "affinity": "TEXT",
+                        "notNull": true
+                    }
+                ],
+                "primaryKey": {
+                    "autoGenerate": false,
+                    "columnNames": [
+                        "search"
+                    ]
+                },
+                "indices": [],
+                "foreignKeys": []
+            },
+            {
+                "tableName": "download",
+                "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `playlist_id` TEXT, `playlist_name` TEXT, `download_state` INTEGER NOT NULL DEFAULT 1, `download_uri` TEXT DEFAULT '', `parent_id` TEXT, `is_dir` INTEGER NOT NULL, `title` TEXT, `album` TEXT, `artist` TEXT, `track` INTEGER, `year` INTEGER, `genre` TEXT, `cover_art_id` TEXT, `size` INTEGER, `content_type` TEXT, `suffix` TEXT, `transcoding_content_type` TEXT, `transcoded_suffix` TEXT, `duration` INTEGER, `bitrate` INTEGER, `sampling_rate` INTEGER, `bit_depth` INTEGER, `path` TEXT, `is_video` INTEGER NOT NULL, `user_rating` INTEGER, `average_rating` REAL, `play_count` INTEGER, `disc_number` INTEGER, `created` INTEGER, `starred` INTEGER, `album_id` TEXT, `artist_id` TEXT, `type` TEXT, `bookmark_position` INTEGER, `original_width` INTEGER, `original_height` INTEGER, PRIMARY KEY(`id`))",
+                "fields": [
+                    {
+                        "fieldPath": "id",
+                        "columnName": "id",
+                        "affinity": "TEXT",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "playlistId",
+                        "columnName": "playlist_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "playlistName",
+                        "columnName": "playlist_name",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "downloadState",
+                        "columnName": "download_state",
+                        "affinity": "INTEGER",
+                        "notNull": true,
+                        "defaultValue": "1"
+                    },
+                    {
+                        "fieldPath": "downloadUri",
+                        "columnName": "download_uri",
+                        "affinity": "TEXT",
+                        "notNull": false,
+                        "defaultValue": "''"
+                    },
+                    {
+                        "fieldPath": "parentId",
+                        "columnName": "parent_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "isDir",
+                        "columnName": "is_dir",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "title",
+                        "columnName": "title",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "album",
+                        "columnName": "album",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "artist",
+                        "columnName": "artist",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "track",
+                        "columnName": "track",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "year",
+                        "columnName": "year",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "genre",
+                        "columnName": "genre",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "coverArtId",
+                        "columnName": "cover_art_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "size",
+                        "columnName": "size",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "contentType",
+                        "columnName": "content_type",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "suffix",
+                        "columnName": "suffix",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "transcodedContentType",
+                        "columnName": "transcoding_content_type",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "transcodedSuffix",
+                        "columnName": "transcoded_suffix",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "duration",
+                        "columnName": "duration",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "bitrate",
+                        "columnName": "bitrate",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "samplingRate",
+                        "columnName": "sampling_rate",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "bitDepth",
+                        "columnName": "bit_depth",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "path",
+                        "columnName": "path",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "isVideo",
+                        "columnName": "is_video",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "userRating",
+                        "columnName": "user_rating",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "averageRating",
+                        "columnName": "average_rating",
+                        "affinity": "REAL",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "playCount",
+                        "columnName": "play_count",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "discNumber",
+                        "columnName": "disc_number",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "created",
+                        "columnName": "created",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "starred",
+                        "columnName": "starred",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "albumId",
+                        "columnName": "album_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "artistId",
+                        "columnName": "artist_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "type",
+                        "columnName": "type",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "bookmarkPosition",
+                        "columnName": "bookmark_position",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "originalWidth",
+                        "columnName": "original_width",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "originalHeight",
+                        "columnName": "original_height",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    }
+                ],
+                "primaryKey": {
+                    "autoGenerate": false,
+                    "columnNames": [
+                        "id"
+                    ]
+                },
+                "indices": [],
+                "foreignKeys": []
+            },
+            {
+                "tableName": "chronology",
+                "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `timestamp` INTEGER NOT NULL, `server` TEXT, `parent_id` TEXT, `is_dir` INTEGER NOT NULL, `title` TEXT, `album` TEXT, `artist` TEXT, `track` INTEGER, `year` INTEGER, `genre` TEXT, `cover_art_id` TEXT, `size` INTEGER, `content_type` TEXT, `suffix` TEXT, `transcoding_content_type` TEXT, `transcoded_suffix` TEXT, `duration` INTEGER, `bitrate` INTEGER, `sampling_rate` INTEGER, `bit_depth` INTEGER, `path` TEXT, `is_video` INTEGER NOT NULL, `user_rating` INTEGER, `average_rating` REAL, `play_count` INTEGER, `disc_number` INTEGER, `created` INTEGER, `starred` INTEGER, `album_id` TEXT, `artist_id` TEXT, `type` TEXT, `bookmark_position` INTEGER, `original_width` INTEGER, `original_height` INTEGER, PRIMARY KEY(`id`))",
+                "fields": [
+                    {
+                        "fieldPath": "id",
+                        "columnName": "id",
+                        "affinity": "TEXT",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "timestamp",
+                        "columnName": "timestamp",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "server",
+                        "columnName": "server",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "parentId",
+                        "columnName": "parent_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "isDir",
+                        "columnName": "is_dir",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "title",
+                        "columnName": "title",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "album",
+                        "columnName": "album",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "artist",
+                        "columnName": "artist",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "track",
+                        "columnName": "track",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "year",
+                        "columnName": "year",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "genre",
+                        "columnName": "genre",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "coverArtId",
+                        "columnName": "cover_art_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "size",
+                        "columnName": "size",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "contentType",
+                        "columnName": "content_type",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "suffix",
+                        "columnName": "suffix",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "transcodedContentType",
+                        "columnName": "transcoding_content_type",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "transcodedSuffix",
+                        "columnName": "transcoded_suffix",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "duration",
+                        "columnName": "duration",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "bitrate",
+                        "columnName": "bitrate",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "samplingRate",
+                        "columnName": "sampling_rate",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "bitDepth",
+                        "columnName": "bit_depth",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "path",
+                        "columnName": "path",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "isVideo",
+                        "columnName": "is_video",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "userRating",
+                        "columnName": "user_rating",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "averageRating",
+                        "columnName": "average_rating",
+                        "affinity": "REAL",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "playCount",
+                        "columnName": "play_count",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "discNumber",
+                        "columnName": "disc_number",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "created",
+                        "columnName": "created",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "starred",
+                        "columnName": "starred",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "albumId",
+                        "columnName": "album_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "artistId",
+                        "columnName": "artist_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "type",
+                        "columnName": "type",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "bookmarkPosition",
+                        "columnName": "bookmark_position",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "originalWidth",
+                        "columnName": "original_width",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "originalHeight",
+                        "columnName": "original_height",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    }
+                ],
+                "primaryKey": {
+                    "autoGenerate": false,
+                    "columnNames": [
+                        "id"
+                    ]
+                },
+                "indices": [],
+                "foreignKeys": []
+            },
+            {
+                "tableName": "favorite",
+                "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`timestamp` INTEGER NOT NULL, `songId` TEXT, `albumId` TEXT, `artistId` TEXT, `toStar` INTEGER NOT NULL, PRIMARY KEY(`timestamp`))",
+                "fields": [
+                    {
+                        "fieldPath": "timestamp",
+                        "columnName": "timestamp",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "songId",
+                        "columnName": "songId",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "albumId",
+                        "columnName": "albumId",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "artistId",
+                        "columnName": "artistId",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "toStar",
+                        "columnName": "toStar",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    }
+                ],
+                "primaryKey": {
+                    "autoGenerate": false,
+                    "columnNames": [
+                        "timestamp"
+                    ]
+                },
+                "indices": [],
+                "foreignKeys": []
+            },
+            {
+                "tableName": "session_media_item",
+                "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`index` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `id` TEXT, `parent_id` TEXT, `is_dir` INTEGER NOT NULL, `title` TEXT, `album` TEXT, `artist` TEXT, `track` INTEGER, `year` INTEGER, `genre` TEXT, `cover_art_id` TEXT, `size` INTEGER, `content_type` TEXT, `suffix` TEXT, `transcoding_content_type` TEXT, `transcoded_suffix` TEXT, `duration` INTEGER, `bitrate` INTEGER, `path` TEXT, `is_video` INTEGER NOT NULL, `user_rating` INTEGER, `average_rating` REAL, `play_count` INTEGER, `disc_number` INTEGER, `created` INTEGER, `starred` INTEGER, `album_id` TEXT, `artist_id` TEXT, `type` TEXT, `bookmark_position` INTEGER, `original_width` INTEGER, `original_height` INTEGER, `stream_id` TEXT, `stream_url` TEXT, `timestamp` INTEGER)",
+                "fields": [
+                    {
+                        "fieldPath": "index",
+                        "columnName": "index",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "id",
+                        "columnName": "id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "parentId",
+                        "columnName": "parent_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "isDir",
+                        "columnName": "is_dir",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "title",
+                        "columnName": "title",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "album",
+                        "columnName": "album",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "artist",
+                        "columnName": "artist",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "track",
+                        "columnName": "track",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "year",
+                        "columnName": "year",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "genre",
+                        "columnName": "genre",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "coverArtId",
+                        "columnName": "cover_art_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "size",
+                        "columnName": "size",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "contentType",
+                        "columnName": "content_type",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "suffix",
+                        "columnName": "suffix",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "transcodedContentType",
+                        "columnName": "transcoding_content_type",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "transcodedSuffix",
+                        "columnName": "transcoded_suffix",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "duration",
+                        "columnName": "duration",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "bitrate",
+                        "columnName": "bitrate",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "path",
+                        "columnName": "path",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "isVideo",
+                        "columnName": "is_video",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "userRating",
+                        "columnName": "user_rating",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "averageRating",
+                        "columnName": "average_rating",
+                        "affinity": "REAL",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "playCount",
+                        "columnName": "play_count",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "discNumber",
+                        "columnName": "disc_number",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "created",
+                        "columnName": "created",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "starred",
+                        "columnName": "starred",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "albumId",
+                        "columnName": "album_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "artistId",
+                        "columnName": "artist_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "type",
+                        "columnName": "type",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "bookmarkPosition",
+                        "columnName": "bookmark_position",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "originalWidth",
+                        "columnName": "original_width",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "originalHeight",
+                        "columnName": "original_height",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "streamId",
+                        "columnName": "stream_id",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "streamUrl",
+                        "columnName": "stream_url",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "timestamp",
+                        "columnName": "timestamp",
+                        "affinity": "INTEGER",
+                        "notNull": false
+                    }
+                ],
+                "primaryKey": {
+                    "autoGenerate": true,
+                    "columnNames": [
+                        "index"
+                    ]
+                },
+                "indices": [],
+                "foreignKeys": []
+            },
+            {
+                "tableName": "playlist",
+                "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT, `duration` INTEGER NOT NULL, `coverArt` TEXT, PRIMARY KEY(`id`))",
+                "fields": [
+                    {
+                        "fieldPath": "id",
+                        "columnName": "id",
+                        "affinity": "TEXT",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "name",
+                        "columnName": "name",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "duration",
+                        "columnName": "duration",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "coverArtId",
+                        "columnName": "coverArt",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    }
+                ],
+                "primaryKey": {
+                    "autoGenerate": false,
+                    "columnNames": [
+                        "id"
+                    ]
+                },
+                "indices": [],
+                "foreignKeys": []
+            },
+            {
+                "tableName": "lyrics_cache",
+                "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`song_id` TEXT NOT NULL, `artist` TEXT, `title` TEXT, `lyrics` TEXT, `structured_lyrics` TEXT, `updated_at` INTEGER NOT NULL, PRIMARY KEY(`song_id`))",
+                "fields": [
+                    {
+                        "fieldPath": "songId",
+                        "columnName": "song_id",
+                        "affinity": "TEXT",
+                        "notNull": true
+                    },
+                    {
+                        "fieldPath": "artist",
+                        "columnName": "artist",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "title",
+                        "columnName": "title",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "lyrics",
+                        "columnName": "lyrics",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "structuredLyrics",
+                        "columnName": "structured_lyrics",
+                        "affinity": "TEXT",
+                        "notNull": false
+                    },
+                    {
+                        "fieldPath": "updatedAt",
+                        "columnName": "updated_at",
+                        "affinity": "INTEGER",
+                        "notNull": true
+                    }
+                ],
+                "primaryKey": {
+                    "autoGenerate": false,
+                    "columnNames": [
+                        "song_id"
+                    ]
+                },
+                "indices": [],
+                "foreignKeys": []
+            }
+        ],
+        "views": [],
+        "setupQueries": [
+            "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+            "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '2d26471ae15a1cdaf996261b72f81613')"
+        ]
+    }
+}

--- a/app/src/main/java/com/cappielloantonio/tempo/database/AppDatabase.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/database/AppDatabase.java
@@ -12,6 +12,7 @@ import com.cappielloantonio.tempo.database.converter.DateConverters;
 import com.cappielloantonio.tempo.database.dao.ChronologyDao;
 import com.cappielloantonio.tempo.database.dao.DownloadDao;
 import com.cappielloantonio.tempo.database.dao.FavoriteDao;
+import com.cappielloantonio.tempo.database.dao.LyricsDao;
 import com.cappielloantonio.tempo.database.dao.PlaylistDao;
 import com.cappielloantonio.tempo.database.dao.QueueDao;
 import com.cappielloantonio.tempo.database.dao.RecentSearchDao;
@@ -20,6 +21,7 @@ import com.cappielloantonio.tempo.database.dao.SessionMediaItemDao;
 import com.cappielloantonio.tempo.model.Chronology;
 import com.cappielloantonio.tempo.model.Download;
 import com.cappielloantonio.tempo.model.Favorite;
+import com.cappielloantonio.tempo.model.LyricsCache;
 import com.cappielloantonio.tempo.model.Queue;
 import com.cappielloantonio.tempo.model.RecentSearch;
 import com.cappielloantonio.tempo.model.Server;
@@ -28,9 +30,9 @@ import com.cappielloantonio.tempo.subsonic.models.Playlist;
 
 @UnstableApi
 @Database(
-        version = 11,
-        entities = {Queue.class, Server.class, RecentSearch.class, Download.class, Chronology.class, Favorite.class, SessionMediaItem.class, Playlist.class},
-        autoMigrations = {@AutoMigration(from = 10, to = 11)}
+        version = 12,
+        entities = {Queue.class, Server.class, RecentSearch.class, Download.class, Chronology.class, Favorite.class, SessionMediaItem.class, Playlist.class, LyricsCache.class},
+        autoMigrations = {@AutoMigration(from = 10, to = 11), @AutoMigration(from = 11, to = 12)}
 )
 @TypeConverters({DateConverters.class})
 public abstract class AppDatabase extends RoomDatabase {
@@ -62,4 +64,6 @@ public abstract class AppDatabase extends RoomDatabase {
     public abstract SessionMediaItemDao sessionMediaItemDao();
 
     public abstract PlaylistDao playlistDao();
+
+    public abstract LyricsDao lyricsDao();
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/database/dao/LyricsDao.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/database/dao/LyricsDao.java
@@ -1,0 +1,24 @@
+package com.cappielloantonio.tempo.database.dao;
+
+import androidx.lifecycle.LiveData;
+import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
+import androidx.room.Query;
+
+import com.cappielloantonio.tempo.model.LyricsCache;
+
+@Dao
+public interface LyricsDao {
+    @Query("SELECT * FROM lyrics_cache WHERE song_id = :songId")
+    LyricsCache getOne(String songId);
+
+    @Query("SELECT * FROM lyrics_cache WHERE song_id = :songId")
+    LiveData<LyricsCache> observeOne(String songId);
+
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    void insert(LyricsCache lyricsCache);
+
+    @Query("DELETE FROM lyrics_cache WHERE song_id = :songId")
+    void delete(String songId);
+}

--- a/app/src/main/java/com/cappielloantonio/tempo/model/LyricsCache.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/model/LyricsCache.kt
@@ -1,0 +1,25 @@
+package com.cappielloantonio.tempo.model
+
+import androidx.annotation.Keep
+import androidx.room.ColumnInfo
+import androidx.room.Entity
+import androidx.room.PrimaryKey
+import kotlin.jvm.JvmOverloads
+
+@Keep
+@Entity(tableName = "lyrics_cache")
+data class LyricsCache @JvmOverloads constructor(
+    @PrimaryKey
+    @ColumnInfo(name = "song_id")
+    var songId: String,
+    @ColumnInfo(name = "artist")
+    var artist: String? = null,
+    @ColumnInfo(name = "title")
+    var title: String? = null,
+    @ColumnInfo(name = "lyrics")
+    var lyrics: String? = null,
+    @ColumnInfo(name = "structured_lyrics")
+    var structuredLyrics: String? = null,
+    @ColumnInfo(name = "updated_at")
+    var updatedAt: Long = System.currentTimeMillis()
+)

--- a/app/src/main/java/com/cappielloantonio/tempo/repository/LyricsRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/LyricsRepository.java
@@ -1,0 +1,92 @@
+package com.cappielloantonio.tempo.repository;
+
+import androidx.lifecycle.LiveData;
+
+import com.cappielloantonio.tempo.database.AppDatabase;
+import com.cappielloantonio.tempo.database.dao.LyricsDao;
+import com.cappielloantonio.tempo.model.LyricsCache;
+
+public class LyricsRepository {
+    private final LyricsDao lyricsDao = AppDatabase.getInstance().lyricsDao();
+
+    public LyricsCache getLyrics(String songId) {
+        GetLyricsThreadSafe getLyricsThreadSafe = new GetLyricsThreadSafe(lyricsDao, songId);
+        Thread thread = new Thread(getLyricsThreadSafe);
+        thread.start();
+
+        try {
+            thread.join();
+            return getLyricsThreadSafe.getLyrics();
+        } catch (InterruptedException e) {
+            e.printStackTrace();
+        }
+
+        return null;
+    }
+
+    public LiveData<LyricsCache> observeLyrics(String songId) {
+        return lyricsDao.observeOne(songId);
+    }
+
+    public void insert(LyricsCache lyricsCache) {
+        InsertThreadSafe insert = new InsertThreadSafe(lyricsDao, lyricsCache);
+        Thread thread = new Thread(insert);
+        thread.start();
+    }
+
+    public void delete(String songId) {
+        DeleteThreadSafe delete = new DeleteThreadSafe(lyricsDao, songId);
+        Thread thread = new Thread(delete);
+        thread.start();
+    }
+
+    private static class GetLyricsThreadSafe implements Runnable {
+        private final LyricsDao lyricsDao;
+        private final String songId;
+        private LyricsCache lyricsCache;
+
+        public GetLyricsThreadSafe(LyricsDao lyricsDao, String songId) {
+            this.lyricsDao = lyricsDao;
+            this.songId = songId;
+        }
+
+        @Override
+        public void run() {
+            lyricsCache = lyricsDao.getOne(songId);
+        }
+
+        public LyricsCache getLyrics() {
+            return lyricsCache;
+        }
+    }
+
+    private static class InsertThreadSafe implements Runnable {
+        private final LyricsDao lyricsDao;
+        private final LyricsCache lyricsCache;
+
+        public InsertThreadSafe(LyricsDao lyricsDao, LyricsCache lyricsCache) {
+            this.lyricsDao = lyricsDao;
+            this.lyricsCache = lyricsCache;
+        }
+
+        @Override
+        public void run() {
+            lyricsDao.insert(lyricsCache);
+        }
+    }
+
+    private static class DeleteThreadSafe implements Runnable {
+        private final LyricsDao lyricsDao;
+        private final String songId;
+
+        public DeleteThreadSafe(LyricsDao lyricsDao, String songId) {
+            this.lyricsDao = lyricsDao;
+            this.songId = songId;
+        }
+
+        @Override
+        public void run() {
+            lyricsDao.delete(songId);
+        }
+    }
+}

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsFragment.java
@@ -116,6 +116,7 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         actionChangeDownloadStorage();
         actionDeleteDownloadStorage();
         actionKeepScreenOn();
+        actionAutoDownloadLyrics();
 
         bindMediaService();
         actionAppEqualizer();
@@ -353,6 +354,21 @@ public class SettingsFragment extends PreferenceFragmentCompat {
         findPreference("delete_download_storage").setOnPreferenceClickListener(preference -> {
             DeleteDownloadStorageDialog dialog = new DeleteDownloadStorageDialog();
             dialog.show(activity.getSupportFragmentManager(), null);
+            return true;
+        });
+    }
+
+    private void actionAutoDownloadLyrics() {
+        SwitchPreference preference = findPreference("auto_download_lyrics");
+        if (preference == null) {
+            return;
+        }
+
+        preference.setChecked(Preferences.isAutoDownloadLyricsEnabled());
+        preference.setOnPreferenceChangeListener((pref, newValue) -> {
+            if (newValue instanceof Boolean) {
+                Preferences.setAutoDownloadLyricsEnabled((Boolean) newValue);
+            }
             return true;
         });
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -46,6 +46,7 @@ object Preferences {
     private const val ROUNDED_CORNER_SIZE = "rounded_corner_size"
     private const val PODCAST_SECTION_VISIBILITY = "podcast_section_visibility"
     private const val RADIO_SECTION_VISIBILITY = "radio_section_visibility"
+    private const val AUTO_DOWNLOAD_LYRICS = "auto_download_lyrics"
     private const val MUSIC_DIRECTORY_SECTION_VISIBILITY = "music_directory_section_visibility"
     private const val REPLAY_GAIN_MODE = "replay_gain_mode"
     private const val AUDIO_TRANSCODE_PRIORITY = "audio_transcode_priority"
@@ -161,6 +162,24 @@ object Preferences {
     @JvmStatic
     fun setOpenSubsonicExtensions(extension: List<OpenSubsonicExtension>) {
         App.getInstance().preferences.edit().putString(OPEN_SUBSONIC_EXTENSIONS, Gson().toJson(extension)).apply()
+    }
+
+    @JvmStatic
+    fun isAutoDownloadLyricsEnabled(): Boolean {
+        val preferences = App.getInstance().preferences
+
+        if (preferences.contains(AUTO_DOWNLOAD_LYRICS)) {
+            return preferences.getBoolean(AUTO_DOWNLOAD_LYRICS, false)
+        }
+
+        return false
+    }
+
+    @JvmStatic
+    fun setAutoDownloadLyricsEnabled(isEnabled: Boolean) {
+        App.getInstance().preferences.edit()
+            .putBoolean(AUTO_DOWNLOAD_LYRICS, isEnabled)
+            .apply()
     }
 
     @JvmStatic

--- a/app/src/main/res/layout/inner_fragment_player_lyrics.xml
+++ b/app/src/main/res/layout/inner_fragment_player_lyrics.xml
@@ -51,7 +51,25 @@
             app:layout_constraintTop_toTopOf="parent" />
     </androidx.core.widget.NestedScrollView>
 
-    <Button
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/download_lyrics_button"
+        style="@style/Widget.Material3.Button.TonalButton.Icon"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:layout_margin="16dp"
+        android:alpha="0.7"
+        android:contentDescription="@string/player_lyrics_download_content_description"
+        android:insetLeft="0dp"
+        android:insetTop="0dp"
+        android:insetRight="0dp"
+        android:insetBottom="0dp"
+        android:visibility="gone"
+        app:cornerRadius="64dp"
+        app:icon="@drawable/ic_download"
+        app:layout_constraintBottom_toTopOf="@+id/sync_lyrics_tap_button"
+        app:layout_constraintEnd_toEndOf="@+id/now_playing_song_lyrics_sroll_view" />
+
+    <com.google.android.material.button.MaterialButton
         android:id="@+id/sync_lyrics_tap_button"
         style="@style/Widget.Material3.Button.TonalButton.Icon"
         android:layout_width="48dp"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -199,6 +199,10 @@
     <string name="player_playback_speed">%1$.2fx</string>
     <string name="player_queue_clean_all_button">Clean play queue</string>
     <string name="player_queue_save_queue_success">Saved play queue</string>
+    <string name="player_lyrics_download_content_description">Download lyrics for offline playback</string>
+    <string name="player_lyrics_downloaded_content_description">Lyrics downloaded for offline playback</string>
+    <string name="player_lyrics_download_success">Lyrics saved for offline playback.</string>
+    <string name="player_lyrics_download_failure">Lyrics are not available to download.</string>
     <string name="player_server_priority">Server Priority</string>
     <string name="player_unknown_format">Unknown format</string>
     <string name="player_transcoding">Transcoding</string>
@@ -327,6 +331,8 @@
     <string name="settings_queue_syncing_title">Sync play queue for this user [Not Fully Baked]</string>
     <string name="settings_radio">Show radio</string>
     <string name="settings_radio_summary">If enabled, show the radio section. Restart the app for it to take full effect.</string>
+    <string name="settings_auto_download_lyrics">Auto download lyrics</string>
+    <string name="settings_auto_download_lyrics_summary">Automatically save lyrics when they are available so they can be shown while offline.</string>
     <string name="settings_replay_gain">Set replay gain mode</string>
     <string name="settings_rounded_corner">Rounded corners</string>
     <string name="settings_rounded_corner_size">Corners size</string>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -87,6 +87,12 @@
             android:key="radio_section_visibility" />
 
         <SwitchPreference
+            android:title="@string/settings_auto_download_lyrics"
+            android:defaultValue="false"
+            android:summary="@string/settings_auto_download_lyrics_summary"
+            android:key="auto_download_lyrics" />
+
+        <SwitchPreference
             android:title="@string/settings_music_directory"
             android:defaultValue="true"
             android:summary="@string/settings_music_directory_summary"


### PR DESCRIPTION
This feature is intended to persist song lyrics (either automatically or manually) within the Tempo database.

The one caveat is that since the lyrics are stored in the database, there is no streamlined manner to delete them all at once. Although this should not matter as whatever lyrics exist in the database will be overwritten when a internet provider becomes responsive again.

Tested on Android 14.

Created:
- database/dao/LyricsDao.java: Interface with lyrics database (query, replace, delete)
- model/LyricsCache.kt: Define lyrics data structure
- repository/LyricsRepository.java: Instantiate lyrics database and provide control functions

Changed:
- database: Updated entities, regenerated database
- ui/fragment/PlayerLyricsFragment.java: Remove unused imports, add download button to lyrics window, track lyric download state
- ui/fragment/SettingsFragment.java: Add option to automatically download lyrics when playing a song
- util/Preferences.kt: Manage app preferences for automatic lyric downloading
- viewmodel/PlayerBottomSheetViewModel.java: Load lyrics repository, save latest lyrics if online, retrieve from repo if offline, cleaned up structured lyric checks
- app/src/main/res/layout/inner_fragment_player_lyrics.xml: Use Google material button texture for buttons in the lyrics window (Note: Can use regular button style instead if we don't want to pull in Google libraries)
- app/src/main/res/values/strings.xml: Add setting and toast strings
- app/src/main/res/xml/global_preferences.xml: Add preference object for automatic lyric download

Fixed:
- viewmodel/PlayerBottomSheetViewModel.java: Fixed issue where stale lyrics would remain in the window after starting a new song that doesn't have lyrics available/downloaded