### PR TITLE
fix: do not override getItemViewType and getItemId

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/AlbumCatalogueAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/AlbumCatalogueAdapter.java
@@ -106,16 +106,6 @@ public class AlbumCatalogueAdapter extends RecyclerView.Adapter<AlbumCatalogueAd
     }
 
     @Override
-    public int getItemViewType(int position) {
-        return position;
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
-
-    @Override
     public Filter getFilter() {
         return filtering;
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistAdapter.java
@@ -66,16 +66,6 @@ public class ArtistAdapter extends RecyclerView.Adapter<ArtistAdapter.ViewHolder
         notifyDataSetChanged();
     }
 
-    @Override
-    public int getItemViewType(int position) {
-        return position;
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
-
     public class ViewHolder extends RecyclerView.ViewHolder {
         ItemLibraryArtistBinding item;
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistCatalogueAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistCatalogueAdapter.java
@@ -98,16 +98,6 @@ public class ArtistCatalogueAdapter extends RecyclerView.Adapter<ArtistCatalogue
     }
 
     @Override
-    public int getItemViewType(int position) {
-        return position;
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
-
-    @Override
     public Filter getFilter() {
         return filtering;
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistHorizontalAdapter.java
@@ -113,16 +113,6 @@ public class ArtistHorizontalAdapter extends RecyclerView.Adapter<ArtistHorizont
         return artists.get(id);
     }
 
-    @Override
-    public int getItemViewType(int position) {
-        return position;
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
-
     public class ViewHolder extends RecyclerView.ViewHolder {
         ItemHorizontalArtistBinding item;
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistSimilarAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistSimilarAdapter.java
@@ -60,16 +60,6 @@ public class ArtistSimilarAdapter extends RecyclerView.Adapter<ArtistSimilarAdap
         notifyDataSetChanged();
     }
 
-    @Override
-    public int getItemViewType(int position) {
-        return position;
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
-
     public class ViewHolder extends RecyclerView.ViewHolder {
         ItemLibrarySimilarArtistBinding item;
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/DownloadHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/DownloadHorizontalAdapter.java
@@ -96,16 +96,6 @@ public class DownloadHorizontalAdapter extends RecyclerView.Adapter<DownloadHori
         return shuffling;
     }
 
-    @Override
-    public int getItemViewType(int position) {
-        return position;
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
-
     private List<Child> groupSong(List<Child> songs) {
         switch (view) {
             case Constants.DOWNLOAD_TYPE_TRACK:

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PodcastChannelCatalogueAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PodcastChannelCatalogueAdapter.java
@@ -96,16 +96,6 @@ public class PodcastChannelCatalogueAdapter extends RecyclerView.Adapter<Podcast
     }
 
     @Override
-    public int getItemViewType(int position) {
-        return position;
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
-
-    @Override
     public Filter getFilter() {
         return filtering;
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PodcastEpisodeAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PodcastEpisodeAdapter.java
@@ -71,16 +71,6 @@ public class PodcastEpisodeAdapter extends RecyclerView.Adapter<PodcastEpisodeAd
         notifyDataSetChanged();
     }
 
-    @Override
-    public int getItemViewType(int position) {
-        return position;
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
-
     public class ViewHolder extends RecyclerView.ViewHolder {
         ItemHomePodcastEpisodeBinding item;
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SongHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SongHorizontalAdapter.java
@@ -252,16 +252,6 @@ public class SongHorizontalAdapter extends RecyclerView.Adapter<SongHorizontalAd
         notifyDataSetChanged();
     }
 
-    @Override
-    public int getItemViewType(int position) {
-        return position;
-    }
-
-    @Override
-    public long getItemId(int position) {
-        return position;
-    }
-
     public void setPlaybackState(String mediaId, boolean playing) {
         String oldId = this.currentPlayingId;
         boolean oldPlaying = this.isPlaying;


### PR DESCRIPTION
For recycler views, apparently the item view type determines what item can be recycled, and returning the position makes recycling impossible, increasing memory usage, which probably caused the crash for large playlists in #208. I checked the memory profiler result, previously there were a lot of `ConstrainedLayout` in the heap for large playlists, but that is gone after this patch.

Item id is the persistent id for the item, which should be different from position. So I removed the override for that as well.