### PR TITLE
Fix missing Replay Gain metadata from .m4a files

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/util/ReplayGainUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/ReplayGainUtil.java
@@ -7,6 +7,7 @@ import androidx.media3.common.Metadata;
 import androidx.media3.common.Tracks;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.common.Player;
+import androidx.media3.extractor.metadata.id3.InternalFrame;
 
 import com.cappielloantonio.tempo.model.ReplayGain;
 
@@ -82,26 +83,32 @@ public class ReplayGainUtil {
     private static ReplayGain setReplayGains(Metadata.Entry entry) {
         ReplayGain replayGain = new ReplayGain();
 
-        if (entry.toString().contains(tags[0])) {
-            replayGain.setTrackGain(parseReplayGainTag(entry));
+        // The logic below assumes .toString() contains the dB value. That's not the case for InternalFrame
+        String str = entry.toString();
+        if (entry instanceof InternalFrame) {
+            str = ((InternalFrame) entry).description + ((InternalFrame) entry).text;
         }
 
-        if (entry.toString().contains(tags[1])) {
-            replayGain.setAlbumGain(parseReplayGainTag(entry));
+        if (str.contains(tags[0])) {
+            replayGain.setTrackGain(parseReplayGainTag(str));
         }
 
-        if (entry.toString().contains(tags[2])) {
-            replayGain.setTrackGain(parseReplayGainTag(entry) / 256f);
+        if (str.contains(tags[1])) {
+            replayGain.setAlbumGain(parseReplayGainTag(str));
         }
 
-        if (entry.toString().contains(tags[3])) {
-            replayGain.setAlbumGain(parseReplayGainTag(entry) / 256f);
+        if (str.contains(tags[2])) {
+            replayGain.setTrackGain(parseReplayGainTag(str) / 256f);
+        }
+
+        if (str.contains(tags[3])) {
+            replayGain.setAlbumGain(parseReplayGainTag(str) / 256f);
         }
 
         return replayGain;
     }
 
-    private static Float parseReplayGainTag(Metadata.Entry entry) {
+    private static Float parseReplayGainTag(String entry) {
         try {
             return Float.parseFloat(entry.toString().replaceAll("[^\\d.-]", ""));
         } catch (NumberFormatException exception) {


### PR DESCRIPTION
The existing logic parses Replay Gain metadata by assuming that the `toString()` method of the metadata entry returns a string containing the description and value fields. That's not the case for `InternalFrame` (value is omitted).

`m4a` files have `InternalFrame` metadata entries for replay gain, at least when tagged via `rsgain`.

This is not the most elegant solution, but avoids rewriting / altering any of the parsing logic for other formats. Reduces the risk of regressions in other file formats. 

Tested with .m4a (broken before, working now) and .mp3 (worked before, still fine) files with metadata from `rsgain`