### PR TITLE
prerelease v4.14.0.2: refactor: move tag ID from AA files to Contants.kt

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/repository/AutomotiveRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/AutomotiveRepository.java
@@ -38,6 +38,7 @@ import com.cappielloantonio.tempo.subsonic.models.MusicFolder;
 import com.cappielloantonio.tempo.subsonic.models.Playlist;
 import com.cappielloantonio.tempo.subsonic.models.PodcastEpisode;
 import com.cappielloantonio.tempo.subsonic.models.Genre;
+import com.cappielloantonio.tempo.util.Constants;
 import com.cappielloantonio.tempo.util.DownloadUtil;
 import com.cappielloantonio.tempo.util.MappingUtil;
 import com.cappielloantonio.tempo.util.MusicUtil;
@@ -58,9 +59,6 @@ import retrofit2.Response;
 public class AutomotiveRepository {
     private final SessionMediaItemDao sessionMediaItemDao = AppDatabase.getInstance().sessionMediaItemDao();
     private final ChronologyDao chronologyDao = AppDatabase.getInstance().chronologyDao();
-
-    public static final String ALBUM = "[albumSource]";
-    public static final String PLAYLIST = "[playlistSource]";
 
     public ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> getAlbums(String prefix, String type, int size) {
         final SettableFuture<LibraryResult<ImmutableList<MediaItem>>> listenableFuture = SettableFuture.create();
@@ -663,7 +661,7 @@ public class AutomotiveRepository {
 
                             setChildrenMetadata(tracks);
 
-                            List<MediaItem> mediaItems = MappingUtil.mapMediaItems(tracks, ALBUM + id);
+                            List<MediaItem> mediaItems = MappingUtil.mapMediaItems(tracks, Constants.AA_ALBUM_SOURCE + id);
 
                             LibraryResult<ImmutableList<MediaItem>> libraryResult = LibraryResult.ofItemList(ImmutableList.copyOf(mediaItems), null);
 
@@ -748,7 +746,7 @@ public class AutomotiveRepository {
 
                             setChildrenMetadata(tracks);
 
-                            List<MediaItem> mediaItems = MappingUtil.mapMediaItems(tracks, PLAYLIST + id);
+                            List<MediaItem> mediaItems = MappingUtil.mapMediaItems(tracks, Constants.AA_PLAYLIST_SOURCE + id);
 
                             LibraryResult<ImmutableList<MediaItem>> libraryResult = LibraryResult.ofItemList(ImmutableList.copyOf(mediaItems), null);
 

--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -145,12 +145,12 @@ open class BaseMediaService : MediaLibraryService() {
                 Log.d(TAG, "onMediaItemTransition" + player.currentMediaItemIndex)
                 if (mediaItem == null) return
 
-                // --- Add for AA : aa_start_index if présent ---
+                // --- Add for AA : Constants.AA_START_INDEX if présent ---
                 val extras = mediaItem.mediaMetadata.extras
-                val startIndex = extras?.getInt("aa_start_index", -1) ?: -1
+                val startIndex = extras?.getInt(Constants.AA_START_INDEX, -1) ?: -1
                 if (startIndex >= 0 ) {
                     val cleanExtras = Bundle(extras).apply {
-                        remove("aa_start_index")
+                        remove(Constants.AA_START_INDEX)
                     }
                     val newMetadata = mediaItem.mediaMetadata.buildUpon()
                         .setExtras(cleanExtras)

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Constants.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Constants.kt
@@ -132,4 +132,39 @@ object Constants {
     enum class SeedType {
         ARTIST, ALBUM, TRACK
     }
+
+    // Android Root function
+    const val AA_ROOT_ID = "[rootID]"
+    // Android Auto functions
+    const val AA_HOME_ID = "[homeID]"
+    const val AA_LAST_PLAYED_ID = "[lastPlayedID]"
+    const val AA_ALBUMS_ID = "[albumsID]"
+    const val AA_ARTISTS_ID = "[artistsID]"
+    const val AA_MOST_PLAYED_ID = "[mostPlayedID]"
+    const val AA_PLAYLIST_ID = "[playlistID]"
+    const val AA_PODCAST_ID = "[podcastID]"
+    const val AA_RADIO_ID = "[radioID]"
+    const val AA_RECENTLY_ADDED_ID = "[recentlyAddedID]"
+    const val AA_RECENT_SONGS_ID = "[recentSongsID]"
+    const val AA_MADE_FOR_YOU_ID = "[madeForYouID]"
+    const val AA_STARRED_TRACKS_ID = "[starredTracksID]"
+    const val AA_STARRED_ALBUMS_ID = "[starredAlbumsID]"
+    const val AA_STARRED_ARTISTS_ID = "[starredArtistsID]"
+    const val AA_RANDOM_ID = "[randomID]"
+    const val AA_FOLDER_ID = "[folderID]"
+    const val AA_GENRES_ID = "[genresID]"
+
+    // Android Auto System functions
+    const val AA_INDEX_ID = "[indexID]"
+    const val AA_DIRECTORY_ID = "[directoryID]"
+    const val AA_ALBUM_ID = "[albumID]"
+    const val AA_ARTIST_ID = "[artistID]"
+
+    // Android Auto Source tag
+    const val AA_ALBUM_SOURCE = "[albumSource]";
+    const val AA_PLAYLIST_SOURCE = "[playlistSource]";
+
+    // Android Auto start index extra
+    const val AA_START_INDEX = "aa_start_index";
+
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Constants.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Constants.kt
@@ -161,10 +161,9 @@ object Constants {
     const val AA_ARTIST_ID = "[artistID]"
 
     // Android Auto Source tag
-    const val AA_ALBUM_SOURCE = "[albumSource]";
-    const val AA_PLAYLIST_SOURCE = "[playlistSource]";
+    const val AA_ALBUM_SOURCE = "[albumSource]"
+    const val AA_PLAYLIST_SOURCE = "[playlistSource]"
 
     // Android Auto start index extra
-    const val AA_START_INDEX = "aa_start_index";
-
+    const val AA_START_INDEX = "aa_start_index"
 }

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaBrowserTree.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaBrowserTree.kt
@@ -16,6 +16,7 @@ import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.SettableFuture
 import com.cappielloantonio.tempo.R
+import com.cappielloantonio.tempo.util.Constants
 import com.cappielloantonio.tempo.util.Preferences
 
 object MediaBrowserTree {
@@ -26,32 +27,6 @@ object MediaBrowserTree {
 
     private var isInitialized = false
 
-    // Root
-    private const val ROOT_ID = "[rootID]"
-	// Available functions
-    private const val HOME_ID = "[homeID]"
-    private const val LAST_PLAYED_ID = "[lastPlayedID]"
-    private const val ALBUMS_ID = "[albumsID]"
-    private const val ARTISTS_ID = "[artistsID]"
-    private const val MOST_PLAYED_ID = "[mostPlayedID]"
-    private const val PLAYLIST_ID = "[playlistID]"
-    private const val PODCAST_ID = "[podcastID]"
-    private const val RADIO_ID = "[radioID]"
-    private const val RECENTLY_ADDED_ID = "[recentlyAddedID]"
-    private const val RECENT_SONGS_ID = "[recentSongsID]"
-    private const val MADE_FOR_YOU_ID = "[madeForYouID]"
-    private const val STARRED_TRACKS_ID = "[starredTracksID]"
-    private const val STARRED_ALBUMS_ID = "[starredAlbumsID]"
-    private const val STARRED_ARTISTS_ID = "[starredArtistsID]"
-    private const val RANDOM_ID = "[randomID]"
-    private const val FOLDER_ID = "[folderID]"
-    private const val GENRES_ID = "[genresID]"
-
-	// System functions
-    private const val INDEX_ID = "[indexID]"
-    private const val DIRECTORY_ID = "[directoryID]"
-    private const val ALBUM_ID = "[albumID]"
-    private const val ARTIST_ID = "[artistID]"
 
     private fun iconUri(resId: Int): Uri =
         Uri.parse("android.resource://${BuildConfig.APPLICATION_ID}/$resId")
@@ -159,32 +134,32 @@ object MediaBrowserTree {
 
         // This list must be exactly the same as the one in aa_tab_titles
         val allFunctions = listOf(
-            HOME_ID,
-            LAST_PLAYED_ID,
-            ALBUMS_ID,
-            ARTISTS_ID,
-            PLAYLIST_ID,
-            PODCAST_ID,
-            RADIO_ID,
-            FOLDER_ID,
-            MOST_PLAYED_ID,
-            // RECENT_SONGS_ID,            // => doesn't work !
-            RECENTLY_ADDED_ID,
-            // MADE_FOR_YOU_ID,            // => doesn't work !
-            STARRED_TRACKS_ID,
-            STARRED_ALBUMS_ID,
-            STARRED_ARTISTS_ID,
-            RANDOM_ID,
-            GENRES_ID
+            Constants.AA_HOME_ID,
+            Constants.AA_LAST_PLAYED_ID,
+            Constants.AA_ALBUMS_ID,
+            Constants.AA_ARTISTS_ID,
+            Constants.AA_PLAYLIST_ID,
+            Constants.AA_PODCAST_ID,
+            Constants.AA_RADIO_ID,
+            Constants.AA_FOLDER_ID,
+            Constants.AA_MOST_PLAYED_ID,
+            //Constants.AA_RECENT_SONGS_ID,            // => doesn't work !
+            Constants.AA_RECENTLY_ADDED_ID,
+            //Constants.AA_MADE_FOR_YOU_ID,            // => doesn't work !
+            Constants.AA_STARRED_TRACKS_ID,
+            Constants.AA_STARRED_ALBUMS_ID,
+            Constants.AA_STARRED_ARTISTS_ID,
+            Constants.AA_RANDOM_ID,
+            Constants.AA_GENRES_ID
         )
 
         // Root level
-        treeNodes[ROOT_ID] =
+        treeNodes[Constants.AA_ROOT_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = albumView,
                     title = "Root Folder",
-                    mediaId = ROOT_ID,
+                    mediaId = Constants.AA_ROOT_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     mediaType = MediaMetadata.MEDIA_TYPE_FOLDER_MIXED
@@ -194,12 +169,12 @@ object MediaBrowserTree {
 		// All available functions
 		// if HOME is in first place or no item is selected
 		if (tabIndex.firstOrNull() == 0 || tabIndex.all { it == -1 }){
-			treeNodes[HOME_ID] =
+			treeNodes[Constants.AA_HOME_ID] =
 				MediaItemNode(
 					buildMediaItem(
 						gridView = homeView,
 						title = appContext.getString(R.string.aa_home),
-						mediaId = HOME_ID,
+						mediaId = Constants.AA_HOME_ID,
 						isPlayable = false,
 						isBrowsable = true,
 						imageUri = iconUri(R.drawable.ic_aa_home),
@@ -208,12 +183,12 @@ object MediaBrowserTree {
 				)
 		}
 		else { // More instead of Home
-			treeNodes[HOME_ID] =
+			treeNodes[Constants.AA_HOME_ID] =
 				MediaItemNode(
 					buildMediaItem(
 						gridView = homeView,
 						title = appContext.getString(R.string.aa_more),
-						mediaId = HOME_ID,
+						mediaId = Constants.AA_HOME_ID,
 						isPlayable = false,
 						isBrowsable = true,
 						imageUri = iconUri(R.drawable.ic_aa_other),
@@ -222,12 +197,12 @@ object MediaBrowserTree {
 				)
 		}
 		
-        treeNodes[LAST_PLAYED_ID] =
+        treeNodes[Constants.AA_LAST_PLAYED_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = albumView,
                     title = appContext.getString(R.string.aa_recent_albums),
-                    mediaId = LAST_PLAYED_ID,
+                    mediaId = Constants.AA_LAST_PLAYED_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_recent),
@@ -235,12 +210,12 @@ object MediaBrowserTree {
                 )
             )
 			
-        treeNodes[ALBUMS_ID] =
+        treeNodes[Constants.AA_ALBUMS_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = albumView,
                     title = appContext.getString(R.string.aa_albums),
-                    mediaId = ALBUMS_ID,
+                    mediaId = Constants.AA_ALBUMS_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_albums),
@@ -248,12 +223,12 @@ object MediaBrowserTree {
                 )
             )
 			
-        treeNodes[ARTISTS_ID] =
+        treeNodes[Constants.AA_ARTISTS_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = albumView,
                     title = appContext.getString(R.string.aa_artists),
-                    mediaId = ARTISTS_ID,
+                    mediaId = Constants.AA_ARTISTS_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_artists),
@@ -261,12 +236,12 @@ object MediaBrowserTree {
                 )
             )
 			
-        treeNodes[PLAYLIST_ID] =
+        treeNodes[Constants.AA_PLAYLIST_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = playlistView,
                     title = appContext.getString(R.string.aa_playlists),
-                    mediaId = PLAYLIST_ID,
+                    mediaId = Constants.AA_PLAYLIST_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_playlist),
@@ -274,12 +249,12 @@ object MediaBrowserTree {
                 )
             )
 
-        treeNodes[PODCAST_ID] =
+        treeNodes[Constants.AA_PODCAST_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = podcastView,
                     title = appContext.getString(R.string.aa_podcast),
-                    mediaId = PODCAST_ID,
+                    mediaId = Constants.AA_PODCAST_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_podcasts),
@@ -287,12 +262,12 @@ object MediaBrowserTree {
                 )
             )
 
-        treeNodes[RADIO_ID] =
+        treeNodes[Constants.AA_RADIO_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = radioView,
                     title = appContext.getString(R.string.aa_radio),
-                    mediaId = RADIO_ID,
+                    mediaId = Constants.AA_RADIO_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_radio),
@@ -300,24 +275,24 @@ object MediaBrowserTree {
                 )
             )
 
-        treeNodes[MOST_PLAYED_ID] =
+        treeNodes[Constants.AA_MOST_PLAYED_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = albumView,
                     title = appContext.getString(R.string.aa_album_most_played),
-                    mediaId = MOST_PLAYED_ID,
+                    mediaId = Constants.AA_MOST_PLAYED_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_mostplayed),
                     mediaType = MediaMetadata.MEDIA_TYPE_FOLDER_ALBUMS
                 )
             )
-        treeNodes[RECENTLY_ADDED_ID] =
+        treeNodes[Constants.AA_RECENTLY_ADDED_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = albumView,
                     title = appContext.getString(R.string.aa_album_recently_added),
-                    mediaId = RECENTLY_ADDED_ID,
+                    mediaId = Constants.AA_RECENTLY_ADDED_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_added_album),
@@ -325,12 +300,12 @@ object MediaBrowserTree {
                 )
             )
 		
-        treeNodes[RECENT_SONGS_ID] =
+        treeNodes[Constants.AA_RECENT_SONGS_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = false,
                     title = appContext.getString(R.string.aa_song_recently_played),
-                    mediaId = RECENT_SONGS_ID,
+                    mediaId = Constants.AA_RECENT_SONGS_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_recent_title),
@@ -338,12 +313,12 @@ object MediaBrowserTree {
                 )
             )
 		
-        treeNodes[MADE_FOR_YOU_ID] =
+        treeNodes[Constants.AA_MADE_FOR_YOU_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = albumView,
                     title = appContext.getString(R.string.aa_made_for_you),
-                    mediaId = MADE_FOR_YOU_ID,
+                    mediaId = Constants.AA_MADE_FOR_YOU_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_for_you),
@@ -351,12 +326,12 @@ object MediaBrowserTree {
                 )
             )
 
-        treeNodes[STARRED_TRACKS_ID] =
+        treeNodes[Constants.AA_STARRED_TRACKS_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = albumView,
                     title = appContext.getString(R.string.aa_starred_tracks),
-                    mediaId = STARRED_TRACKS_ID,
+                    mediaId = Constants.AA_STARRED_TRACKS_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_star_title),
@@ -364,12 +339,12 @@ object MediaBrowserTree {
                 )
             )
 
-        treeNodes[STARRED_ALBUMS_ID] =
+        treeNodes[Constants.AA_STARRED_ALBUMS_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = albumView,
                     title = appContext.getString(R.string.aa_starred_albums),
-                    mediaId = STARRED_ALBUMS_ID,
+                    mediaId = Constants.AA_STARRED_ALBUMS_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_star_album),
@@ -377,12 +352,12 @@ object MediaBrowserTree {
                 )
             )
 
-        treeNodes[STARRED_ARTISTS_ID] =
+        treeNodes[Constants.AA_STARRED_ARTISTS_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = albumView,
                     title = appContext.getString(R.string.aa_starred_artists),
-                    mediaId = STARRED_ARTISTS_ID,
+                    mediaId = Constants.AA_STARRED_ARTISTS_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_artists),
@@ -390,12 +365,12 @@ object MediaBrowserTree {
                 )
             )
 
-        treeNodes[FOLDER_ID] =
+        treeNodes[Constants.AA_FOLDER_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = false,
                     title = appContext.getString(R.string.aa_music_folder),
-                    mediaId = FOLDER_ID,
+                    mediaId = Constants.AA_FOLDER_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_folders),
@@ -403,12 +378,12 @@ object MediaBrowserTree {
                 )
             )
 
-        treeNodes[RANDOM_ID] =
+        treeNodes[Constants.AA_RANDOM_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = false,
                     title = appContext.getString(R.string.aa_random),
-                    mediaId = RANDOM_ID,
+                    mediaId = Constants.AA_RANDOM_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_random),
@@ -416,12 +391,12 @@ object MediaBrowserTree {
                 )
             )
 
-        treeNodes[GENRES_ID] =
+        treeNodes[Constants.AA_GENRES_ID] =
             MediaItemNode(
                 buildMediaItem(
                     gridView = false,
                     title = appContext.getString(R.string.aa_genres),
-                    mediaId = GENRES_ID,
+                    mediaId = Constants.AA_GENRES_ID,
                     isPlayable = false,
                     isBrowsable = true,
                     imageUri = iconUri(R.drawable.ic_aa_genres),
@@ -429,7 +404,7 @@ object MediaBrowserTree {
                 )
             )
 
-        val root = treeNodes[ROOT_ID]!!
+        val root = treeNodes[Constants.AA_ROOT_ID]!!
         val selectedIds = mutableSetOf<String>()
 
         // First level
@@ -445,8 +420,8 @@ object MediaBrowserTree {
             }
 		// if no function is selected, add at least HOME_ID
         if (selectedIds.isEmpty()) {
-            root.addChild(HOME_ID)
-            selectedIds.add(HOME_ID)
+            root.addChild(Constants.AA_HOME_ID)
+            selectedIds.add(Constants.AA_HOME_ID)
         }
 
         // Second level for HOME_ID even there is no HOME_ID displayed
@@ -454,37 +429,37 @@ object MediaBrowserTree {
         allFunctions
             .filter { it !in selectedIds }
             .forEach { function ->
-                treeNodes[HOME_ID]?.addChild(function)
+                treeNodes[Constants.AA_HOME_ID]?.addChild(function)
             }
 	}
 	
     fun getRootItem(): MediaItem {
-        return treeNodes[ROOT_ID]!!.item
+        return treeNodes[Constants.AA_ROOT_ID]!!.item
     }
 
     fun getChildren(
         id: String
     ): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> {
         return when (id) {
-            ROOT_ID -> treeNodes[ROOT_ID]?.getChildren()!!
+            Constants.AA_ROOT_ID -> treeNodes[Constants.AA_ROOT_ID]?.getChildren()!!
 
-            HOME_ID -> treeNodes[HOME_ID]?.getChildren()!!
-            LAST_PLAYED_ID -> automotiveRepository.getAlbums(ALBUM_ID, "recent", 15)
-            ALBUMS_ID -> automotiveRepository.getAlbums(ALBUM_ID, "alphabeticalByName", 500)
-            ARTISTS_ID -> automotiveRepository.getAlbums(ALBUM_ID, "alphabeticalByArtist", 500)
-            PLAYLIST_ID -> automotiveRepository.getPlaylists(PLAYLIST_ID)
-            PODCAST_ID -> automotiveRepository.getNewestPodcastEpisodes(100)
-            RADIO_ID -> automotiveRepository.getInternetRadioStations() //internetRadioStations
-            FOLDER_ID -> automotiveRepository.getMusicFolders(FOLDER_ID)
-            MOST_PLAYED_ID -> automotiveRepository.getAlbums(ALBUM_ID, "frequent", 15)
-            //RECENT_SONGS_ID -> automotiveRepository.getRecentlyPlayedSongs(getServerId(),30)
-            RECENTLY_ADDED_ID -> automotiveRepository.getAlbums(ALBUM_ID, "newest", 15)
-            //MADE_FOR_YOU_ID -> automotiveRepository.getStarredArtists(id)
-            STARRED_TRACKS_ID -> automotiveRepository.starredSongs
-            STARRED_ALBUMS_ID -> automotiveRepository.getStarredAlbums(ALBUM_ID)
-            STARRED_ARTISTS_ID -> automotiveRepository.getStarredArtists(ARTIST_ID)
-            RANDOM_ID -> automotiveRepository.getRandomSongs(100)
-            GENRES_ID -> automotiveRepository.getGenres(GENRES_ID)
+            Constants.AA_HOME_ID -> treeNodes[Constants.AA_HOME_ID]?.getChildren()!!
+            Constants.AA_LAST_PLAYED_ID -> automotiveRepository.getAlbums(Constants.AA_ALBUM_ID, "recent", 15)
+            Constants.AA_ALBUMS_ID -> automotiveRepository.getAlbums(Constants.AA_ALBUM_ID, "alphabeticalByName", 500)
+            Constants.AA_ARTISTS_ID -> automotiveRepository.getAlbums(Constants.AA_ALBUM_ID, "alphabeticalByArtist", 500)
+            Constants.AA_PLAYLIST_ID -> automotiveRepository.getPlaylists(Constants.AA_PLAYLIST_ID)
+            Constants.AA_PODCAST_ID -> automotiveRepository.getNewestPodcastEpisodes(100)
+            Constants.AA_RADIO_ID -> automotiveRepository.getInternetRadioStations()
+            Constants.AA_FOLDER_ID -> automotiveRepository.getMusicFolders(Constants.AA_FOLDER_ID)
+            Constants.AA_MOST_PLAYED_ID -> automotiveRepository.getAlbums(Constants.AA_ALBUM_ID, "frequent", 15)
+            //Constants.AA_RECENT_SONGS_ID -> automotiveRepository.getRecentlyPlayedSongs(getServerId(),30)
+            Constants.AA_RECENTLY_ADDED_ID -> automotiveRepository.getAlbums(Constants.AA_ALBUM_ID, "newest", 15)
+            //Constants.AA_MADE_FOR_YOU_ID -> automotiveRepository.getStarredArtists(id)
+            Constants.AA_STARRED_TRACKS_ID -> automotiveRepository.starredSongs
+            Constants.AA_STARRED_ALBUMS_ID -> automotiveRepository.getStarredAlbums(Constants.AA_ALBUM_ID)
+            Constants.AA_STARRED_ARTISTS_ID -> automotiveRepository.getStarredArtists(Constants.AA_ARTIST_ID)
+            Constants.AA_RANDOM_ID -> automotiveRepository.getRandomSongs(100)
+            Constants.AA_GENRES_ID -> automotiveRepository.getGenres(Constants.AA_GENRES_ID)
 
             else -> {
 				/*
@@ -493,35 +468,35 @@ object MediaBrowserTree {
                 }
                 */
 
-                if (id.startsWith(GENRES_ID)) {
+                if (id.startsWith(Constants.AA_GENRES_ID)) {
                     val shuffle = Preferences.isAndroidAutoShuffleGenreSongsEnabled()
                     // If the user doesn't want random songs, it's likely it's for perusing them, so provide as many as possible
                     val count = if (shuffle) 100 else 500
-                    return automotiveRepository.getSongsByGenre(id.removePrefix(GENRES_ID), count, shuffle)
+                    return automotiveRepository.getSongsByGenre(id.removePrefix(Constants.AA_GENRES_ID), count, shuffle)
                 }
 
-                if (id.startsWith(PLAYLIST_ID)) {
-                    return automotiveRepository.getPlaylistSongs(id.removePrefix(PLAYLIST_ID))
+                if (id.startsWith(Constants.AA_PLAYLIST_ID)) {
+                    return automotiveRepository.getPlaylistSongs(id.removePrefix(Constants.AA_PLAYLIST_ID))
                 }
 
-                if (id.startsWith(ALBUM_ID)) {
-                    return automotiveRepository.getAlbumTracks(id.removePrefix(ALBUM_ID))
+                if (id.startsWith(Constants.AA_ALBUM_ID)) {
+                    return automotiveRepository.getAlbumTracks(id.removePrefix(Constants.AA_ALBUM_ID))
                 }
 
-                if (id.startsWith(ARTIST_ID)) {
-                    return automotiveRepository.getArtistAlbum(ALBUM_ID,id.removePrefix(ARTIST_ID))
+                if (id.startsWith(Constants.AA_ARTIST_ID)) {
+                    return automotiveRepository.getArtistAlbum(Constants.AA_ALBUM_ID,id.removePrefix(Constants.AA_ARTIST_ID))
                 }
 
-                if (id.startsWith(FOLDER_ID)) {
-                    return automotiveRepository.getIndexes(INDEX_ID,id.removePrefix(FOLDER_ID))
+                if (id.startsWith(Constants.AA_FOLDER_ID)) {
+                    return automotiveRepository.getIndexes(Constants.AA_INDEX_ID,id.removePrefix(Constants.AA_FOLDER_ID))
                 }
 
-                if (id.startsWith(INDEX_ID)) {
-                    return automotiveRepository.getDirectories(DIRECTORY_ID,id.removePrefix(INDEX_ID))
+                if (id.startsWith(Constants.AA_INDEX_ID)) {
+                    return automotiveRepository.getDirectories(Constants.AA_DIRECTORY_ID,id.removePrefix(Constants.AA_INDEX_ID))
                 }
 
-                if (id.startsWith(DIRECTORY_ID)) {
-                    return automotiveRepository.getDirectories(DIRECTORY_ID,id.removePrefix(DIRECTORY_ID))
+                if (id.startsWith(Constants.AA_DIRECTORY_ID)) {
+                    return automotiveRepository.getDirectories(Constants.AA_DIRECTORY_ID,id.removePrefix(Constants.AA_DIRECTORY_ID))
                 }
 
                 return Futures.immediateFuture(LibraryResult.ofError(LibraryResult.RESULT_ERROR_BAD_VALUE))
@@ -532,8 +507,8 @@ object MediaBrowserTree {
     fun search(query: String): ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> {
         return automotiveRepository.search(
             query,
-            ALBUM_ID,
-            ARTIST_ID
+            Constants.AA_ALBUM_ID,
+            Constants.AA_ARTIST_ID
         )
     }
 }

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
@@ -421,19 +421,19 @@ open class MediaLibrarySessionCallback(
         val parentId = extras?.getString("parent_id")
 
         val futureQueue: ListenableFuture<List<MediaItem>> = when {
-            parentId?.startsWith(AutomotiveRepository.ALBUM) == true -> {
+            parentId?.startsWith(Constants.AA_ALBUM_SOURCE) == true -> {
                 Log.d(TAG, "Fetching album tracks for $parentId")
                 Futures.transform(
-                    automotiveRepository.getAlbumTracks(parentId.removePrefix(AutomotiveRepository.ALBUM)),
+                    automotiveRepository.getAlbumTracks(parentId.removePrefix(Constants.AA_ALBUM_SOURCE)),
                     { it.value ?: emptyList() },
                     MoreExecutors.directExecutor()
                 )
             }
 
-            parentId?.startsWith(AutomotiveRepository.PLAYLIST) == true -> {
+            parentId?.startsWith(Constants.AA_PLAYLIST_SOURCE) == true -> {
                 Log.d(TAG, "Fetching playlist tracks for $parentId")
                 Futures.transform(
-                    automotiveRepository.getPlaylistSongs(parentId.removePrefix(AutomotiveRepository.PLAYLIST)),
+                    automotiveRepository.getPlaylistSongs(parentId.removePrefix(Constants.AA_PLAYLIST_SOURCE)),
                     { it.value ?: emptyList() },
                     MoreExecutors.directExecutor()
                 )
@@ -470,7 +470,7 @@ open class MediaLibrarySessionCallback(
 
                 val firstResolved = resolvedItems[0]
                 val extras = (firstResolved.mediaMetadata.extras ?: Bundle()).apply {
-                    putInt("aa_start_index", startIndex)
+                    putInt(Constants.AA_START_INDEX, startIndex)
                 }
                 val newFirstResolved = firstResolved.buildUpon()
                     .setMediaMetadata(firstResolved.mediaMetadata.buildUpon().setExtras(extras).build())


### PR DESCRIPTION
This PR is intended for the prerelease [v4.14.0.2-dev](https://github.com/eddyizm/tempus/releases/tag/v4.14.0.2-dev)

All the ID used for android auto are moved into Constants.kt
This is important for future Android Auto features and their maintainability.