### PR TITLE
fix: skip mapping downloaded item

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/util/MappingUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/MappingUtil.java
@@ -116,6 +116,13 @@ public class MappingUtil {
     }
 
     public static MediaItem mapMediaItem(MediaItem old) {
+        String mediaId = null;
+        if (old.requestMetadata.extras != null)
+            mediaId = old.requestMetadata.extras.getString("id");
+
+        if (mediaId != null && DownloadUtil.getDownloadTracker(App.getContext()).isDownloaded(mediaId)) {
+            return old;
+        }
         Uri uri = old.requestMetadata.mediaUri == null ? null : MusicUtil.updateStreamUri(old.requestMetadata.mediaUri);
         return new MediaItem.Builder()
                 .setMediaId(old.mediaId)


### PR DESCRIPTION
It seems that #222 makes local playback impossible. This should fix the issue.