### PR TITLE
feat: accordion for settings page with minimal changes

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsContainerFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsContainerFragment.java
@@ -34,6 +34,7 @@ import androidx.preference.ListPreference;
 import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
+import androidx.preference.PreferenceScreen;
 import androidx.preference.SwitchPreference;
 
 import com.cappielloantonio.tempo.BuildConfig;
@@ -50,14 +51,17 @@ import com.cappielloantonio.tempo.ui.dialog.StarredAlbumSyncDialog;
 import com.cappielloantonio.tempo.ui.dialog.StarredArtistSyncDialog;
 import com.cappielloantonio.tempo.ui.dialog.StarredSyncDialog;
 import com.cappielloantonio.tempo.ui.dialog.StreamingCacheStorageDialog;
+import com.cappielloantonio.tempo.util.ClickablePreferenceCategory;
 import com.cappielloantonio.tempo.util.DownloadUtil;
 import com.cappielloantonio.tempo.util.ExternalAudioReader;
 import com.cappielloantonio.tempo.util.Preferences;
 import com.cappielloantonio.tempo.util.UIUtil;
 import com.cappielloantonio.tempo.viewmodel.SettingViewModel;
 
+import java.util.HashSet;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Set;
 
 @OptIn(markerClass = UnstableApi.class)
 public class SettingsContainerFragment extends PreferenceFragmentCompat {
@@ -73,6 +77,8 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
     private boolean isServiceBound = false;
     private ActivityResultLauncher<Intent> equalizerResultLauncher;
 
+    private final Set<String> expandedCategories = new HashSet<>();
+
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -81,13 +87,6 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
                 new ActivityResultContracts.StartActivityForResult(),
                 result -> {}
         );
-
-        if (!BuildConfig.FLAVOR.equals("tempus")) {
-            PreferenceCategory githubUpdateCategory = findPreference("settings_github_update_category_key");
-            if (githubUpdateCategory != null) {
-                getPreferenceScreen().removePreference(githubUpdateCategory);
-            }
-        }
 
         directoryPickerLauncher = registerForActivityResult(
                 new ActivityResultContracts.StartActivityForResult(),
@@ -137,10 +136,7 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
     public void onResume() {
         super.onResume();
 
-        checkSystemEqualizer();
-        checkCacheStorage();
-        checkStorage();
-        checkDownloadDirectory();
+        expandedCategories.clear();
 
         setStreamingCacheSize();
         setAppLanguage();
@@ -162,11 +158,43 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
 
         bindMediaService();
         actionAppEqualizer();
+
+        applyAccordionState();
     }
 
     @Override
     public void onCreatePreferences(Bundle savedInstanceState, String rootKey) {
         setPreferencesFromResource(R.xml.global_preferences, rootKey);
+
+        if (!BuildConfig.FLAVOR.equals("tempus")) {
+            PreferenceCategory githubUpdateCategory = findPreference("settings_github_update_category_key");
+            if (githubUpdateCategory != null) {
+                getPreferenceScreen().removePreference(githubUpdateCategory);
+            }
+        }
+
+        PreferenceScreen screen = getPreferenceScreen();
+        if (screen != null) {
+            for (int i = 0; i < screen.getPreferenceCount(); i++) {
+                Preference pref = screen.getPreference(i);
+                if (pref instanceof ClickablePreferenceCategory) {
+                    ClickablePreferenceCategory category = (ClickablePreferenceCategory) pref;
+                    if (category.getKey() == null) {
+                        category.setKey("category_key_" + i);
+                    }
+                    category.setOnClickListener(cat -> {
+                        String key = cat.getKey();
+                        if (expandedCategories.contains(key)) {
+                            expandedCategories.remove(key);
+                        } else {
+                            expandedCategories.add(key);
+                        }
+                        applyAccordionState();
+                    });
+                }
+            }
+        }
+
         ListPreference themePreference = findPreference(Preferences.THEME);
         if (themePreference != null) {
             themePreference.setOnPreferenceChangeListener(
@@ -175,6 +203,45 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
                         ThemeHelper.applyTheme(themeOption);
                         return true;
                     });
+        }
+    }
+
+    private void applyAccordionState() {
+        PreferenceScreen screen = getPreferenceScreen();
+        if (screen == null) return;
+
+        for (int i = 0; i < screen.getPreferenceCount(); i++) {
+            Preference pref = screen.getPreference(i);
+            if (pref instanceof PreferenceCategory) {
+                PreferenceCategory category = (PreferenceCategory) pref;
+                for (int j = 0; j < category.getPreferenceCount(); j++) {
+                    category.getPreference(j).setVisible(true);
+                }
+            }
+        }
+
+        checkSystemEqualizer();
+        checkCacheStorage();
+        checkStorage();
+        checkDownloadDirectory();
+        checkEqualizerBands();
+
+        for (int i = 0; i < screen.getPreferenceCount(); i++) {
+            Preference pref = screen.getPreference(i);
+            if (pref instanceof PreferenceCategory) {
+                PreferenceCategory category = (PreferenceCategory) pref;
+                boolean expanded = expandedCategories.contains(category.getKey());
+                category.setIcon(expanded ? R.drawable.ic_arrow_down : R.drawable.ic_navigate_next);
+                if (!expanded) {
+                    for (int j = 0; j < category.getPreferenceCount(); j++) {
+                        category.getPreference(j).setVisible(false);
+                    }
+                }
+            }
+        }
+
+        if (getListView() != null && getListView().getAdapter() != null) {
+            getListView().getAdapter().notifyDataSetChanged();
         }
     }
 
@@ -548,6 +615,7 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
             mediaServiceBinder = (MediaService.LocalBinder) service;
             isServiceBound = true;
             checkEqualizerBands();
+            applyAccordionState();
         }
 
         @Override

--- a/app/src/main/java/com/cappielloantonio/tempo/util/ClickablePreferenceCategory.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/ClickablePreferenceCategory.java
@@ -1,0 +1,36 @@
+package com.cappielloantonio.tempo.util;
+
+import android.content.Context;
+import android.util.AttributeSet;
+
+import androidx.annotation.NonNull;
+import androidx.preference.PreferenceCategory;
+import androidx.preference.PreferenceViewHolder;
+
+public class ClickablePreferenceCategory extends PreferenceCategory {
+    public interface OnClickListener {
+        void onClick(ClickablePreferenceCategory category);
+    }
+
+    private OnClickListener clickListener;
+
+    public ClickablePreferenceCategory(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        setSelectable(true);
+    }
+
+    public void setOnClickListener(OnClickListener listener) {
+        this.clickListener = listener;
+    }
+
+    @Override
+    public void onBindViewHolder(@NonNull PreferenceViewHolder holder) {
+        super.onBindViewHolder(holder);
+        holder.itemView.setClickable(true);
+        holder.itemView.setOnClickListener(v -> {
+            if (clickListener != null) {
+                clickListener.onClick(this);
+            }
+        });
+    }
+}

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -1,6 +1,6 @@
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
-    <PreferenceCategory app:title="@string/settings_title_general">
+    <com.cappielloantonio.tempo.util.ClickablePreferenceCategory app:title="@string/settings_title_general">
         <Preference
             android:layout_height="match_parent"
             android:key="system_equalizer"
@@ -29,9 +29,9 @@
         <Preference
             android:key="logout"
             android:title="@string/settings_logout_title"/>
-    </PreferenceCategory>
+    </com.cappielloantonio.tempo.util.ClickablePreferenceCategory>
 
-    <PreferenceCategory app:title="@string/settings_title_ui">
+    <com.cappielloantonio.tempo.util.ClickablePreferenceCategory app:title="@string/settings_title_ui">
         <ListPreference
             android:layout_height="match_parent"
             app:defaultValue="default"
@@ -156,9 +156,9 @@
             android:summary="@string/search_sort_summary"
             android:key="sort_search_chronologically" />
 
-    </PreferenceCategory>
+    </com.cappielloantonio.tempo.util.ClickablePreferenceCategory>
 
-     <PreferenceCategory app:title="@string/settings_title_playlist">
+     <com.cappielloantonio.tempo.util.ClickablePreferenceCategory app:title="@string/settings_title_playlist">
         <SwitchPreference
             android:title="@string/settings_allow_playlist_duplicates"
             android:defaultValue="false"
@@ -172,10 +172,10 @@
              app:key="home_sort_playlists"
              app:title="@string/settings_playlist_sort"
              app:useSimpleSummaryProvider="true" />
-    </PreferenceCategory>
+    </com.cappielloantonio.tempo.util.ClickablePreferenceCategory>
 
     
-    <PreferenceCategory app:title="@string/settings_title_data">
+    <com.cappielloantonio.tempo.util.ClickablePreferenceCategory app:title="@string/settings_title_data">
         <ListPreference
             app:defaultValue="256"
             app:dialogTitle="@string/settings_streaming_cache_size"
@@ -268,9 +268,9 @@
             android:key="delete_download_storage"
             app:title="@string/settings_delete_download_storage_title"
             app:summary="@string/settings_delete_download_storage_summary"/>
-    </PreferenceCategory>
+    </com.cappielloantonio.tempo.util.ClickablePreferenceCategory>
 
-    <PreferenceCategory app:title="@string/settings_title_transcoding">
+    <com.cappielloantonio.tempo.util.ClickablePreferenceCategory app:title="@string/settings_title_transcoding">
         <Preference
             app:selectable="false"
             app:summary="@string/settings_summary_transcoding" />
@@ -326,9 +326,9 @@
         <Preference
             app:selectable="false"
             app:summary="@string/settings_summary_transcoding_estimate_content_length" />
-    </PreferenceCategory>
+    </com.cappielloantonio.tempo.util.ClickablePreferenceCategory>
 
-    <PreferenceCategory app:title="@string/settings_title_transcoding_download">
+    <com.cappielloantonio.tempo.util.ClickablePreferenceCategory app:title="@string/settings_title_transcoding_download">
         <Preference
             app:selectable="false"
             app:summary="@string/settings_summary_transcoding_download" />
@@ -362,9 +362,9 @@
             app:key="max_bitrate_download"
             app:title="@string/settings_max_bitrate_download"
             app:useSimpleSummaryProvider="true" />
-    </PreferenceCategory>
+    </com.cappielloantonio.tempo.util.ClickablePreferenceCategory>
 
-    <PreferenceCategory app:title="@string/settings_title_replay_gain">
+    <com.cappielloantonio.tempo.util.ClickablePreferenceCategory app:title="@string/settings_title_replay_gain">
         <Preference
             app:selectable="false"
             app:summary="@string/settings_summary_replay_gain" />
@@ -378,9 +378,9 @@
             app:title="@string/settings_replay_gain"
             app:useSimpleSummaryProvider="true" />
 
-    </PreferenceCategory>
+    </com.cappielloantonio.tempo.util.ClickablePreferenceCategory>
 
-    <PreferenceCategory app:title="@string/settings_title_rating">
+    <com.cappielloantonio.tempo.util.ClickablePreferenceCategory app:title="@string/settings_title_rating">
         <SeekBarPreference
             android:key="min_star_rating"
             app:defaultValue="0"
@@ -391,9 +391,9 @@
             app:summary="@string/settings_summary_skip_min_star_rating"
             app:title="@string/settings_title_skip_min_star_rating" />
 
-    </PreferenceCategory>
+    </com.cappielloantonio.tempo.util.ClickablePreferenceCategory>
 
-    <PreferenceCategory app:title="@string/settings_title_scrobble">
+    <com.cappielloantonio.tempo.util.ClickablePreferenceCategory app:title="@string/settings_title_scrobble">
         <Preference
             app:selectable="false"
             app:summary="@string/settings_summary_scrobble" />
@@ -407,9 +407,9 @@
             android:defaultValue="true"
             android:key="scrobbling" />
 
-    </PreferenceCategory>
+    </com.cappielloantonio.tempo.util.ClickablePreferenceCategory>
 
-    <PreferenceCategory app:title="@string/settings_title_share">
+    <com.cappielloantonio.tempo.util.ClickablePreferenceCategory app:title="@string/settings_title_share">
         <Preference
             app:selectable="false"
             app:summary="@string/settings_summary_share" />
@@ -419,9 +419,9 @@
             android:defaultValue="false"
             android:key="share" />
 
-    </PreferenceCategory>
+    </com.cappielloantonio.tempo.util.ClickablePreferenceCategory>
 
-    <PreferenceCategory app:title="@string/settings_title_syncing">
+    <com.cappielloantonio.tempo.util.ClickablePreferenceCategory app:title="@string/settings_title_syncing">
         <Preference
             app:selectable="false"
             app:summary="@string/settings_summary_syncing" />
@@ -440,9 +440,9 @@
             app:key="queue_syncing_countdown"
             app:title="@string/settings_queue_syncing_countdown"
             app:useSimpleSummaryProvider="true" />
-    </PreferenceCategory>
+    </com.cappielloantonio.tempo.util.ClickablePreferenceCategory>
 
-    <PreferenceCategory 
+    <com.cappielloantonio.tempo.util.ClickablePreferenceCategory 
         android:key="settings_github_update_category_key"
         app:title="@string/settings_github_update">
         <Preference
@@ -452,10 +452,10 @@
             android:title="@string/settings_github_update_title"
             android:defaultValue="true"
             android:key="github_update_check" />
-    </PreferenceCategory>
+    </com.cappielloantonio.tempo.util.ClickablePreferenceCategory>
 
 	<!-- Android Auto configuration -->
-    <PreferenceCategory app:title="@string/settings_androidauto">
+    <com.cappielloantonio.tempo.util.ClickablePreferenceCategory app:title="@string/settings_androidauto">
          <Preference
             app:selectable="false"
             app:summary="@string/home_rearrangement_dialog_subtitle" />
@@ -526,10 +526,10 @@
             android:defaultValue="false"
             android:key="androidauto_shuffle_genre_songs" />
 			
-	</PreferenceCategory>
+	</com.cappielloantonio.tempo.util.ClickablePreferenceCategory>
 	<!-- end Add by MFO -->
 
-    <PreferenceCategory app:title="@string/settings_about_title">
+    <com.cappielloantonio.tempo.util.ClickablePreferenceCategory app:title="@string/settings_about_title">
         <Preference
             app:selectable="false"
             app:summary="@string/settings_about_summary" />
@@ -562,5 +562,5 @@
                 android:action="android.intent.action.VIEW"
                 android:data="@string/undraw_url" />
         </Preference>
-    </PreferenceCategory>
+    </com.cappielloantonio.tempo.util.ClickablePreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Since I do a lot of testing with Android Auto, I have to access the settings frequently.
Honestly, the settings page is far too long, and it's difficult to find what we're looking for.

So, after reading https://github.com/eddyizm/tempus/discussions/416, I wondered what could be done while modifying the code as little as possible.
I couldn't manage it without adding a class and modifying the XML heading category.

Here is this feature as a draft.

**Before:**
<img src="https://github.com/user-attachments/assets/8bbee10e-6471-4b90-bf3a-b1fff680ecaf" width="300">  <img src="https://github.com/user-attachments/assets/015c8f16-2d5e-43ad-b764-97826d913ec4" width="300">

**After folded:**
<img src="https://github.com/user-attachments/assets/7cc0b9a9-616c-4835-aa68-6655f3204522" width="300">

**unfolded:**
<img src="https://github.com/user-attachments/assets/bba604d1-1951-4c8f-82c8-056c36b1082b" width="300">  <img src="https://github.com/user-attachments/assets/e7cb799a-5f74-486a-836b-6efc04236caf" width="300">

