### PR TITLE
fix: Re-add new equalizer settings that got lost

### DIFF
--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -3,9 +3,15 @@
     <PreferenceCategory app:title="@string/settings_title_general">
         <Preference
             android:layout_height="match_parent"
-            android:key="equalizer"
+            android:key="system_equalizer"
             android:summary="@string/settings_system_equalizer_summary"
             android:title="@string/settings_system_equalizer_title" />
+
+        <Preference
+            android:layout_height="match_parent"
+            android:key="app_equalizer"
+            android:summary="@string/settings_app_equalizer_summary"
+            android:title="@string/settings_app_equalizer" />
 
         <Preference
             android:key="scan_library"


### PR DESCRIPTION
Added back the new Equalizer settings that disappeared at some point.

This fixes a bug where the "system equalizer" doesn't work because the setting in `global_preferences.xml` changed to its old name. Also, the "app equalizer" setting wasn't displayed.