### PR TITLE
Update description_empty_title in English and Polish

### DIFF
--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -61,7 +61,7 @@
     <string name="delete_download_storage_dialog_positive_button">Kontynuuj</string>
     <string name="delete_download_storage_dialog_summary">Miej na uwadze to że kontynuowanie tej operacji spowoduje usunięcie wszystkich pobranych plików z wszystkich serwerów.</string>
     <string name="delete_download_storage_dialog_title">Usuwanie zapisanych plików</string>
-    <string name="description_empty_title">Brak opisu</string>
+    <string name="description_empty_title">Brak tekstu</string>
     <string name="disc_titlefull">Płyta %1$s - %2$s</string>
     <string name="disc_titleless">Płyta %1$s</string>
     <string name="download_directory_dialog_negative_button">Anuluj</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -61,7 +61,7 @@
     <string name="delete_download_storage_dialog_positive_button">Continue</string>
     <string name="delete_download_storage_dialog_summary">Please be aware that continuing with this action will result in the permanent deletion of all saved items downloaded from all servers.</string>
     <string name="delete_download_storage_dialog_title">Delete saved items</string>
-    <string name="description_empty_title">No description available</string>
+    <string name="description_empty_title">No lyrics available</string>
     <string name="disc_titlefull">Disc %1$s - %2$s</string>
     <string name="disc_titleless">Disc %1$s</string>
     <string name="download_directory_dialog_negative_button">Cancel</string>


### PR DESCRIPTION
Updates the description_empty_title variable values for Polish and English. This is part of feature requested here: [https://github.com/eddyizm/tempus/issues/306](https://github.com/eddyizm/tempus/issues/306)