### PR TITLE
Fix player queue soft-lock

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerQueueFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerQueueFragment.java
@@ -73,12 +73,16 @@ public class PlayerQueueFragment extends Fragment implements ClickCallback {
         super.onResume();
         setMediaBrowserListenableFuture();
         updateNowPlayingItem();
-        try {
-            long position = mediaBrowserListenableFuture.get().getCurrentMediaItemIndex();
-            bind.playerQueueRecyclerView.scrollToPosition((int) position);
-        } catch (Exception e) {
-            Log.e("PlayerQueueFragment", "Failed to get mediaBrowserListenableFuture in onResume", e);
-        }
+        mediaBrowserListenableFuture.addListener(() -> {
+            try {
+                long position = mediaBrowserListenableFuture.get().getCurrentMediaItemIndex();
+                requireActivity().runOnUiThread(() -> {
+                    bind.playerQueueRecyclerView.scrollToPosition((int) position);
+                });
+            } catch (Exception e) {
+                Log.e("PlayerQueueFragment", "Failed to get mediaBrowserListenableFuture in onResume", e);
+            }
+        }, MoreExecutors.directExecutor());
     }
 
     @Override


### PR DESCRIPTION
This logic should be off of the main thread to prevent a race condition caused by improper access of the mediabrowserlistenablefuture.

bug:
when exiting the app with the queue open and reopening, a soft freeze requiring an app restart occurs due to mediabrowserlistenablefuture.get() blocking the main thread while indefinitely waiting.