### PR TITLE
feat: improve sound settings

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsContainerFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsContainerFragment.java
@@ -651,13 +651,13 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
 
         // Seed the widget with the currently persisted value so it shows the
         // correct position when the settings screen opens.
-        preampPref.setValue((int) Preferences.getReplayGainPreamp());
+        preampPref.setValue((int) Preferences.getLoudnessPreamp());
 
         preampPref.setOnPreferenceChangeListener((preference, newValue) -> {
             if (!(newValue instanceof Integer)) return true;
 
             int dB = (Integer) newValue;
-            Preferences.setReplayGainPreamp((float) dB);
+            Preferences.setLoudnessPreamp((float) dB);
 
             // Immediately re-apply gain to whatever is playing so the user can
             // hear the effect without restarting playback.

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -55,8 +55,8 @@ object Preferences {
     private const val AUTO_DOWNLOAD_LYRICS = "auto_download_lyrics"
     private const val MUSIC_DIRECTORY_SECTION_VISIBILITY = "music_directory_section_visibility"
     private const val REPLAY_GAIN_MODE = "replay_gain_mode"
-	private const val REPLAY_GAIN_PREAMP = "replay_gain_preamp"
     private const val REPLAY_GAIN_PREVENT_CLIPPING = "replay_gain_prevent_clipping"
+    private const val LOUDNESS_PREAMP = "loudness_preamp"
     private const val AUDIO_TRANSCODE_PRIORITY = "audio_transcode_priority"
     private const val STREAMING_CACHE_STORAGE = "streaming_cache_storage"
     private const val DOWNLOAD_STORAGE = "download_storage"
@@ -523,20 +523,20 @@ object Preferences {
     }
 
     @JvmStatic
-    fun getReplayGainPreamp(): Float {
-        return App.getInstance().preferences.getInt(REPLAY_GAIN_PREAMP, -6).toFloat()
-    }
-
-    @JvmStatic
-    fun setReplayGainPreamp(value: Float) {
-        App.getInstance().preferences.edit().putInt(REPLAY_GAIN_PREAMP, value.toInt()).apply()
-    }	
-
-    @JvmStatic
     fun isReplayGainPreventClipping(): Boolean {
         return App.getInstance().preferences.getBoolean(REPLAY_GAIN_PREVENT_CLIPPING, true)
     }
-	
+
+    @JvmStatic
+    fun getLoudnessPreamp(): Float {
+        return App.getInstance().preferences.getInt(LOUDNESS_PREAMP, 0).toFloat()
+    }
+
+    @JvmStatic
+    fun setLoudnessPreamp(value: Float) {
+        App.getInstance().preferences.edit().putInt(LOUDNESS_PREAMP, value.toInt()).apply()
+    }
+
     @JvmStatic
     fun isServerPrioritized(): Boolean {
         return App.getInstance().preferences.getBoolean(AUDIO_TRANSCODE_PRIORITY, false)

--- a/app/src/main/java/com/cappielloantonio/tempo/util/ReplayGainUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/ReplayGainUtil.java
@@ -605,7 +605,7 @@ public class ReplayGainUtil {
     // Total gain computation (preamp + clipping prevention)
 
     private static float computeTotalGain(float gain, float peak) {
-        float preamp    = Preferences.getReplayGainPreamp();
+        float preamp    = Preferences.getLoudnessPreamp();
         float totalGain = gain + preamp;
 
         if (Preferences.isReplayGainPreventClipping() && peak > 0f) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -451,7 +451,8 @@
     <string name="settings_streaming_cache_storage_title">Streaming cache storage</string>
     <string name="settings_sub_summary_scrobble">It\'s important to note that scrobbling also relies on the server being enabled to receive this data.</string>
     <string name="settings_summary_skip_min_star_rating">When listening to an artist\'s radio, an instant mix or when shuffling all, tracks below a certain user rating will be ignored.</string>
-    <string name="settings_summary_replay_gain">Replay gain is a feature that allows you to adjust the volume level of audio tracks for a consistent listening experience. This setting is only effective if the track contains the necessary metadata.</string>
+    <string name="settings_summary_replay_gain">Normalizes the volume level of audio tracks. Files must contain the necessary metadata.</string>
+    <string name="settings_summary_loudness">Allows to correct the volume of audio playback devices (e.g. speakers).</string>
     <string name="settings_summary_scrobble">Scrobbling is a feature that allows your device to send information about the songs you listen to the music server. This information helps create personalized recommendations based on your music preferences.</string>
     <string name="settings_summary_share">Allows the user to share music via a link. The functionality must be supported and enabled server-side and is limited to individual tracks, albums and playlists.</string>
     <string name="settings_summary_syncing">Returns the state of the play queue for this user. This includes the tracks in the play queue, the currently playing track, and the position within this track. The server must support this feature.\n*This setting is not 100% working on all servers/devices.</string>
@@ -474,12 +475,13 @@
     <string name="settings_title_players">Players</string>
     <string name="settings_title_playlist">Playlist</string>
     <string name="settings_title_rating">Rating</string>
+    <string name="settings_title_loudness">Loudness correction</string>
+    <string name="settings_loudness_preamp_title">Pre-amplification</string>
+    <string name="settings_loudness_preamp_summary">Set positive values for louder sounds.\nSet negative values for quieter sounds.</string>
+    <string name="settings_loudness_preamp_db">%1$d dB</string>
     <string name="settings_title_replay_gain">Replay Gain</string>
     <string name="settings_replay_gain_prevent_clipping_title">Prevent clipping</string>
     <string name="settings_replay_gain_prevent_clipping_summary">Reduce gain when the track or album peak tag indicates the signal would clip after applying ReplayGain.</string>
-    <string name="settings_replay_gain_preamp_title">Pre-amplification</string>
-    <string name="settings_replay_gain_preamp_summary">Adjust the target loudness offset applied on top of the ReplayGain value. Positive values make playback louder; negative values make it quieter. (Default = -6)</string>
-    <string name="settings_replay_gain_preamp_db">%1$d dB</string>
     <string name="settings_title_scrobble">Scrobble</string>
     <string name="settings_title_skip_min_star_rating">Ignore tracks based on rating</string>
     <string name="settings_title_skip_min_star_rating_dialog">Songs with a rating of:</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -452,7 +452,7 @@
     <string name="settings_sub_summary_scrobble">It\'s important to note that scrobbling also relies on the server being enabled to receive this data.</string>
     <string name="settings_summary_skip_min_star_rating">When listening to an artist\'s radio, an instant mix or when shuffling all, tracks below a certain user rating will be ignored.</string>
     <string name="settings_summary_replay_gain">Normalizes the volume level of audio tracks. Files must contain the necessary metadata.</string>
-    <string name="settings_summary_loudness">Allows to correct the volume of audio playback devices (e.g. speakers).</string>
+    <string name="settings_summary_loudness">Allows to correct the volume of audio playback devices (e.g. speakers).\n\nFor ReplayGain -6 is recommended, this is to avoid conflicts with clipping prevention.</string>
     <string name="settings_summary_scrobble">Scrobbling is a feature that allows your device to send information about the songs you listen to the music server. This information helps create personalized recommendations based on your music preferences.</string>
     <string name="settings_summary_share">Allows the user to share music via a link. The functionality must be supported and enabled server-side and is limited to individual tracks, albums and playlists.</string>
     <string name="settings_summary_syncing">Returns the state of the play queue for this user. This includes the tracks in the play queue, the currently playing track, and the position within this track. The server must support this feature.\n*This setting is not 100% working on all servers/devices.</string>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -166,21 +166,30 @@
                 app:title="@string/settings_replay_gain"
                 app:useSimpleSummaryProvider="true" />
 
-            <SeekBarPreference
-                android:defaultValue="-6"
-                android:key="replay_gain_preamp"
-                android:title="@string/settings_replay_gain_preamp_title"
-                android:summary="@string/settings_replay_gain_preamp_summary"
-                android:max="15"
-                app:min="-15"
-                app:showSeekBarValue="true"
-                app:adjustable="true" />
-
             <SwitchPreference
                 android:defaultValue="true"
                 android:key="replay_gain_prevent_clipping"
                 android:title="@string/settings_replay_gain_prevent_clipping_title"
                 android:summary="@string/settings_replay_gain_prevent_clipping_summary" />
+
+        </PreferenceCategory>
+
+        <PreferenceCategory app:title="@string/settings_title_loudness">
+            <Preference
+                app:selectable="false"
+                app:summary="@string/settings_summary_loudness" />
+
+            <SeekBarPreference
+                android:defaultValue="0"
+                android:key="loudness_preamp"
+                android:title="@string/settings_loudness_preamp_title"
+                android:summary="@string/settings_loudness_preamp_summary"
+                android:max="15"
+                app:min="-15"
+                app:showSeekBarValue="true"
+                app:adjustable="true" />
+
+
         </PreferenceCategory>
     </com.cappielloantonio.tempo.util.ClickablePreferenceCategory>
 


### PR DESCRIPTION
This PR re-organizes elements and gives more succinct descriptions to ReplayGain and the Loudness Offset.

<details>
<summary>New sound settings distribution</summary>
<img width="320" src="https://github.com/user-attachments/assets/7f872c54-a9f7-421e-bc48-4a6ea978a91e" />


</details>

_ReplayGain_ is a known term, easily searchable and understood by those that have it as metadata.

_Loudness Offset_ on the other hand is more technical, so I chose the word "correction". If your car speaker is too loud or your earphones are too quiet, you would want to "correct" their hardware volume, hence the choice of words.

Method names, constants, getters/setters and string vars have been updated to use the term _loudness_ instead of ReplayGain since those feats are independent from one another.

Default loudness offset set to 0.

---

Supersedes #618
Addresses #613