### PR TITLE
fix: stop periodic update of queue on Android Auto

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -512,6 +512,7 @@ open class BaseMediaService : MediaLibraryService() {
         mediaLibrarySession =
             MediaLibrarySession.Builder(this, player, getMediaLibrarySessionCallback())
                 .setSessionActivity(sessionActivityPendingIntent)
+                .setPeriodicPositionUpdateEnabled(false)
                 .build()
     }
 


### PR DESCRIPTION
This PR solves issue https://github.com/eddyizm/tempus/issues/615
Adding .setPeriodicPositionUpdateEnabled(false) stop the periodic update of queue on Android Auto : https://github.com/androidx/media/issues/2192

However, it does not seem possible to center the queue on the current track.