### PR TITLE
fix: prevent NPE from getView() in SearchFragment (#548)

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/repository/SearchingRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/SearchingRepository.java
@@ -96,7 +96,6 @@ public class SearchingRepository {
                 }
             }
             PlaylistWithSongs pws = new PlaylistWithSongs("allsongs", allSongs);
-            pws.setName(sf.getView().getContext().getString(R.string.search_all_songs, String.valueOf(allSongs.size())));
             pws.setSongCount(allSongs.size());
             List<Playlist> lpws = new ArrayList<>();
             lpws.add(pws);
@@ -109,7 +108,10 @@ public class SearchingRepository {
             pws.setDuration(duration);
 
             new Handler(Looper.getMainLooper()).post(() -> {
-                sf.updateUI(lpws);
+                if (sf.getView() != null && sf.isAdded()) {
+                    pws.setName(sf.getView().getContext().getString(R.string.search_all_songs, String.valueOf(allSongs.size())));
+                    sf.updateUI(lpws);
+                }
             });
         });
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SearchFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SearchFragment.java
@@ -235,12 +235,14 @@ public class SearchFragment extends Fragment implements ClickCallback {
     }
 
     public void updateUI(List<Playlist> allSongs) {
-        if (!allSongs.isEmpty()) {
+        if (allSongs != null && !allSongs.isEmpty()) {
             playlistHorizontalAdapter.setItems(allSongs);
+            if (getView() != null && bind != null) {
+                bind.allSongs.setText(this.getView().getContext().getString(R.string.search_all_songs_play, String.valueOf(allSongs.get(0).getName())));
+            }
         } else {
             playlistHorizontalAdapter.setItems(Collections.emptyList());
         }
-        bind.allSongs.setText(this.getView().getContext().getString(R.string.search_all_songs_play,String.valueOf(allSongs.getFirst().getName())));
     }
     private void performSearch(String query) {
         searchViewModel.search3(this, query).observe(getViewLifecycleOwner(), result -> {


### PR DESCRIPTION
This PR fixes the crash reported in #548 where calling `getView()` directly from a background thread caused a `NullPointerException` inside `SearchingRepository.java`, and another potential crash during view destruction in `SearchFragment.java`.

**Changes:**
- Moved the string resource fetching inside the `Looper.getMainLooper()` handler in `SearchingRepository`.
- Added safety checks (`sf.getView() != null && sf.isAdded()`) before attempting UI updates.
- Added null binding checks in `SearchFragment` and replaced the API35+ `getFirst()` with `get(0)` for backward compatibility.

Confirmed the build succeeds and fixes the immediate search crash on device.