### PR TITLE
feat: Set Replay Gain preamp offset

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -936,6 +936,10 @@ open class BaseMediaService : MediaLibraryService() {
         fun getEqualizerManager(): EqualizerManager {
             return equalizerManager
         }
+
+        fun getPlayer(): ExoPlayer {
+            return exoplayer
+        }
     }
 }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsContainerFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsContainerFragment.java
@@ -35,6 +35,7 @@ import androidx.preference.Preference;
 import androidx.preference.PreferenceCategory;
 import androidx.preference.PreferenceFragmentCompat;
 import androidx.preference.PreferenceScreen;
+import androidx.preference.SeekBarPreference;
 import androidx.preference.SwitchPreference;
 
 import com.cappielloantonio.tempo.BuildConfig;
@@ -158,6 +159,7 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
 
         bindMediaService();
         actionAppEqualizer();
+        actionReplayGainPreamp();
 
         applyAccordionState();
     }
@@ -641,6 +643,31 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
                 appEqualizer.setVisible(numBands > 0);
             }
         }
+    }
+
+    private void actionReplayGainPreamp() {
+        SeekBarPreference preampPref = findPreference("replay_gain_preamp");
+        if (preampPref == null) return;
+
+        // Seed the widget with the currently persisted value so it shows the
+        // correct position when the settings screen opens.
+        preampPref.setValue((int) Preferences.getReplayGainPreamp());
+
+        preampPref.setOnPreferenceChangeListener((preference, newValue) -> {
+            if (!(newValue instanceof Integer)) return true;
+
+            int dB = (Integer) newValue;
+            Preferences.setReplayGainPreamp((float) dB);
+
+            // Immediately re-apply gain to whatever is playing so the user can
+            // hear the effect without restarting playback.
+            if (isServiceBound && mediaServiceBinder != null) {
+                com.cappielloantonio.tempo.util.ReplayGainUtil.reapplyCurrentTrackGain(
+                        mediaServiceBinder.getPlayer());
+            }
+
+            return true;
+        });
     }
 
     private void actionAppEqualizer() {

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -523,12 +523,12 @@ object Preferences {
 
     @JvmStatic
     fun getReplayGainPreamp(): Float {
-        return App.getInstance().preferences.getFloat(REPLAY_GAIN_PREAMP, -6f)
+        return App.getInstance().preferences.getInt(REPLAY_GAIN_PREAMP, -6).toFloat()
     }
 
     @JvmStatic
     fun setReplayGainPreamp(value: Float) {
-        App.getInstance().preferences.edit().putFloat(REPLAY_GAIN_PREAMP, value).apply()
+        App.getInstance().preferences.edit().putInt(REPLAY_GAIN_PREAMP, value.toInt()).apply()
     }	
 
     @JvmStatic

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -474,7 +474,7 @@
     <string name="settings_replay_gain_prevent_clipping_title">Prevent clipping</string>
     <string name="settings_replay_gain_prevent_clipping_summary">Reduce gain when the track or album peak tag indicates the signal would clip after applying ReplayGain.</string>
     <string name="settings_replay_gain_preamp_title">Pre-amplification</string>
-    <string name="settings_replay_gain_preamp_summary">Adjust the target loudness offset applied on top of the ReplayGain value. 0 dB targets the reference level encoded in the tags (typically −18 LUFS). Positive values make playback louder; negative values make it quieter.</string>
+    <string name="settings_replay_gain_preamp_summary">Adjust the target loudness offset applied on top of the ReplayGain value. Positive values make playback louder; negative values make it quieter. (Default = -6)</string>
     <string name="settings_replay_gain_preamp_db">%1$d dB</string>
     <string name="settings_title_scrobble">Scrobble</string>
     <string name="settings_title_skip_min_star_rating">Ignore tracks based on rating</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -473,6 +473,9 @@
     <string name="settings_title_replay_gain">Replay Gain</string>
     <string name="settings_replay_gain_prevent_clipping_title">Prevent clipping</string>
     <string name="settings_replay_gain_prevent_clipping_summary">Reduce gain when the track or album peak tag indicates the signal would clip after applying ReplayGain.</string>
+    <string name="settings_replay_gain_preamp_title">Pre-amplification</string>
+    <string name="settings_replay_gain_preamp_summary">Adjust the target loudness offset applied on top of the ReplayGain value. 0 dB targets the reference level encoded in the tags (typically −18 LUFS). Positive values make playback louder; negative values make it quieter.</string>
+    <string name="settings_replay_gain_preamp_db">%1$d dB</string>
     <string name="settings_title_scrobble">Scrobble</string>
     <string name="settings_title_skip_min_star_rating">Ignore tracks based on rating</string>
     <string name="settings_title_skip_min_star_rating_dialog">Songs with a rating of:</string>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -166,6 +166,16 @@
                 app:title="@string/settings_replay_gain"
                 app:useSimpleSummaryProvider="true" />
 
+            <SeekBarPreference
+                android:defaultValue="-6"
+                android:key="replay_gain_preamp"
+                android:title="@string/settings_replay_gain_preamp_title"
+                android:summary="@string/settings_replay_gain_preamp_summary"
+                android:max="15"
+                app:min="-15"
+                app:showSeekBarValue="true"
+                app:adjustable="true" />
+
             <SwitchPreference
                 android:defaultValue="true"
                 android:key="replay_gain_prevent_clipping"


### PR DESCRIPTION
Added a slider inside the existing Replay Gain Preference Category, placed above the "Prevent clipping" switch:

Range: −15 to +15 dB (covers all practical use cases)
Default: −6 (matches the existing hardcoded default)

The current dB value is always visible next to the slider

Addresses #241 