### PR TITLE
fix: Tile Size Manager applied to Made For You adapter

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SimilarTrackAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SimilarTrackAdapter.java
@@ -13,6 +13,7 @@ import com.cappielloantonio.tempo.interfaces.ClickCallback;
 import com.cappielloantonio.tempo.subsonic.models.Child;
 import com.cappielloantonio.tempo.util.Constants;
 import com.cappielloantonio.tempo.util.MusicUtil;
+import com.cappielloantonio.tempo.util.TileSizeManager;
 
 import java.util.Collections;
 import java.util.List;
@@ -21,6 +22,7 @@ public class SimilarTrackAdapter extends RecyclerView.Adapter<SimilarTrackAdapte
     private final ClickCallback click;
 
     private List<Child> songs;
+    private int sizePx = 400;
 
     public SimilarTrackAdapter(ClickCallback click) {
         this.click = click;
@@ -31,11 +33,20 @@ public class SimilarTrackAdapter extends RecyclerView.Adapter<SimilarTrackAdapte
     @Override
     public ViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         ItemHomeSimilarTrackBinding view = ItemHomeSimilarTrackBinding.inflate(LayoutInflater.from(parent.getContext()), parent, false);
+
+        TileSizeManager.getInstance().calculateTileSize(parent.getContext());
+        sizePx = TileSizeManager.getInstance().getTileSizePx(parent.getContext());
+
         return new ViewHolder(view);
     }
 
     @Override
     public void onBindViewHolder(ViewHolder holder, int position) {
+        ViewGroup.LayoutParams lp = holder.item.trackCoverImageView.getLayoutParams();
+        lp.width = sizePx;
+        lp.height = sizePx;
+        holder.item.trackCoverImageView.setLayoutParams(lp);
+
         Child song = songs.get(position);
 
         holder.item.titleTrackLabel.setText(song.getTitle());


### PR DESCRIPTION
Tile Size Manager is now applied also to Made For You adapter.
The size of the thumbnails is consistent with the rest of the page.