### PR TITLE
fix: Proper raw stream detection

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/util/DynamicMediaSourceFactory.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/DynamicMediaSourceFactory.kt
@@ -49,8 +49,7 @@ class DynamicMediaSourceFactory(
                 val progressiveFactory = ProgressiveMediaSource.Factory(dataSourceFactory, extractorsFactory)
 
                 val uri = mediaItem.localConfiguration?.uri
-                val isTranscoding = uri?.getQueryParameter("maxBitRate") != null || 
-                                   (uri?.getQueryParameter("format") != null && uri?.getQueryParameter("format") != "raw")
+                val isTranscoding = uri?.getQueryParameter("format") != null && uri.getQueryParameter("format") != "raw"
                 
                 if (isTranscoding && OpenSubsonicExtensionsUtil.isTranscodeOffsetExtensionAvailable()) {
                      TranscodingMediaSource(mediaItem, dataSourceFactory, progressiveFactory)


### PR DESCRIPTION
This PR fixes a bug where seeking in a raw stream restarted the song. It was detected as a transcoded stream (PR #358).
At least in Navidrome, when getting a raw stream, it always returns the stream from the beginning even if `timeOffset` param is set.

The `maxBitRate` param in URL is always sent when getting a stream, either as 0 (no limit) or another value, so there is no point in using it to detect if the stream is transcoded.

Applying this change resolves the issue.