### PR TITLE
fix: redundant padding on artist page carousels

### DIFF
--- a/app/src/main/res/layout/item_album_carousel.xml
+++ b/app/src/main/res/layout/item_album_carousel.xml
@@ -3,7 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:paddingStart="8dp"
     android:paddingEnd="8dp">
 
     <com.google.android.material.imageview.ShapeableImageView

--- a/app/src/main/res/layout/item_artist_carousel.xml
+++ b/app/src/main/res/layout/item_artist_carousel.xml
@@ -3,7 +3,6 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="wrap_content"
     android:layout_height="wrap_content"
-    android:paddingStart="8dp"
     android:paddingEnd="8dp">
 
     <com.google.android.material.imageview.ShapeableImageView


### PR DESCRIPTION
This PR fixes a minor visual misalignment of the carousel items cause by an extra `startPadding`.

This also caused a large spacing between items, which doesn't follow the UI standards of the rest of the app.

### Screenshots

<details>
<summary>Before | After</summary>

<img width="300" src="https://github.com/user-attachments/assets/99d7197a-9e07-45e4-bac6-0ffb9765071e" />

<img width="300" src="https://github.com/user-attachments/assets/43a0280d-8919-40dc-8fea-5e0b892e8db3" />

</details>