### PR TITLE
fix: local url used in share link instead of server url

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/App.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/App.java
@@ -55,6 +55,48 @@ public class App extends Application {
         }
         return subsonic;
     }
+    
+    public static Subsonic getSubsonicPublicClientInstance(boolean override) {
+
+        /*
+        If I do the shortcut that the IDE suggests:
+            SubsonicPreferences preferences = getSubsonicPreferences1();
+        During the chain of calls it will run the following:
+            String server = Preferences.getInUseServerAddress();
+        Which could return Local URL, causing issues like generating public shares with Local URL
+
+        To prevent this I just replicated the entire chain of functions here,
+        if you need a call to Subsonic using the Server (Public) URL use this function.
+         */
+
+        String server = Preferences.getServer();
+        String username = Preferences.getUser();
+        String password = Preferences.getPassword();
+        String token = Preferences.getToken();
+        String salt = Preferences.getSalt();
+        boolean isLowSecurity = Preferences.isLowScurity();
+
+        SubsonicPreferences preferences = new SubsonicPreferences();
+        preferences.setServerUrl(server);
+        preferences.setUsername(username);
+        preferences.setAuthentication(password, token, salt, isLowSecurity);
+
+        if (subsonic == null || override) {
+            
+            if (preferences.getAuthentication() != null) {
+                if (preferences.getAuthentication().getPassword() != null)
+                    Preferences.setPassword(preferences.getAuthentication().getPassword());
+                if (preferences.getAuthentication().getToken() != null)
+                    Preferences.setToken(preferences.getAuthentication().getToken());
+                if (preferences.getAuthentication().getSalt() != null)
+                    Preferences.setSalt(preferences.getAuthentication().getSalt());
+            }
+
+            
+        }
+        
+        return new Subsonic(preferences);
+    }
 
     public static Github getGithubClientInstance() {
         if (github == null) {

--- a/app/src/main/java/com/cappielloantonio/tempo/repository/SharingRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/SharingRepository.java
@@ -41,7 +41,7 @@ public class SharingRepository {
     public MutableLiveData<Share> createShare(String id, String description, Long expires) {
         MutableLiveData<Share> share = new MutableLiveData<>();
 
-        App.getSubsonicClientInstance(false)
+        App.getSubsonicPublicClientInstance(false)
                 .getSharingClient()
                 .createShare(id, description, expires)
                 .enqueue(new Callback<ApiResponse>() {
@@ -64,7 +64,7 @@ public class SharingRepository {
     }
 
     public void updateShare(String id, String description, Long expires) {
-        App.getSubsonicClientInstance(false)
+        App.getSubsonicPublicClientInstance(false)
                 .getSharingClient()
                 .updateShare(id, description, expires)
                 .enqueue(new Callback<ApiResponse>() {


### PR DESCRIPTION
Fixes #101

https://github.com/user-attachments/assets/cb793a55-f166-4278-90fd-0c7754d33046

I was only able to test this using a VPN as 'server', however in the code now the public URL is explicitly requested when creating and updating sharing urls.