### PR TITLE
fix: Show full album name when displaying details

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
@@ -261,8 +261,10 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
         bind.albumOtherInfoButton.setOnClickListener(v -> {
             if (bind.albumDetailView.getVisibility() == View.GONE) {
                 bind.albumDetailView.setVisibility(View.VISIBLE);
+                bind.albumNameLabel.setMaxLines(Integer.MAX_VALUE);
             } else if (bind.albumDetailView.getVisibility() == View.VISIBLE) {
                 bind.albumDetailView.setVisibility(View.GONE);
+                bind.albumNameLabel.setMaxLines(2);
             }
         });
 


### PR DESCRIPTION
This PR allows showing the full album name when tapping on the arrow to show its details.

# Screenshots:
Before:
<img src="https://github.com/user-attachments/assets/9860bc62-440c-4079-88a7-76f38c366a59" width="300">
After:
<img src="https://github.com/user-attachments/assets/2557161e-8cf1-47d6-9a8c-5b7695b9f5ab" width="300">
If the album name isn't long enough to cover more than two lines, the behavior is the same as before:
<img src="https://github.com/user-attachments/assets/df77d4c4-a528-42ff-998e-f50d7d5bd677" width="300">
</p>


