### PR TITLE
fix: Avoid crash when server has no songs

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/repository/SongRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/SongRepository.java
@@ -283,7 +283,10 @@ public class SongRepository {
             @Override public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
                 List<Child> songs = new ArrayList<>();
                 if (response.isSuccessful() && response.body() != null && response.body().getSubsonicResponse().getRandomSongs() != null) {
-                    songs.addAll(Objects.requireNonNull(response.body().getSubsonicResponse().getRandomSongs().getSongs()));
+                    List<Child> returned = response.body().getSubsonicResponse().getRandomSongs().getSongs();
+                    if (returned != null) {
+                        songs.addAll(returned);
+                    }
                 }
                 randomSongsSample.setValue(songs);
             }
@@ -299,7 +302,10 @@ public class SongRepository {
             @Override public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
                 List<Child> songs = new ArrayList<>();
                 if (response.isSuccessful() && response.body() != null && response.body().getSubsonicResponse().getRandomSongs() != null) {
-                    songs.addAll(Objects.requireNonNull(response.body().getSubsonicResponse().getRandomSongs().getSongs()));
+                    List<Child> returned = response.body().getSubsonicResponse().getRandomSongs().getSongs();
+                    if (returned != null) {
+                        songs.addAll(returned);
+                    }
                 }
                 randomSongsSample.setValue(songs);
             }
@@ -342,7 +348,10 @@ public class SongRepository {
                 @Override public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
                     List<Child> songs = new ArrayList<>();
                     if (response.isSuccessful() && response.body() != null && response.body().getSubsonicResponse().getSongsByGenre() != null) {
-                        songs.addAll(Objects.requireNonNull(response.body().getSubsonicResponse().getSongsByGenre().getSongs()));
+                        List<Child> returned = response.body().getSubsonicResponse().getSongsByGenre().getSongs();
+                        if (returned != null) {
+                            songs.addAll(returned);
+                        }
                     }
                     songsByGenre.setValue(songs);
                 }


### PR DESCRIPTION
This PR fixes #371.

The issue was with the `getRandomSample()` method in `SongRepository`, which needed a null check when calling `getSongs()` in the Subsonic response.
Adding this null check resolved the issue, but I also added null checks in two other methods written identically, for safety.