### PR TITLE
fix: radio playback "source error" on android auto

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/repository/AutomotiveRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/AutomotiveRepository.java
@@ -606,20 +606,7 @@ public class AutomotiveRepository {
                             List<MediaItem> mediaItems = new ArrayList<>();
 
                             for (InternetRadioStation radioStation : radioStations) {
-                                MediaMetadata mediaMetadata = new MediaMetadata.Builder()
-                                        .setTitle(radioStation.getName())
-                                        .setIsBrowsable(false)
-                                        .setIsPlayable(true)
-                                        .setMediaType(MediaMetadata.MEDIA_TYPE_RADIO_STATION)
-                                        .build();
-
-                                MediaItem mediaItem = new MediaItem.Builder()
-                                        .setMediaId(radioStation.getId())
-                                        .setMediaMetadata(mediaMetadata)
-                                        .setUri(radioStation.getStreamUrl())
-                                        .build();
-
-                                mediaItems.add(mediaItem);
+                                mediaItems.add(MappingUtil.mapInternetRadioStation(radioStation));
                             }
 
                             setInternetRadioStationsMetadata(radioStations);

--- a/app/src/main/java/com/cappielloantonio/tempo/util/DynamicMediaSourceFactory.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/DynamicMediaSourceFactory.kt
@@ -3,6 +3,7 @@ package com.cappielloantonio.tempo.util
 import android.content.Context
 import androidx.media3.common.C
 import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
 import androidx.media3.common.MimeTypes
 import androidx.media3.common.util.UnstableApi
 import androidx.media3.datasource.DataSource
@@ -20,10 +21,10 @@ class DynamicMediaSourceFactory(
 ) : MediaSource.Factory {
 
     override fun createMediaSource(mediaItem: MediaItem): MediaSource {
-        val mediaType: String? = mediaItem.mediaMetadata.extras?.getString("type", "")
+        val mediaId = mediaItem.mediaId
 
         val streamingCacheSize = Preferences.getStreamingCacheSize()
-        val bypassCache = mediaType == Constants.MEDIA_TYPE_RADIO
+        val bypassCache = mediaId.startsWith("ir-")
 
         val useUpstream = when {
             streamingCacheSize.toInt() == 0 -> true

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
@@ -32,6 +32,7 @@ import com.cappielloantonio.tempo.util.Constants.CUSTOM_COMMAND_TOGGLE_REPEAT_MO
 import com.cappielloantonio.tempo.util.Constants.CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_OFF
 import com.cappielloantonio.tempo.util.Constants.CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_ON
 import com.google.common.collect.ImmutableList
+import com.cappielloantonio.tempo.util.Constants
 import com.cappielloantonio.tempo.util.Preferences
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
@@ -366,11 +367,31 @@ open class MediaLibrarySessionCallback(
         controller: MediaSession.ControllerInfo,
         mediaItems: List<MediaItem>
     ): ListenableFuture<List<MediaItem>> {
-        return super.onAddMediaItems(
-            mediaSession,
-            controller,
-            MediaBrowserTree.getItems(mediaItems)
-        )
+        val firstItem = mediaItems.firstOrNull()
+        val isRadio = firstItem?.mediaId?.startsWith("ir-") == true
+
+        if (isRadio) {
+            return Futures.transformAsync(
+                automotiveRepository.internetRadioStations,
+                { result ->
+                    val stations = result?.value
+                    val selected = stations?.find { it.mediaId == firstItem?.mediaId }
+                    if (selected != null) {
+                        val updatedSelected = selected.buildUpon()
+                            .setMimeType(selected.localConfiguration?.mimeType)
+                            .build()
+
+                        Futures.immediateFuture(listOf(updatedSelected))
+                    } else {
+                        Futures.immediateFuture(emptyList())
+                    }
+                },
+                androidx.core.content.ContextCompat.getMainExecutor(context)
+            )
+        }
+
+        val resolvedItems = MediaBrowserTree.getItems(mediaItems)
+        return super.onAddMediaItems(mediaSession, controller, resolvedItems)
     }
 
     override fun onSearch(


### PR DESCRIPTION
**Description**
This PR addresses the intermittent "Source error" (UnrecognizedInputFormatException) encountered when playing internet radio streams, only with Android Auto.

**The Problem**
The root cause was identified as ExoPlayer attempting to cache infinite live streams. When Android Auto is connected, it often strips custom metadata/extras, causing the player to lose the "radio" flag and fall back to the default caching strategy. 

**Verification Results**
Fix tested with success with the Desktop Head Unit