### PR TITLE
feat: make navigation drawer translatable

### DIFF
--- a/app/src/main/res/menu/nav_drawer.xml
+++ b/app/src/main/res/menu/nav_drawer.xml
@@ -6,7 +6,7 @@
         android:icon="@drawable/ic_search"
         android:title="@string/menu_search_button" />
 
-    <item android:title="Index" >
+    <item android:title="@string/nav_drawer_index">
         <menu>
             <item
                 android:id="@+id/homeFragment"
@@ -31,28 +31,28 @@
 
     </item>
 
-    <item android:title="All" >
+    <item android:title="@string/menu_filter_all" >
         <menu>
             <item
                 android:id="@+id/albumCatalogueFragment"
                 android:icon="@drawable/ic_albums"
-                android:title="Albums" />
+                android:title="@string/library_title_album" />
 
             <item
                 android:id="@+id/artistCatalogueFragment"
                 android:icon="@drawable/ic_artists"
-                android:title="Artists" />
+                android:title="@string/library_title_artist" />
 
 
             <item
                 android:id="@+id/genreCatalogueFragment"
                 android:icon="@drawable/ic_genres"
-                android:title="Genres" />
+                android:title="@string/library_title_genre" />
 
             <item
                 android:id="@+id/playlistCatalogueFragment"
                 android:icon="@drawable/ic_playlist"
-                android:title="Playlists"
+                android:title="@string/library_title_playlist"
                 android:defaultValue="ALL"/>
 
         </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -615,4 +615,7 @@
     <string name="search_all_songs_loading">Getting all songs ...</string>
     <string name="search_all_songs">all %1$s songs</string>
     <string name="search_all_songs_play">Play %1$s</string>
+
+    <string name="nav_drawer_index">Index</string>
+
 </resources>


### PR DESCRIPTION
Makes the navigation drawer translatable by using existing strings (so no need to translate them since they are already translated!).

I only added one new string for "Index" (`nav_drawer_index`) since I couldn't find one.

My other PR (#553) contains that new string translated for the new language :)