### PR TITLE
fix: Prevent crash when getting artist radio and song list is null

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistPageFragment.java
@@ -160,7 +160,7 @@ public class ArtistPageFragment extends Fragment implements ClickCallback {
 
         bind.artistPageRadioButton.setOnClickListener(v -> {
             artistPageViewModel.getArtistInstantMix().observe(getViewLifecycleOwner(), songs -> {
-                if (!songs.isEmpty()) {
+                if (songs != null && !songs.isEmpty()) {
                     MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
                     activity.setBottomSheetInPeek(true);
                 } else {


### PR DESCRIPTION
This PR prevents a crash when clicking the "Radio" button in artist page and the song list fetched is null.

The issue was reproducible using a Navidrome instance when the artist has no starred songs. The API response in that case was:

```
{
  "subsonic-response": {
    "status": "ok",
    "version": "1.16.1",
    "type": "navidrome",
    "serverVersion": "0.58.0 (9dbe0c18)",
    "openSubsonic": true,
    "similarSongs2": {}
  }
}
```

Now it displays the error message in a `Toast`.