### PR TITLE
fix: remove estimate content length from german localization

### DIFF
--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -343,8 +343,6 @@
     <string name="settings_audio_transcode_download_priority_title">Format-Einstellung des Servers bevorzugen</string>
     <string name="settings_audio_transcode_download_summary">Titel werden vor dem Herunterladen umgewandelt</string>
     <string name="settings_audio_transcode_download_title">Umgewandelte Titel herunterladen</string>
-    <string name="settings_audio_transcode_estimate_content_length_summary">Den Server nach der geschätzten Dauer des Titels fragen.</string>
-    <string name="settings_audio_transcode_estimate_content_length_title">Inhaltslänge schätzen</string>
     <string name="settings_audio_transcode_format_download">Format für Downloads</string>
     <string name="settings_audio_transcode_format_mobile">Format bei Mobilfunk</string>
     <string name="settings_audio_transcode_format_wifi">Format im WLAN</string>


### PR DESCRIPTION
This PR fixes the re-introduction of some old strings by #547.