### PR TITLE
Document LMS API key in USAGE.md

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -52,7 +52,7 @@ This app works with any service that implements the Subsonic API, including:
 ### Initial Setup
 **IN PROGRESS**
 1. Enter your server URL (e.g., `https://your-subsonic-server.com`)
-2. Provide your username and password
+2. Provide your username and password. Or in some cases, API key (eg LMS: https://github.com/epoupon/lms/discussions/562).
 3. Test the connection to ensure proper configuration
 
 ### Advanced Settings


### PR DESCRIPTION
LMS requires an API key, and that could be confusing for users (it was for me! https://github.com/eddyizm/tempus/issues/585)

Link to a discussion on the LMS side, which includes screenshots.