### PR TITLE
fix: Android Auto queue initialization and queue confusion 

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/repository/AutomotiveRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/AutomotiveRepository.java
@@ -24,6 +24,7 @@ import com.cappielloantonio.tempo.model.Download;
 import com.cappielloantonio.tempo.model.SessionMediaItem;
 import com.cappielloantonio.tempo.provider.AlbumArtContentProvider;
 import com.cappielloantonio.tempo.service.DownloaderManager;
+import com.cappielloantonio.tempo.service.MediaBrowserTree;
 import com.cappielloantonio.tempo.subsonic.base.ApiResponse;
 import com.cappielloantonio.tempo.subsonic.models.AlbumID3;
 import com.cappielloantonio.tempo.subsonic.models.Artist;
@@ -650,7 +651,7 @@ public class AutomotiveRepository {
 
                             setChildrenMetadata(tracks);
 
-                            List<MediaItem> mediaItems = MappingUtil.mapMediaItems(tracks);
+                            List<MediaItem> mediaItems = MappingUtil.mapMediaItems(tracks, MediaBrowserTree.ALBUMS_ID + id);
 
                             LibraryResult<ImmutableList<MediaItem>> libraryResult = LibraryResult.ofItemList(ImmutableList.copyOf(mediaItems), null);
 
@@ -735,7 +736,7 @@ public class AutomotiveRepository {
 
                             setChildrenMetadata(tracks);
 
-                            List<MediaItem> mediaItems = MappingUtil.mapMediaItems(tracks);
+                            List<MediaItem> mediaItems = MappingUtil.mapMediaItems(tracks, MediaBrowserTree.PLAYLIST_ID + id);
 
                             LibraryResult<ImmutableList<MediaItem>> libraryResult = LibraryResult.ofItemList(ImmutableList.copyOf(mediaItems), null);
 

--- a/app/src/main/java/com/cappielloantonio/tempo/repository/AutomotiveRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/AutomotiveRepository.java
@@ -69,7 +69,6 @@ public class AutomotiveRepository {
                         if (response.isSuccessful() && response.body() != null && response.body().getSubsonicResponse().getAlbumList2() != null && response.body().getSubsonicResponse().getAlbumList2().getAlbums() != null) {
                             List<AlbumID3> albums = response.body().getSubsonicResponse().getAlbumList2().getAlbums();
 
-                            // add by MFO
                             // Hack for artist view
                             if("alphabeticalByArtist".equals(type))for(AlbumID3 album : albums){
                                 String artistName = album.getArtist();
@@ -77,7 +76,6 @@ public class AutomotiveRepository {
                                 album.setName(artistName);
                                 album.setArtist(albumName);
                             }
-                            // end add by MFO
 
                             List<MediaItem> mediaItems = new ArrayList<>();
 

--- a/app/src/main/java/com/cappielloantonio/tempo/repository/AutomotiveRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/AutomotiveRepository.java
@@ -24,7 +24,6 @@ import com.cappielloantonio.tempo.model.Download;
 import com.cappielloantonio.tempo.model.SessionMediaItem;
 import com.cappielloantonio.tempo.provider.AlbumArtContentProvider;
 import com.cappielloantonio.tempo.service.DownloaderManager;
-import com.cappielloantonio.tempo.service.MediaBrowserTree;
 import com.cappielloantonio.tempo.subsonic.base.ApiResponse;
 import com.cappielloantonio.tempo.subsonic.models.AlbumID3;
 import com.cappielloantonio.tempo.subsonic.models.Artist;
@@ -57,6 +56,9 @@ import retrofit2.Response;
 public class AutomotiveRepository {
     private final SessionMediaItemDao sessionMediaItemDao = AppDatabase.getInstance().sessionMediaItemDao();
     private final ChronologyDao chronologyDao = AppDatabase.getInstance().chronologyDao();
+
+    public static final String ALBUM = "[albumSource]";
+    public static final String PLAYLIST = "[playlistSource]";
 
     public ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> getAlbums(String prefix, String type, int size) {
         final SettableFuture<LibraryResult<ImmutableList<MediaItem>>> listenableFuture = SettableFuture.create();
@@ -651,7 +653,7 @@ public class AutomotiveRepository {
 
                             setChildrenMetadata(tracks);
 
-                            List<MediaItem> mediaItems = MappingUtil.mapMediaItems(tracks, MediaBrowserTree.ALBUMS_ID + id);
+                            List<MediaItem> mediaItems = MappingUtil.mapMediaItems(tracks, ALBUM + id);
 
                             LibraryResult<ImmutableList<MediaItem>> libraryResult = LibraryResult.ofItemList(ImmutableList.copyOf(mediaItems), null);
 
@@ -736,7 +738,7 @@ public class AutomotiveRepository {
 
                             setChildrenMetadata(tracks);
 
-                            List<MediaItem> mediaItems = MappingUtil.mapMediaItems(tracks, MediaBrowserTree.PLAYLIST_ID + id);
+                            List<MediaItem> mediaItems = MappingUtil.mapMediaItems(tracks, PLAYLIST + id);
 
                             LibraryResult<ImmutableList<MediaItem>> libraryResult = LibraryResult.ofItemList(ImmutableList.copyOf(mediaItems), null);
 

--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -145,6 +145,28 @@ open class BaseMediaService : MediaLibraryService() {
                 Log.d(TAG, "onMediaItemTransition" + player.currentMediaItemIndex)
                 if (mediaItem == null) return
 
+                // --- Add for AA : aa_start_index if présent ---
+                val extras = mediaItem.mediaMetadata.extras
+                val startIndex = extras?.getInt("aa_start_index", -1) ?: -1
+                if (startIndex >= 0 ) {
+                    val cleanExtras = Bundle(extras).apply {
+                        remove("aa_start_index")
+                    }
+                    val newMetadata = mediaItem.mediaMetadata.buildUpon()
+                        .setExtras(cleanExtras)
+                        .build()
+                    val currentIdx = player.currentMediaItemIndex
+                    if (player is ExoPlayer && currentIdx != C.INDEX_UNSET) {
+                        player.replaceMediaItem(
+                            currentIdx,
+                            mediaItem.buildUpon().setMediaMetadata(newMetadata).build()
+                        )
+                    }
+                    if (startIndex in 0 until player.mediaItemCount && startIndex != currentIdx) {
+                        player.seekTo(startIndex, 0L)
+                    }
+                }
+                // --- End add for AA ---
                 if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_SEEK || reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) {
                     MediaManager.setLastPlayedTimestamp(mediaItem)
                 }

--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -145,28 +145,6 @@ open class BaseMediaService : MediaLibraryService() {
                 Log.d(TAG, "onMediaItemTransition" + player.currentMediaItemIndex)
                 if (mediaItem == null) return
 
-                // --- Add for AA : aa_start_index if présent ---
-                val extras = mediaItem.mediaMetadata.extras
-                val startIndex = extras?.getInt("aa_start_index", -1) ?: -1
-                if (startIndex >= 0 ) {
-                    val cleanExtras = Bundle(extras).apply {
-                        remove("aa_start_index")
-                    }
-                    val newMetadata = mediaItem.mediaMetadata.buildUpon()
-                        .setExtras(cleanExtras)
-                        .build()
-                    val currentIdx = player.currentMediaItemIndex
-                    if (player is ExoPlayer && currentIdx != C.INDEX_UNSET) {
-                        player.replaceMediaItem(
-                            currentIdx,
-                            mediaItem.buildUpon().setMediaMetadata(newMetadata).build()
-                        )
-                    }
-                    if (startIndex in 0 until player.mediaItemCount && startIndex != currentIdx) {
-                        player.seekTo(startIndex, 0L)
-                    }
-                }
-                // --- End add for AA ---
                 if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_SEEK || reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) {
                     MediaManager.setLastPlayedTimestamp(mediaItem)
                 }

--- a/app/src/main/java/com/cappielloantonio/tempo/util/MappingUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/MappingUtil.java
@@ -164,6 +164,34 @@ public class MappingUtil {
                 .setUri(uri)
                 .build();
     }
+    public static List<MediaItem> mapMediaItems(List<Child> items, String parentId) {
+        ArrayList<MediaItem> mediaItems = new ArrayList<>();
+
+        for (int i = 0; i < items.size(); i++) {
+            mediaItems.add(mapMediaItem(items.get(i), parentId));
+        }
+
+        return mediaItems;
+    }
+    public static MediaItem mapMediaItem(Child item, String parentId) {
+        MediaItem mediaItem = mapMediaItem(item);
+
+        Bundle extras = mediaItem.mediaMetadata.extras != null
+                ? new Bundle(mediaItem.mediaMetadata.extras)
+                : new Bundle();
+
+        extras.putString("parent_id", parentId);
+
+        MediaMetadata metadata = mediaItem.mediaMetadata
+                .buildUpon()
+                .setExtras(extras)
+                .build();
+
+        return mediaItem.buildUpon()
+                .setMediaId(item.getId())
+                .setMediaMetadata(metadata)
+                .build();
+    }
 
     public static List<MediaItem> mapDownloads(List<Child> items) {
         ArrayList<MediaItem> downloads = new ArrayList<>();

--- a/app/src/main/res/values-fr/arrays.xml
+++ b/app/src/main/res/values-fr/arrays.xml
@@ -310,6 +310,5 @@
         <item>15</item>
         <item>16</item>
     </string-array>
-	<!-- end Add by MFO -->
-	
+
 </resources>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -334,6 +334,5 @@
         <item>15</item>
         <item>16</item>
     </string-array>
-	<!-- end Add by MFO -->
-	
+
 </resources>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -527,7 +527,6 @@
             android:key="androidauto_shuffle_genre_songs" />
 			
 	</PreferenceCategory>
-	<!-- end Add by MFO -->
 
     <PreferenceCategory app:title="@string/settings_about_title">
         <Preference

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaBrowserTree.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaBrowserTree.kt
@@ -406,7 +406,7 @@ object MediaBrowserTree {
         treeNodes[RANDOM_ID] =
             MediaItemNode(
                 buildMediaItem(
-                    gridView = albumView,
+                    gridView = false,
                     title = appContext.getString(R.string.aa_random),
                     mediaId = RANDOM_ID,
                     isPlayable = false,
@@ -419,7 +419,7 @@ object MediaBrowserTree {
         treeNodes[GENRES_ID] =
             MediaItemNode(
                 buildMediaItem(
-                    gridView = albumView,
+                    gridView = false,
                     title = appContext.getString(R.string.aa_genres),
                     mediaId = GENRES_ID,
                     isPlayable = false,
@@ -491,14 +491,7 @@ object MediaBrowserTree {
                 if (id.startsWith(MADE_FOR_YOU_ID)) {
                     return automotiveRepository.getMadeForYou(id.removePrefix(MADE_FOR_YOU_ID),20)
                 }
-
-                if (id.startsWith(STARRED_ALBUMS_ID)) {
-                    return automotiveRepository.getAlbumTracks(id.removePrefix(STARRED_ALBUMS_ID))
-                }
-
-                if (id.startsWith(STARRED_ARTISTS_ID)) {
-                    return automotiveRepository.getArtistAlbum(STARRED_ALBUMS_ID,id.removePrefix(STARRED_ARTISTS_ID))
-                }
+                */
 
                 if (id.startsWith(GENRES_ID)) {
                     val shuffle = Preferences.isAndroidAutoShuffleGenreSongsEnabled()
@@ -506,8 +499,6 @@ object MediaBrowserTree {
                     val count = if (shuffle) 100 else 500
                     return automotiveRepository.getSongsByGenre(id.removePrefix(GENRES_ID), count, shuffle)
                 }
-
-				*/
                 if (id.startsWith(PLAYLIST_ID)) {
                     return automotiveRepository.getPlaylistSongs(id.removePrefix(PLAYLIST_ID))
                 }

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaBrowserTree.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaBrowserTree.kt
@@ -31,10 +31,10 @@ object MediaBrowserTree {
 	// Available functions
     private const val HOME_ID = "[homeID]"
     private const val LAST_PLAYED_ID = "[lastPlayedID]"
-    public  const val ALBUMS_ID = "[albumsID]"
+    private const val ALBUMS_ID = "[albumsID]"
     private const val ARTISTS_ID = "[artistsID]"
     private const val MOST_PLAYED_ID = "[mostPlayedID]"
-    public  const val PLAYLIST_ID = "[playlistID]"
+    private const val PLAYLIST_ID = "[playlistID]"
     private const val PODCAST_ID = "[podcastID]"
     private const val RADIO_ID = "[radioID]"
     private const val RECENTLY_ADDED_ID = "[recentlyAddedID]"
@@ -469,48 +469,25 @@ object MediaBrowserTree {
             ROOT_ID -> treeNodes[ROOT_ID]?.getChildren()!!
 
             HOME_ID -> treeNodes[HOME_ID]?.getChildren()!!
-            LAST_PLAYED_ID -> automotiveRepository.getAlbums(id, "recent", 15)
-            ALBUMS_ID -> automotiveRepository.getAlbums(id, "alphabeticalByName", 500)
-            ARTISTS_ID -> automotiveRepository.getAlbums(id, "alphabeticalByArtist", 500)
-            PLAYLIST_ID -> automotiveRepository.getPlaylists(id)
+            LAST_PLAYED_ID -> automotiveRepository.getAlbums(ALBUM_ID, "recent", 15)
+            ALBUMS_ID -> automotiveRepository.getAlbums(ALBUM_ID, "alphabeticalByName", 500)
+            ARTISTS_ID -> automotiveRepository.getAlbums(ALBUM_ID, "alphabeticalByArtist", 500)
+            PLAYLIST_ID -> automotiveRepository.getPlaylists(PLAYLIST_ID)
             PODCAST_ID -> automotiveRepository.getNewestPodcastEpisodes(100)
             RADIO_ID -> automotiveRepository.internetRadioStations
-            FOLDER_ID -> automotiveRepository.getMusicFolders(id)
-            MOST_PLAYED_ID -> automotiveRepository.getAlbums(id, "frequent", 15)
-            RECENT_SONGS_ID -> automotiveRepository.getRecentlyPlayedSongs(getServerId(),30)
-            RECENTLY_ADDED_ID -> automotiveRepository.getAlbums(id, "newest", 15)
-            MADE_FOR_YOU_ID -> automotiveRepository.getStarredArtists(id)
+            FOLDER_ID -> automotiveRepository.getMusicFolders(FOLDER_ID)
+            MOST_PLAYED_ID -> automotiveRepository.getAlbums(ALBUM_ID, "frequent", 15)
+            //RECENT_SONGS_ID -> automotiveRepository.getRecentlyPlayedSongs(getServerId(),30)
+            RECENTLY_ADDED_ID -> automotiveRepository.getAlbums(ALBUM_ID, "newest", 15)
+            //MADE_FOR_YOU_ID -> automotiveRepository.getStarredArtists(id)
             STARRED_TRACKS_ID -> automotiveRepository.starredSongs
-            STARRED_ALBUMS_ID -> automotiveRepository.getStarredAlbums(id)
-            STARRED_ARTISTS_ID -> automotiveRepository.getStarredArtists(id)
+            STARRED_ALBUMS_ID -> automotiveRepository.getStarredAlbums(ALBUM_ID)
+            STARRED_ARTISTS_ID -> automotiveRepository.getStarredArtists(ARTIST_ID)
             RANDOM_ID -> automotiveRepository.getRandomSongs(100)
             GENRES_ID -> automotiveRepository.getGenres(id)
 
             else -> {
-                if (id.startsWith(LAST_PLAYED_ID)) {
-                    return automotiveRepository.getAlbumTracks(id.removePrefix(LAST_PLAYED_ID))
-                }
-
-                if (id.startsWith(ALBUMS_ID)) {
-                    return automotiveRepository.getAlbumTracks(id.removePrefix(ALBUMS_ID))
-                }
-
-                if (id.startsWith(ARTISTS_ID)) {
-                    return automotiveRepository.getAlbumTracks(id.removePrefix(ARTISTS_ID))
-                }
-
-                if (id.startsWith(HOME_ID)) {
-                    return automotiveRepository.getAlbumTracks(id.removePrefix(HOME_ID))
-                }
-
-                if (id.startsWith(MOST_PLAYED_ID)) {
-                    return automotiveRepository.getAlbumTracks(id.removePrefix(MOST_PLAYED_ID))
-                }
-
-                if (id.startsWith(RECENTLY_ADDED_ID)) {
-                    return automotiveRepository.getAlbumTracks(id.removePrefix(RECENTLY_ADDED_ID))
-                }
-
+				/*
                 if (id.startsWith(MADE_FOR_YOU_ID)) {
                     return automotiveRepository.getMadeForYou(id.removePrefix(MADE_FOR_YOU_ID),20)
                 }
@@ -530,6 +507,7 @@ object MediaBrowserTree {
                     return automotiveRepository.getSongsByGenre(id.removePrefix(GENRES_ID), count, shuffle)
                 }
 
+				*/
                 if (id.startsWith(PLAYLIST_ID)) {
                     return automotiveRepository.getPlaylistSongs(id.removePrefix(PLAYLIST_ID))
                 }

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaBrowserTree.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaBrowserTree.kt
@@ -26,11 +26,6 @@ object MediaBrowserTree {
 
     private var isInitialized = false
 
-/*	data class FunctionItem(
-		val id: String,
-		var isDisplayed: Boolean
-	)
-*/
     // Root
     private const val ROOT_ID = "[rootID]"
 	// Available functions
@@ -575,10 +570,7 @@ object MediaBrowserTree {
                 val sessionMediaItem = automotiveRepository.getSessionMediaItem(it.mediaId)
 
                 if (sessionMediaItem != null) {
-                    var toAdd = automotiveRepository.getMetadatas(sessionMediaItem.timestamp!!)
-                    val index = toAdd.indexOfFirst { mediaItem -> mediaItem.mediaId == it.mediaId }
-
-                    toAdd = toAdd.subList(index, toAdd.size)
+                    val toAdd = automotiveRepository.getMetadatas(sessionMediaItem.timestamp!!)
 
                     updatedMediaItems.addAll(toAdd)
                 }
@@ -591,7 +583,6 @@ object MediaBrowserTree {
     fun search(query: String): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> {
         return automotiveRepository.search(
             query,
-       //     ALBUM_ID,
             ALBUM_ID,
             ARTIST_ID
         )

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaBrowserTree.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaBrowserTree.kt
@@ -31,10 +31,10 @@ object MediaBrowserTree {
 	// Available functions
     private const val HOME_ID = "[homeID]"
     private const val LAST_PLAYED_ID = "[lastPlayedID]"
-    private const val ALBUMS_ID = "[albumsID]"
+    public  const val ALBUMS_ID = "[albumsID]"
     private const val ARTISTS_ID = "[artistsID]"
     private const val MOST_PLAYED_ID = "[mostPlayedID]"
-    private const val PLAYLIST_ID = "[playlistID]"
+    public  const val PLAYLIST_ID = "[playlistID]"
     private const val PODCAST_ID = "[podcastID]"
     private const val RADIO_ID = "[radioID]"
     private const val RECENTLY_ADDED_ID = "[recentlyAddedID]"
@@ -557,27 +557,6 @@ object MediaBrowserTree {
                 return Futures.immediateFuture(LibraryResult.ofError(LibraryResult.RESULT_ERROR_BAD_VALUE))
             }
         }
-    }
-
-    // https://github.com/androidx/media/issues/156
-    fun getItems(mediaItems: List<MediaItem>): List<MediaItem> {
-        val updatedMediaItems = ArrayList<MediaItem>()
-
-        mediaItems.forEach {
-            if (it.localConfiguration?.uri != null) {
-                updatedMediaItems.add(it)
-            } else {
-                val sessionMediaItem = automotiveRepository.getSessionMediaItem(it.mediaId)
-
-                if (sessionMediaItem != null) {
-                    val toAdd = automotiveRepository.getMetadatas(sessionMediaItem.timestamp!!)
-
-                    updatedMediaItems.addAll(toAdd)
-                }
-            }
-        }
-
-        return updatedMediaItems
     }
 
     fun search(query: String): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> {

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaBrowserTree.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaBrowserTree.kt
@@ -328,7 +328,7 @@ object MediaBrowserTree {
         treeNodes[RECENT_SONGS_ID] =
             MediaItemNode(
                 buildMediaItem(
-                    gridView = albumView,
+                    gridView = false,
                     title = appContext.getString(R.string.aa_song_recently_played),
                     mediaId = RECENT_SONGS_ID,
                     isPlayable = false,
@@ -474,7 +474,7 @@ object MediaBrowserTree {
             ARTISTS_ID -> automotiveRepository.getAlbums(ALBUM_ID, "alphabeticalByArtist", 500)
             PLAYLIST_ID -> automotiveRepository.getPlaylists(PLAYLIST_ID)
             PODCAST_ID -> automotiveRepository.getNewestPodcastEpisodes(100)
-            RADIO_ID -> automotiveRepository.internetRadioStations
+            RADIO_ID -> automotiveRepository.getInternetRadioStations() //internetRadioStations
             FOLDER_ID -> automotiveRepository.getMusicFolders(FOLDER_ID)
             MOST_PLAYED_ID -> automotiveRepository.getAlbums(ALBUM_ID, "frequent", 15)
             //RECENT_SONGS_ID -> automotiveRepository.getRecentlyPlayedSongs(getServerId(),30)
@@ -484,7 +484,7 @@ object MediaBrowserTree {
             STARRED_ALBUMS_ID -> automotiveRepository.getStarredAlbums(ALBUM_ID)
             STARRED_ARTISTS_ID -> automotiveRepository.getStarredArtists(ARTIST_ID)
             RANDOM_ID -> automotiveRepository.getRandomSongs(100)
-            GENRES_ID -> automotiveRepository.getGenres(id)
+            GENRES_ID -> automotiveRepository.getGenres(GENRES_ID)
 
             else -> {
 				/*
@@ -499,6 +499,7 @@ object MediaBrowserTree {
                     val count = if (shuffle) 100 else 500
                     return automotiveRepository.getSongsByGenre(id.removePrefix(GENRES_ID), count, shuffle)
                 }
+
                 if (id.startsWith(PLAYLIST_ID)) {
                     return automotiveRepository.getPlaylistSongs(id.removePrefix(PLAYLIST_ID))
                 }

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
@@ -36,6 +36,7 @@ import com.cappielloantonio.tempo.util.Constants
 import com.cappielloantonio.tempo.util.Preferences
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.MoreExecutors
 import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
@@ -391,29 +392,82 @@ open class MediaLibrarySessionCallback(
             )
         }
 
-        val resolvedItems = MediaBrowserTree.getItems(mediaItems)
-        val requestedId = firstItem?.mediaId
+        val parentId =
+            firstItem.requestMetadata.extras?.getString("parent_id")
+                ?: firstItem.mediaMetadata.extras?.getString("parent_id")
 
-        if (requestedId == null || resolvedItems.isEmpty()) {
-            return super.onAddMediaItems(mediaSession, controller, resolvedItems)
+        val futureQueue: ListenableFuture<List<MediaItem>> = when {
+            parentId?.startsWith(MediaBrowserTree.ALBUMS_ID) == true -> {
+                Futures.transform(
+                    automotiveRepository.getAlbumTracks(parentId.removePrefix(MediaBrowserTree.ALBUMS_ID)),
+                    { result -> result.value ?: emptyList() },
+                    MoreExecutors.directExecutor()
+                )
+            }
+
+            parentId?.startsWith(MediaBrowserTree.PLAYLIST_ID) == true -> {
+                Futures.transform(
+                    automotiveRepository.getPlaylistSongs(parentId.removePrefix(MediaBrowserTree.PLAYLIST_ID)),
+                    { result -> result.value ?: emptyList() },
+                    MoreExecutors.directExecutor()
+                )
+            }
+
+            else -> {
+                val updatedMediaItems = ArrayList<MediaItem>()
+
+                mediaItems.forEach { item ->
+                    if (item.localConfiguration?.uri != null) {
+                        updatedMediaItems.add(item)
+                    } else {
+                        val sessionMediaItem = automotiveRepository.getSessionMediaItem(item.mediaId)
+
+                        if (sessionMediaItem != null) {
+                            val toAdd = automotiveRepository.getMetadatas(sessionMediaItem.timestamp!!)
+                            updatedMediaItems.addAll(toAdd)
+                        }
+                    }
+                }
+
+                if (updatedMediaItems.isEmpty()) {
+                    updatedMediaItems.add(firstItem)
+                }
+
+                Futures.immediateFuture(updatedMediaItems)
+            }
         }
 
-        val startIndex = resolvedItems.indexOfFirst { it.mediaId == requestedId }
+        return Futures.transform(
+            futureQueue,
+            { resolvedItems ->
+                if (resolvedItems.isEmpty()) return@transform resolvedItems
 
-        if (startIndex < 0) {
-            return super.onAddMediaItems(mediaSession, controller, resolvedItems)
-        }
-        val firstResolved = resolvedItems[0]
-        val extras = (firstResolved.mediaMetadata.extras ?: Bundle()).apply {
-            putInt("aa_start_index", startIndex)
-        }
-        val newFirstResolved = firstResolved.buildUpon()
-            .setMediaMetadata(firstResolved.mediaMetadata.buildUpon().setExtras(extras).build())
-            .build()
+                val requestedId = firstItem.mediaId
+                val startIndex = resolvedItems.indexOfFirst {
+                    it.mediaId == requestedId
+                }
 
-        val updatedResolved = resolvedItems.toMutableList()
-        updatedResolved[0] = newFirstResolved
-        return Futures.immediateFuture(updatedResolved)
+                if (startIndex < 0) return@transform resolvedItems
+
+                val firstResolved = resolvedItems[0]
+                val extras = (firstResolved.mediaMetadata.extras ?: Bundle()).apply {
+                    putInt("aa_start_index", startIndex)
+                }
+                val newFirstResolved = firstResolved.buildUpon()
+                    .setMediaMetadata(
+                        firstResolved.mediaMetadata.buildUpon()
+                            .setExtras(extras)
+                            .build()
+                    )
+                    .build()
+
+                val updatedResolved = resolvedItems.toMutableList()
+                updatedResolved[0] = newFirstResolved
+
+                updatedResolved
+            },
+            MoreExecutors.directExecutor()
+        )
     }
 
     override fun onSearch(

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
@@ -397,17 +397,17 @@ open class MediaLibrarySessionCallback(
                 ?: firstItem.mediaMetadata.extras?.getString("parent_id")
 
         val futureQueue: ListenableFuture<List<MediaItem>> = when {
-            parentId?.startsWith(MediaBrowserTree.ALBUMS_ID) == true -> {
+            parentId?.startsWith(AutomotiveRepository.ALBUM) == true -> {
                 Futures.transform(
-                    automotiveRepository.getAlbumTracks(parentId.removePrefix(MediaBrowserTree.ALBUMS_ID)),
+                    automotiveRepository.getAlbumTracks(parentId.removePrefix(AutomotiveRepository.ALBUM)),
                     { result -> result.value ?: emptyList() },
                     MoreExecutors.directExecutor()
                 )
             }
 
-            parentId?.startsWith(MediaBrowserTree.PLAYLIST_ID) == true -> {
+            parentId?.startsWith(AutomotiveRepository.PLAYLIST) == true -> {
                 Futures.transform(
-                    automotiveRepository.getPlaylistSongs(parentId.removePrefix(MediaBrowserTree.PLAYLIST_ID)),
+                    automotiveRepository.getPlaylistSongs(parentId.removePrefix(AutomotiveRepository.PLAYLIST)),
                     { result -> result.value ?: emptyList() },
                     MoreExecutors.directExecutor()
                 )

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
@@ -47,7 +47,6 @@ open class MediaLibrarySessionCallback(
     MediaLibraryService.MediaLibrarySession.Callback {
 
     init {
-        // modified by MFO
         MediaBrowserTree.initialize(context, automotiveRepository)
     }
 
@@ -349,7 +348,6 @@ open class MediaLibrarySessionCallback(
         browser: MediaSession.ControllerInfo,
         params: MediaLibraryService.LibraryParams?
     ): ListenableFuture<LibraryResult<MediaItem>> {
-        // added by MFO
         MediaBrowserTree.buildTree()
         return Futures.immediateFuture(LibraryResult.ofItem(MediaBrowserTree.getRootItem(), params))
     }
@@ -370,8 +368,8 @@ open class MediaLibrarySessionCallback(
         controller: MediaSession.ControllerInfo,
         mediaItems: List<MediaItem>
     ): ListenableFuture<List<MediaItem>> {
-        val firstItem = mediaItems.firstOrNull()
-        val isRadio = firstItem?.mediaId?.startsWith("ir-") == true
+        val firstItem = mediaItems.firstOrNull() ?: return Futures.immediateFuture(mediaItems)
+        val isRadio = firstItem?.mediaId?.startsWith("ir-") == true || firstItem?.mediaMetadata?.extras?.getString("type", "") == Constants.MEDIA_TYPE_RADIO
 
         if (isRadio) {
             return Futures.transformAsync(
@@ -394,7 +392,28 @@ open class MediaLibrarySessionCallback(
         }
 
         val resolvedItems = MediaBrowserTree.getItems(mediaItems)
-        return super.onAddMediaItems(mediaSession, controller, resolvedItems)
+        val requestedId = firstItem?.mediaId
+
+        if (requestedId == null || resolvedItems.isEmpty()) {
+            return super.onAddMediaItems(mediaSession, controller, resolvedItems)
+        }
+
+        val startIndex = resolvedItems.indexOfFirst { it.mediaId == requestedId }
+
+        if (startIndex < 0) {
+            return super.onAddMediaItems(mediaSession, controller, resolvedItems)
+        }
+        val firstResolved = resolvedItems[0]
+        val extras = (firstResolved.mediaMetadata.extras ?: Bundle()).apply {
+            putInt("aa_start_index", startIndex)
+        }
+        val newFirstResolved = firstResolved.buildUpon()
+            .setMediaMetadata(firstResolved.mediaMetadata.buildUpon().setExtras(extras).build())
+            .build()
+
+        val updatedResolved = resolvedItems.toMutableList()
+        updatedResolved[0] = newFirstResolved
+        return Futures.immediateFuture(updatedResolved)
     }
 
     override fun onSearch(

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.util.Log
 import androidx.annotation.OptIn
 import androidx.concurrent.futures.CallbackToFutureAdapter
+import androidx.media3.common.C
 import androidx.media3.common.HeartRating
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
@@ -364,42 +365,89 @@ open class MediaLibrarySessionCallback(
         return MediaBrowserTree.getChildren(parentId)
     }
 
+    @OptIn(UnstableApi::class)
+    override fun onSetMediaItems(
+        mediaSession: MediaSession,
+        controller: MediaSession.ControllerInfo,
+        mediaItems: MutableList<MediaItem>,
+        startIndex: Int,
+        startPositionMs: Long
+    ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> {
+
+        val firstItem = mediaItems.firstOrNull()
+            ?: return Futures.immediateFuture(
+                MediaSession.MediaItemsWithStartPosition(
+                    emptyList(),
+                    C.INDEX_UNSET,
+                    C.TIME_UNSET
+                )
+            )
+
+        return Futures.transform(
+            resolveQueue(firstItem),
+            { resolved ->
+                if (resolved.isEmpty()) {
+                    MediaSession.MediaItemsWithStartPosition(
+                        resolved,
+                        C.INDEX_UNSET,
+                        C.TIME_UNSET
+                    )
+                } else {
+                    val idx = resolved.indexOfFirst { it.mediaId == firstItem.mediaId }
+                    val startIdx = if (idx >= 0) idx else 0
+                    MediaSession.MediaItemsWithStartPosition(
+                        resolved,
+                        startIdx,
+                        0L
+                    )
+                }
+            },
+            MoreExecutors.directExecutor()
+        )
+    }
+
     override fun onAddMediaItems(
         mediaSession: MediaSession,
         controller: MediaSession.ControllerInfo,
         mediaItems: List<MediaItem>
     ): ListenableFuture<List<MediaItem>> {
         val firstItem = mediaItems.firstOrNull() ?: return Futures.immediateFuture(mediaItems)
-        val isRadio = firstItem?.mediaId?.startsWith("ir-") == true || firstItem?.mediaMetadata?.extras?.getString("type", "") == Constants.MEDIA_TYPE_RADIO
+        val isRadio = firstItem.mediaId?.startsWith("ir-") == true ||
+                firstItem.mediaMetadata.extras?.getString("type", "") == Constants.MEDIA_TYPE_RADIO
 
-        if (isRadio) {
-            return Futures.transformAsync(
-                automotiveRepository.internetRadioStations,
-                { result ->
-                    val stations = result?.value
-                    val selected = stations?.find { item -> item.mediaId == firstItem?.mediaId }
-                    if (selected != null) {
-                        val updatedSelected = selected.buildUpon()
-                            .setMimeType(selected.localConfiguration?.mimeType)
-                            .build()
-
-                        Futures.immediateFuture(listOf(updatedSelected))
-                    } else {
-                        Futures.immediateFuture(emptyList())
-                    }
-                },
-                androidx.core.content.ContextCompat.getMainExecutor(context)
-            )
+        if (!isRadio) {
+            return Futures.immediateFuture(mediaItems)
         }
 
-        val parentId =
-            firstItem.requestMetadata.extras?.getString("parent_id")
-                ?: firstItem.mediaMetadata.extras?.getString("parent_id")
+        return Futures.transformAsync(
+            automotiveRepository.internetRadioStations,
+            { result ->
+                val stations = result?.value
+                val selected = stations?.find { item -> item.mediaId == firstItem?.mediaId }
+                if (selected != null) {
+                    val updatedSelected = selected.buildUpon()
+                        .setMimeType(selected.localConfiguration?.mimeType)
+                        .build()
 
-        val futureQueue: ListenableFuture<List<MediaItem>> = when {
+                    Futures.immediateFuture(listOf(updatedSelected))
+                } else {
+                    Futures.immediateFuture(emptyList())
+                }
+            },
+            MoreExecutors.directExecutor()
+        )
+    }
+
+    @OptIn(UnstableApi::class)
+    private fun resolveQueue(firstItem: MediaItem): ListenableFuture<List<MediaItem>> {
+        val extras = firstItem.requestMetadata.extras ?: firstItem.mediaMetadata.extras
+        val parentId = extras?.getString("parent_id")
+
+        return when {
             parentId?.startsWith(AutomotiveRepository.ALBUM) == true -> {
                 Futures.transform(
-                    automotiveRepository.getAlbumTracks(parentId.removePrefix(AutomotiveRepository.ALBUM)),
+                    automotiveRepository.getAlbumTracks(parentId.removePrefix(AutomotiveRepository.ALBUM)
+                    ),
                     { result -> result.value ?: emptyList() },
                     MoreExecutors.directExecutor()
                 )
@@ -407,7 +455,8 @@ open class MediaLibrarySessionCallback(
 
             parentId?.startsWith(AutomotiveRepository.PLAYLIST) == true -> {
                 Futures.transform(
-                    automotiveRepository.getPlaylistSongs(parentId.removePrefix(AutomotiveRepository.PLAYLIST)),
+                    automotiveRepository.getPlaylistSongs(parentId.removePrefix(AutomotiveRepository.PLAYLIST)
+                    ),
                     { result -> result.value ?: emptyList() },
                     MoreExecutors.directExecutor()
                 )
@@ -416,16 +465,15 @@ open class MediaLibrarySessionCallback(
             else -> {
                 val updatedMediaItems = ArrayList<MediaItem>()
 
-                mediaItems.forEach { item ->
-                    if (item.localConfiguration?.uri != null) {
-                        updatedMediaItems.add(item)
-                    } else {
-                        val sessionMediaItem = automotiveRepository.getSessionMediaItem(item.mediaId)
-
-                        if (sessionMediaItem != null) {
-                            val toAdd = automotiveRepository.getMetadatas(sessionMediaItem.timestamp!!)
-                            updatedMediaItems.addAll(toAdd)
-                        }
+                if (firstItem.localConfiguration?.uri != null) {
+                    updatedMediaItems.add(firstItem)
+                } else {
+                    val sessionMediaItem =
+                        automotiveRepository.getSessionMediaItem(firstItem.mediaId)
+                    if (sessionMediaItem != null) {
+                        val toAdd =
+                            automotiveRepository.getMetadatas(sessionMediaItem.timestamp!!)
+                        updatedMediaItems.addAll(toAdd)
                     }
                 }
 
@@ -436,38 +484,6 @@ open class MediaLibrarySessionCallback(
                 Futures.immediateFuture(updatedMediaItems)
             }
         }
-
-        return Futures.transform(
-            futureQueue,
-            { resolvedItems ->
-                if (resolvedItems.isEmpty()) return@transform resolvedItems
-
-                val requestedId = firstItem.mediaId
-                val startIndex = resolvedItems.indexOfFirst {
-                    it.mediaId == requestedId
-                }
-
-                if (startIndex < 0) return@transform resolvedItems
-
-                val firstResolved = resolvedItems[0]
-                val extras = (firstResolved.mediaMetadata.extras ?: Bundle()).apply {
-                    putInt("aa_start_index", startIndex)
-                }
-                val newFirstResolved = firstResolved.buildUpon()
-                    .setMediaMetadata(
-                        firstResolved.mediaMetadata.buildUpon()
-                            .setExtras(extras)
-                            .build()
-                    )
-                    .build()
-
-                val updatedResolved = resolvedItems.toMutableList()
-                updatedResolved[0] = newFirstResolved
-
-                updatedResolved
-            },
-            MoreExecutors.directExecutor()
-        )
     }
 
     override fun onSearch(

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
@@ -5,7 +5,6 @@ import android.os.Bundle
 import android.util.Log
 import androidx.annotation.OptIn
 import androidx.concurrent.futures.CallbackToFutureAdapter
-import androidx.media3.common.C
 import androidx.media3.common.HeartRating
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
@@ -42,6 +41,7 @@ import retrofit2.Call
 import retrofit2.Callback
 import retrofit2.Response
 
+private const val TAG = "MediaLibraryServiceCallback"
 open class MediaLibrarySessionCallback(
     private val context: Context,
     private val automotiveRepository: AutomotiveRepository
@@ -365,125 +365,116 @@ open class MediaLibrarySessionCallback(
         return MediaBrowserTree.getChildren(parentId)
     }
 
-    @OptIn(UnstableApi::class)
-    override fun onSetMediaItems(
-        mediaSession: MediaSession,
-        controller: MediaSession.ControllerInfo,
-        mediaItems: MutableList<MediaItem>,
-        startIndex: Int,
-        startPositionMs: Long
-    ): ListenableFuture<MediaSession.MediaItemsWithStartPosition> {
-
-        val firstItem = mediaItems.firstOrNull()
-            ?: return Futures.immediateFuture(
-                MediaSession.MediaItemsWithStartPosition(
-                    emptyList(),
-                    C.INDEX_UNSET,
-                    C.TIME_UNSET
-                )
-            )
-
-        return Futures.transform(
-            resolveQueue(firstItem),
-            { resolved ->
-                if (resolved.isEmpty()) {
-                    MediaSession.MediaItemsWithStartPosition(
-                        resolved,
-                        C.INDEX_UNSET,
-                        C.TIME_UNSET
-                    )
-                } else {
-                    val idx = resolved.indexOfFirst { it.mediaId == firstItem.mediaId }
-                    val startIdx = if (idx >= 0) idx else 0
-                    MediaSession.MediaItemsWithStartPosition(
-                        resolved,
-                        startIdx,
-                        0L
-                    )
-                }
-            },
-            MoreExecutors.directExecutor()
-        )
-    }
-
     override fun onAddMediaItems(
         mediaSession: MediaSession,
         controller: MediaSession.ControllerInfo,
         mediaItems: List<MediaItem>
     ): ListenableFuture<List<MediaItem>> {
+        Log.d(TAG, "onAddMediaItems")
         val firstItem = mediaItems.firstOrNull() ?: return Futures.immediateFuture(mediaItems)
-        val isRadio = firstItem.mediaId?.startsWith("ir-") == true ||
-                firstItem.mediaMetadata.extras?.getString("type", "") == Constants.MEDIA_TYPE_RADIO
 
-        if (!isRadio) {
-            return Futures.immediateFuture(mediaItems)
+        Log.d(TAG, "mediaId = ${firstItem.mediaId}")
+        val extras = firstItem.requestMetadata.extras ?: firstItem.mediaMetadata.extras
+        Log.d(TAG, "extras: ${extras?.keySet()?.joinToString { key -> "$key=${extras.get(key)}" } ?: "null"}")
+
+        if (isRadio(firstItem)) {
+            Log.d(TAG, "Radio")
+            return fetchRadioItem(firstItem)
         }
 
+        return resolveQueueForItem(firstItem, mediaItems)
+    }
+
+    private fun isRadio(item: MediaItem): Boolean {
+        return item.mediaId?.startsWith("ir-") == true ||
+                item.mediaMetadata.extras?.getString("type", "") == Constants.MEDIA_TYPE_RADIO ||
+                item.requestMetadata.extras?.getString("type", "") == Constants.MEDIA_TYPE_RADIO
+    }
+
+    private fun fetchRadioItem(firstItem: MediaItem): ListenableFuture<List<MediaItem>> {
         return Futures.transformAsync(
             automotiveRepository.internetRadioStations,
             { result ->
-                val stations = result?.value
-                val selected = stations?.find { item -> item.mediaId == firstItem?.mediaId }
+                val selected = result?.value?.find { it.mediaId == firstItem.mediaId }
                 if (selected != null) {
-                    val updatedSelected = selected.buildUpon()
+                    val updated = selected.buildUpon()
                         .setMimeType(selected.localConfiguration?.mimeType)
                         .build()
-
-                    Futures.immediateFuture(listOf(updatedSelected))
+                    Futures.immediateFuture(listOf(updated))
                 } else {
                     Futures.immediateFuture(emptyList())
                 }
             },
-            MoreExecutors.directExecutor()
+            androidx.core.content.ContextCompat.getMainExecutor(context)
         )
     }
 
-    @OptIn(UnstableApi::class)
-    private fun resolveQueue(firstItem: MediaItem): ListenableFuture<List<MediaItem>> {
+    private fun resolveQueueForItem(
+        firstItem: MediaItem,
+        mediaItems: List<MediaItem>
+    ): ListenableFuture<List<MediaItem>> {
+        Log.d(TAG, "Resolve queue for item")
+
         val extras = firstItem.requestMetadata.extras ?: firstItem.mediaMetadata.extras
         val parentId = extras?.getString("parent_id")
 
-        return when {
+        val futureQueue: ListenableFuture<List<MediaItem>> = when {
             parentId?.startsWith(AutomotiveRepository.ALBUM) == true -> {
+                Log.d(TAG, "Fetching album tracks for $parentId")
                 Futures.transform(
-                    automotiveRepository.getAlbumTracks(parentId.removePrefix(AutomotiveRepository.ALBUM)
-                    ),
-                    { result -> result.value ?: emptyList() },
+                    automotiveRepository.getAlbumTracks(parentId.removePrefix(AutomotiveRepository.ALBUM)),
+                    { it.value ?: emptyList() },
                     MoreExecutors.directExecutor()
                 )
             }
 
             parentId?.startsWith(AutomotiveRepository.PLAYLIST) == true -> {
+                Log.d(TAG, "Fetching playlist tracks for $parentId")
                 Futures.transform(
-                    automotiveRepository.getPlaylistSongs(parentId.removePrefix(AutomotiveRepository.PLAYLIST)
-                    ),
-                    { result -> result.value ?: emptyList() },
+                    automotiveRepository.getPlaylistSongs(parentId.removePrefix(AutomotiveRepository.PLAYLIST)),
+                    { it.value ?: emptyList() },
                     MoreExecutors.directExecutor()
                 )
             }
 
             else -> {
-                val updatedMediaItems = ArrayList<MediaItem>()
-
-                if (firstItem.localConfiguration?.uri != null) {
-                    updatedMediaItems.add(firstItem)
-                } else {
-                    val sessionMediaItem =
-                        automotiveRepository.getSessionMediaItem(firstItem.mediaId)
-                    if (sessionMediaItem != null) {
-                        val toAdd =
-                            automotiveRepository.getMetadatas(sessionMediaItem.timestamp!!)
-                        updatedMediaItems.addAll(toAdd)
-                    }
+                Log.d(TAG, "Fallback queue for item ${firstItem.mediaId}")
+                val resolvedItems = ArrayList<MediaItem>()
+                mediaItems.forEach { item ->
+                    val sessionItem = item.localConfiguration?.uri?.let { item }
+                        ?: automotiveRepository.getSessionMediaItem(item.mediaId)?.let { session ->
+                            automotiveRepository.getMetadatas(session.timestamp!!)
+                        }
+                    sessionItem?.let { resolvedItems.addAll(if (it is List<*>) it as List<MediaItem> else listOf(it as MediaItem)) }
                 }
-
-                if (updatedMediaItems.isEmpty()) {
-                    updatedMediaItems.add(firstItem)
-                }
-
-                Futures.immediateFuture(updatedMediaItems)
+                if (resolvedItems.isEmpty()) resolvedItems.add(firstItem)
+                Futures.immediateFuture(resolvedItems)
             }
         }
+
+        return Futures.transform(
+            futureQueue,
+            { resolvedItems ->
+                if (resolvedItems.isEmpty()) return@transform resolvedItems
+
+                val startIndex = resolvedItems.indexOfFirst { it.mediaId == firstItem.mediaId }
+                Log.d(TAG, "Start index for clicked item ${firstItem.mediaId} = $startIndex")
+                if (startIndex < 0) return@transform resolvedItems
+
+                val firstResolved = resolvedItems[0]
+                val extras = (firstResolved.mediaMetadata.extras ?: Bundle()).apply {
+                    putInt("aa_start_index", startIndex)
+                }
+                val newFirstResolved = firstResolved.buildUpon()
+                    .setMediaMetadata(firstResolved.mediaMetadata.buildUpon().setExtras(extras).build())
+                    .build()
+
+                val updatedResolved = resolvedItems.toMutableList()
+                updatedResolved[0] = newFirstResolved
+                updatedResolved
+            },
+            MoreExecutors.directExecutor()
+        )
     }
 
     override fun onSearch(


### PR DESCRIPTION
This PR addresses https://github.com/eddyizm/tempus/issues/490
The fix consists of a full load of the album or playlist instead of a subList. Following by a seekTo to start playback on the correct track.

There's also some cleanup of comments left over from https://github.com/eddyizm/tempus/pull/437

Since I've modified BaseMediaService.kt, it would be good to have some additional tests to make sure there are no problems.

