### PR TITLE
prerelease v4.14.0.1: fix queue reset on resume

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -141,15 +141,6 @@ open class BaseMediaService : MediaLibraryService() {
 
     fun initializePlayerListener(player: Player) {
         player.addListener(object : Player.Listener {
-            override fun onTimelineChanged(timeline: Timeline, reason: Int) {
-                if (reason == Player.TIMELINE_CHANGE_REASON_PLAYLIST_CHANGED) {
-                    Log.d(TAG, "onTimelineChanged: syncing local database queue")
-                    val mediaItems = (0 until player.mediaItemCount).map { player.getMediaItemAt(it) }
-                    val children = mediaItems.mapNotNull { MappingUtil.mapToChild(it) }
-                    QueueRepository().insertAll(children, true, 0)
-                }
-            }
-
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
                 Log.d(TAG, "onMediaItemTransition" + player.currentMediaItemIndex)
                 if (mediaItem == null) return

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
@@ -22,6 +22,7 @@ import androidx.media3.session.SessionResult
 import com.cappielloantonio.tempo.App
 import com.cappielloantonio.tempo.R
 import com.cappielloantonio.tempo.repository.AutomotiveRepository
+import com.cappielloantonio.tempo.repository.QueueRepository
 import com.cappielloantonio.tempo.subsonic.base.ApiResponse
 import com.cappielloantonio.tempo.util.Constants.CUSTOM_COMMAND_TOGGLE_HEART_LOADING
 import com.cappielloantonio.tempo.util.Constants.CUSTOM_COMMAND_TOGGLE_HEART_OFF
@@ -33,6 +34,7 @@ import com.cappielloantonio.tempo.util.Constants.CUSTOM_COMMAND_TOGGLE_SHUFFLE_M
 import com.cappielloantonio.tempo.util.Constants.CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_ON
 import com.google.common.collect.ImmutableList
 import com.cappielloantonio.tempo.util.Constants
+import com.cappielloantonio.tempo.util.MappingUtil
 import com.cappielloantonio.tempo.util.Preferences
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
@@ -460,6 +462,11 @@ open class MediaLibrarySessionCallback(
                 val startIndex = resolvedItems.indexOfFirst { it.mediaId == firstItem.mediaId }
                 Log.d(TAG, "Start index for clicked item ${firstItem.mediaId} = $startIndex")
                 if (startIndex < 0) return@transform resolvedItems
+
+                val children = resolvedItems.mapNotNull { MappingUtil.mapToChild(it) }
+                if (children.isNotEmpty()) {
+                    QueueRepository().insertAll(children, true, 0)
+                }
 
                 val firstResolved = resolvedItems[0]
                 val extras = (firstResolved.mediaMetadata.extras ?: Bundle()).apply {


### PR DESCRIPTION
This PR is intended for the prerelease [v4.14.0.1-dev](https://github.com/eddyizm/tempus/releases/tag/v4.14.0.1-dev)
It fix the queue's pointer reset on resume when playback is paused.