### PR TITLE
Fix downloaded tab performance

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/DownloadFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/DownloadFragment.java
@@ -117,14 +117,12 @@ public class DownloadFragment extends Fragment implements ClickCallback {
                 if (songs.isEmpty()) {
                     if (bind != null) {
                         bind.emptyDownloadLayout.setVisibility(View.VISIBLE);
-                        bind.fragmentDownloadNestedScrollView.setVisibility(View.GONE);
                         bind.downloadDownloadedSector.setVisibility(View.GONE);
                         bind.downloadedGroupByImageView.setVisibility(View.GONE);
                     }
                 } else {
                     if (bind != null) {
                         bind.emptyDownloadLayout.setVisibility(View.GONE);
-                        bind.fragmentDownloadNestedScrollView.setVisibility(View.VISIBLE);
                         bind.downloadDownloadedSector.setVisibility(View.VISIBLE);
                         bind.downloadedGroupByImageView.setVisibility(View.VISIBLE);
 

--- a/app/src/main/res/layout/fragment_download.xml
+++ b/app/src/main/res/layout/fragment_download.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:orientation="vertical">
 
     <fragment
         android:id="@+id/toolbar_fragment"
@@ -26,6 +27,7 @@
         android:layout_height="match_parent"
         android:gravity="center"
         android:orientation="vertical"
+        android:paddingBottom="@dimen/global_padding_bottom"
         android:visibility="gone">
 
         <ImageView
@@ -57,92 +59,78 @@
             android:text="@string/download_info_empty_subtitle" />
     </LinearLayout>
 
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/fragment_download_nested_scroll_view"
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/download_downloaded_sector"
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
+        android:layout_height="wrap_content"
+        android:paddingHorizontal="16dp"
         android:visibility="gone"
-        app:layout_behavior="@string/appbar_scrolling_view_behavior">
+        tools:visibility="visible">
 
-        <androidx.constraintlayout.widget.ConstraintLayout
-            android:id="@+id/download_downloaded_sector"
+        <TextView
+            android:id="@+id/downloaded_text_view_refreshable"
+            style="@style/TitleLarge"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:text="@string/download_title_section"
+            app:layout_constraintEnd_toStartOf="@+id/downloaded_refresh_image_view"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/shuffle_downloaded_text_view_clickable"
+            style="@style/TitleMedium"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:paddingHorizontal="16dp"
-            android:paddingTop="16dp"
-            android:paddingBottom="@dimen/global_padding_bottom"
-            android:visibility="gone"
-            tools:visibility="visible">
+            android:text="@string/download_shuffle_all_subtitle"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/downloaded_text_view_refreshable" />
 
-            <TextView
-                android:id="@+id/downloaded_text_view_refreshable"
-                style="@style/TitleLarge"
-                android:layout_width="0dp"
-                android:layout_height="wrap_content"
-                android:text="@string/download_title_section"
-                app:layout_constraintEnd_toStartOf="@+id/downloaded_refresh_image_view"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toTopOf="parent" />
+        <ImageView
+            android:id="@+id/downloaded_refresh_image_view"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_marginStart="12dp"
+            android:layout_marginEnd="12dp"
+            android:background="@drawable/ic_refresh"
+            android:contentDescription="@string/download_refresh_button_content_description"
+            app:layout_constraintBottom_toBottomOf="@+id/downloaded_text_view_refreshable"
+            app:layout_constraintEnd_toStartOf="@id/downloaded_go_back_image_view"
+            app:layout_constraintStart_toEndOf="@id/downloaded_text_view_refreshable"
+            app:layout_constraintTop_toTopOf="@+id/downloaded_text_view_refreshable" />
 
-            <TextView
-                android:id="@+id/shuffle_downloaded_text_view_clickable"
-                style="@style/TitleMedium"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:text="@string/download_shuffle_all_subtitle"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@+id/downloaded_text_view_refreshable"/>
+        <ImageView
+            android:id="@+id/downloaded_go_back_image_view"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_gravity="center"
+            android:layout_marginHorizontal="12dp"
+            android:background="@drawable/ic_arrow_back"
+            app:layout_constraintBottom_toBottomOf="@+id/downloaded_text_view_refreshable"
+            app:layout_constraintEnd_toStartOf="@id/downloaded_group_by_image_view"
+            app:layout_constraintStart_toEndOf="@id/downloaded_refresh_image_view"
+            app:layout_constraintTop_toTopOf="@+id/downloaded_text_view_refreshable" />
 
-            <ImageView
-                android:id="@+id/downloaded_refresh_image_view"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_marginStart="12dp"
-                android:layout_marginEnd="12dp"
-                android:background="@drawable/ic_refresh"
-                android:contentDescription="@string/download_refresh_button_content_description"
-                app:layout_constraintBottom_toBottomOf="@+id/downloaded_text_view_refreshable"
-                app:layout_constraintEnd_toStartOf="@id/downloaded_go_back_image_view"
-                app:layout_constraintStart_toEndOf="@id/downloaded_text_view_refreshable"
-                app:layout_constraintTop_toTopOf="@+id/downloaded_text_view_refreshable" />
+        <ImageView
+            android:id="@+id/downloaded_group_by_image_view"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:layout_gravity="center"
+            android:background="@drawable/ic_filter_list"
+            app:layout_constraintBottom_toBottomOf="@+id/downloaded_text_view_refreshable"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="@+id/downloaded_text_view_refreshable" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 
-            <ImageView
-                android:id="@+id/downloaded_go_back_image_view"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_marginHorizontal="12dp"
-                android:layout_gravity="center"
-                android:background="@drawable/ic_arrow_back"
-                app:layout_constraintBottom_toBottomOf="@+id/downloaded_text_view_refreshable"
-                app:layout_constraintEnd_toStartOf="@id/downloaded_group_by_image_view"
-                app:layout_constraintStart_toEndOf="@id/downloaded_refresh_image_view"
-                app:layout_constraintTop_toTopOf="@+id/downloaded_text_view_refreshable" />
-
-            <ImageView
-                android:id="@+id/downloaded_group_by_image_view"
-                android:layout_width="24dp"
-                android:layout_height="24dp"
-                android:layout_gravity="center"
-                android:background="@drawable/ic_filter_list"
-                app:layout_constraintBottom_toBottomOf="@+id/downloaded_text_view_refreshable"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintTop_toTopOf="@+id/downloaded_text_view_refreshable" />
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/downloaded_recycler_view"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:clipToPadding="false"
-                android:nestedScrollingEnabled="false"
-                android:paddingTop="12dp"
-                android:paddingBottom="8dp"
-                app:layout_constraintBottom_toBottomOf="parent"
-                app:layout_constraintEnd_toEndOf="parent"
-                app:layout_constraintStart_toStartOf="parent"
-                app:layout_constraintTop_toBottomOf="@id/shuffle_downloaded_text_view_clickable" />
-
-        </androidx.constraintlayout.widget.ConstraintLayout>
-    </androidx.core.widget.NestedScrollView>
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/downloaded_recycler_view"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:clipToPadding="false"
+        android:nestedScrollingEnabled="false"
+        android:paddingHorizontal="12dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="@dimen/global_padding_bottom" />
+</LinearLayout>
 


### PR DESCRIPTION
Fixes #166. Fixes #41 (if I understand it correctly).

Basically, the bug is due to the `RecyclerView` being put inside a `NestedScrollView`, allowing its length to be unbounded. As such, it will attempt to load everything. I refactored the UI xml a bit to remove the `NestedScrollView`, and it works well now.

