### PR TITLE
shuffle for artists without using `getTopSongs`

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistPageFragment.java
@@ -188,8 +188,6 @@ public class ArtistPageFragment extends Fragment implements ClickCallback {
             } else {
                 if (bind != null)
                     bind.artistPageTopSongsSector.setVisibility(!songs.isEmpty() ? View.VISIBLE : View.GONE);
-                if (bind != null)
-                    bind.artistPageShuffleButton.setEnabled(!songs.isEmpty());
                 songHorizontalAdapter.setItems(songs);
                 reapplyPlayback();
             }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/ArtistBottomSheetDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/bottomsheetdialog/ArtistBottomSheetDialog.java
@@ -89,6 +89,9 @@ public class ArtistBottomSheetDialog extends BottomSheetDialogFragment implement
             ArtistRepository artistRepository = new ArtistRepository();
 
             artistRepository.getInstantMix(artist, 20).observe(getViewLifecycleOwner(), songs -> {
+                // navidrome may return null for this
+                if (songs == null)
+                    return;
                 MusicUtil.ratingFilter(songs);
 
                 if (!songs.isEmpty()) {


### PR DESCRIPTION
This implements shuffling for artists without relying on `getTopSongs`, which is not implemented in navidrome when Last.fm is not integrated. This does not care about whether the songs are the top songs. If wanted, we can also sort the albums by `playCount`, but that may make things less random...