### PR TITLE
Improve Synced Lyrics

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerLyricsFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerLyricsFragment.java
@@ -323,7 +323,7 @@ public class PlayerLyricsFragment extends Fragment {
 
             // Make each line clickable for navigation and highlight the current one
             int offset = 0;
-            int highlightStart = 0;
+            int highlightStart = -1;
             for (int i = 0; i < lines.size(); ++i) {
                 boolean highlight = i == curIdx;
                 if (highlight) highlightStart = offset;
@@ -354,7 +354,8 @@ public class PlayerLyricsFragment extends Fragment {
             bind.nowPlayingSongLyricsTextView.setMovementMethod(LinkMovementMethod.getInstance());
             bind.nowPlayingSongLyricsTextView.setText(spannableString);
 
-            if (playerBottomSheetViewModel.getSyncLyricsState()) {
+            // Scroll to the highlighted line, but only if there is one
+            if (highlightStart >= 0 && playerBottomSheetViewModel.getSyncLyricsState()) {
                 bind.nowPlayingSongLyricsSrollView.smoothScrollTo(0, getScroll(highlightStart));
             }
         }


### PR DESCRIPTION
This makes synced lyrics behave like in most other music players:
1. Scrolling during playback is now possible (by not updating the lyrics every time the timestamp changes but only when the playing line actually changes -- that probably improves performance, too)
2. Tapping on a line now jumps to the starting timestamp of that line
3. Before the first line is played, everything is grayed out rather than all lines being highlighted