### PR TITLE
Android Auto: refresh "no items" on Random page

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/repository/AutomotiveRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/AutomotiveRepository.java
@@ -155,8 +155,6 @@ public class AutomotiveRepository {
         return listenableFuture;
     }
 
-
-
     public ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> getRandomSongs(int count) {
         return getRandomSongs(count, false);
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/repository/AutomotiveRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/AutomotiveRepository.java
@@ -15,6 +15,7 @@ import androidx.media3.common.util.UnstableApi;
 import androidx.media3.session.LibraryResult;
 
 import com.cappielloantonio.tempo.App;
+import com.cappielloantonio.tempo.R;
 import com.cappielloantonio.tempo.database.AppDatabase;
 import com.cappielloantonio.tempo.database.dao.ChronologyDao;
 import com.cappielloantonio.tempo.database.dao.SessionMediaItemDao;
@@ -154,7 +155,18 @@ public class AutomotiveRepository {
         return listenableFuture;
     }
 
+
+
     public ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> getRandomSongs(int count) {
+        return getRandomSongs(count, false);
+    }
+
+    /**
+     * Get random songs for Android Auto.
+     * If showRefreshOnFailure is true and the server returns empty or fails,
+     * return a single refresh item instead of an error.
+     */
+    public ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> getRandomSongs(int count, boolean showRefreshOnFailure) {
         final SettableFuture<LibraryResult<ImmutableList<MediaItem>>> listenableFuture = SettableFuture.create();
 
         App.getSubsonicClientInstance(false)
@@ -173,6 +185,9 @@ public class AutomotiveRepository {
                             LibraryResult<ImmutableList<MediaItem>> libraryResult = LibraryResult.ofItemList(ImmutableList.copyOf(mediaItems), null);
 
                             listenableFuture.set(libraryResult);
+                        } else if (showRefreshOnFailure) {
+                            // Return refresh item when server is unreachable or returns empty list
+                            onServerUnavailable(listenableFuture);
                         } else {
                             listenableFuture.set(LibraryResult.ofError(LibraryResult.RESULT_ERROR_BAD_VALUE));
                         }
@@ -180,11 +195,32 @@ public class AutomotiveRepository {
 
                     @Override
                     public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
-                        listenableFuture.setException(t);
+                        if (showRefreshOnFailure) {
+                            onServerUnavailable(listenableFuture);
+                        } else {
+                            listenableFuture.setException(t);
+                        }
                     }
                 });
 
         return listenableFuture;
+    }
+
+    /**
+     * Helper method to set a refresh item when server is unavailable.
+     */
+    private void onServerUnavailable(SettableFuture<LibraryResult<ImmutableList<MediaItem>>> future) {
+        MediaItem refreshItem = new MediaItem.Builder()
+                .setMediaId(App.getContext().getString(R.string.refresh_media_id))
+                .setMediaMetadata(new androidx.media3.common.MediaMetadata.Builder()
+                        .setTitle(App.getContext().getString(R.string.aa_action_refresh))
+                        .setIsBrowsable(false)
+                        .setIsPlayable(true)
+                        .setMediaType(androidx.media3.common.MediaMetadata.MEDIA_TYPE_MUSIC)
+                        .build())
+                .setUri("")
+                .build();
+        future.set(LibraryResult.ofItemList(ImmutableList.of(refreshItem), null));
     }
 
     public ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> getRecentlyPlayedSongs(String server, int count) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -11,6 +11,9 @@
 	<string name="aa_podcast">Podcast</string>
 	<string name="aa_radio">Radio</string>
     <string name="aa_random">Random</string>
+    <string name="aa_action_refresh">No data - Refresh</string>
+    <!-- Internal refresh media ID for Android Auto -->
+    <string name="refresh_media_id" translatable="false">__REFRESH_MEDIA__</string>
     <string name="aa_genres">Genres</string>
     <string name="aa_recent_albums">Recent</string>
     <string name="aa_song_recently_played">Song played</string>

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaBrowserTree.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaBrowserTree.kt
@@ -488,7 +488,7 @@ object MediaBrowserTree {
             STARRED_TRACKS_ID -> automotiveRepository.starredSongs
             STARRED_ALBUMS_ID -> automotiveRepository.getStarredAlbums(id)
             STARRED_ARTISTS_ID -> automotiveRepository.getStarredArtists(id)
-            RANDOM_ID -> automotiveRepository.getRandomSongs(100)
+            RANDOM_ID -> automotiveRepository.getRandomSongs(100, true)
             GENRES_ID -> automotiveRepository.getGenres(id)
 
             else -> {

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
@@ -372,6 +372,7 @@ open class MediaLibrarySessionCallback(
     ): ListenableFuture<List<MediaItem>> {
         val firstItem = mediaItems.firstOrNull()
         val isRadio = firstItem?.mediaId?.startsWith("ir-") == true
+        val isRefreshRandom = firstItem?.mediaId == App.getContext().getString(R.string.refresh_media_id)
 
         if (isRadio) {
             return Futures.transformAsync(
@@ -388,6 +389,21 @@ open class MediaLibrarySessionCallback(
                     } else {
                         Futures.immediateFuture(emptyList())
                     }
+                },
+                androidx.core.content.ContextCompat.getMainExecutor(context)
+            )
+        }
+
+        if (isRefreshRandom) {
+            // Re-fetch random songs when refresh is tapped
+            return Futures.transformAsync(
+                automotiveRepository.getRandomSongs(100),
+                { result ->
+                    val items = result.value ?: emptyList()
+                    val resolvedItems = MediaBrowserTree.getItems(items)
+                    // Return playable items for user to tap and play
+                    // Note: Browse list will auto-refresh after playback or manual navigation
+                    Futures.immediateFuture(resolvedItems)
                 },
                 androidx.core.content.ContextCompat.getMainExecutor(context)
             )


### PR DESCRIPTION
When using the Android Auto interface, if you select the "Random" page but there's some kind of connection error (e.g. you've just got out of the garage and your phone has disconnected from the home wifi) you get a "no items" message with no way to retry.
This PR handles the connection error by showing a fake "playable" item with title "No data - Refresh", which you can press to force a refresh.
(The same logic could be applied to other pages of course, if you like this approach I can write more PRs)

Note: I had to create the `refresh_media_id` string to share a fixed ID between AutomotiveRepository.java and MediaLibraryServiceCallback.kt