### PR TITLE
Issue600 - Slow loading of long playlists

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
@@ -217,8 +217,8 @@ public class MediaManager {
                                     @Override
                                     public void onIsPlayingChanged(boolean isPlaying) {
                                         if (isPlaying) {
-                                            enqueue(mediaBrowserListenableFuture, itemsToQueue.subList(initialBatchSize, itemsToQueue.size()), false);
                                             browser.removeListener(this);
+                                            enqueue(mediaBrowserListenableFuture, itemsToQueue.subList(initialBatchSize, itemsToQueue.size()), false);
                                         }
                                     }
                                 });

--- a/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
@@ -222,7 +222,7 @@ public class MediaManager {
                                     @Override
                                     public void onIsPlayingChanged(boolean isPlaying) {
                                         if (isPlaying) {
-                                            enqueue(mediaBrowserListenableFuture, itemsToQueue.subList(10, itemsToQueue.size()), false);
+                                            enqueue(mediaBrowserListenableFuture, itemsToQueue.subList(initialBatchSize, itemsToQueue.size()), false);
                                             browser.removeListener(this);
                                         }
                                     }
@@ -319,7 +319,7 @@ public class MediaManager {
     public static void enqueue(ListenableFuture<MediaBrowser> mediaBrowserListenableFuture, List<Child> media, boolean playImmediatelyAfter) {
         if (mediaBrowserListenableFuture != null) {
             mediaBrowserListenableFuture.addListener(() -> {
-                Executors.newSingleThreadExecutor().execute(() -> {
+                backgroundExecutor.execute(() -> {
                     // Map the media off the main thread
                     final List<MediaItem> mediaItems = MappingUtil.mapMediaItems(media);
                     // Return to main thread to update the media
@@ -332,9 +332,9 @@ public class MediaManager {
                                     enqueueDatabase(media, false, browser.getNextMediaItemIndex());
                                     browser.addMediaItems(browser.getNextMediaItemIndex(), mediaItems);
                                 } else {
-                                    enqueueDatabase(media, false, mediaBrowserListenableFuture.get().getMediaItemCount());
+                                    enqueueDatabase(media, false, browser.getMediaItemCount());
 
-                                    mediaBrowserListenableFuture.get().addMediaItems(mediaItems);
+                                    browser.addMediaItems(mediaItems);
                                 }
                             }
                         } catch (ExecutionException | InterruptedException e) {

--- a/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
@@ -43,11 +43,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
-// MS TEST IMPORTS
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Collections;
-
 public class MediaManager {
     private static final String TAG = "MediaManager";
     private static WeakReference<MediaBrowser> attachedBrowserRef = new WeakReference<>(null);

--- a/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
@@ -190,63 +190,63 @@ public class MediaManager {
 
     @OptIn(markerClass = UnstableApi.class)
     public static void startQueue(ListenableFuture<MediaBrowser> mediaBrowserListenableFuture, List<Child> media, int startIndex) {
-        Log.d(TAG, "media size=" + media.size() + ", startIndex=" + startIndex);
-        if (startIndex < 0 || startIndex >= media.size()) {
-            Log.e(TAG, "requested startIndex out of range: " + startIndex);
+        if (media == null || startIndex < 0 || startIndex >= media.size()) {
+            Log.e(TAG, "Invalid parameters passed to startQueue");
             return;
         }
-        if (mediaBrowserListenableFuture != null) {
-            mediaBrowserListenableFuture.addListener(() -> {
-                try {
-                    if (mediaBrowserListenableFuture.isDone()) {
-                        final MediaBrowser browser = mediaBrowserListenableFuture.get();
-                        // queing from startIndex is how spotify works and avoids loading excess data before playback
-                        final List<Child> itemsToQueue = media.subList(startIndex, media.size());
-                        // Instead of queing all media, only queue the first 10 tracks
-                        // after the users requested startIndex
-                        final List<Child> initialItems;
-                        if (itemsToQueue.size() > 10) {
-                            initialItems = itemsToQueue.subList(0, 10);
-                        } else {
-                            initialItems = itemsToQueue;
-                        }
-                        // map
-                        final List<MediaItem> initialMedia = MappingUtil.mapMediaItems(initialItems);
+        if (mediaBrowserListenableFuture == null) return;
 
-                        new Handler(Looper.getMainLooper()).post(() -> {
-                            justStarted.set(true);
-                            browser.setMediaItems(initialMedia, 0, 0);
-                            browser.prepare();
+        mediaBrowserListenableFuture.addListener(() -> {
+            try {
+                if (mediaBrowserListenableFuture.isDone()) {
+                    final MediaBrowser browser = mediaBrowserListenableFuture.get();
+                    // Queing from startIndex is how spotify works and avoids loading excess data before playback
+                    final List<Child> itemsToQueue = media.subList(startIndex, media.size());
+                    // Instead of queing all media, only queue a maximum of next 10 tracks initially
+                    int initialBatchSize = Math.min(itemsToQueue.size(), 10);
+                    final List<Child> initialItems = itemsToQueue.subList(0, initialBatchSize);
+                    final List<MediaItem> initialMedia = MappingUtil.mapMediaItems(initialItems);
 
-                            Player.Listener timelineListener = new Player.Listener() {
-                                @Override
-                                public void onTimelineChanged(Timeline timeline, int reason) {
-                                    
-                                    int itemCount = browser.getMediaItemCount();
-                                    if (itemCount > 0) {
-                                        browser.seekTo(0, 0);
-                                        browser.play();
-                                        browser.removeListener(this);
-                                        enqueueDatabase(initialItems, true, 0);
-                                        // If more than 10 songs were queued
-                                        // add all the other media to the queue if the first song plays successfully
-                                        if (itemsToQueue.size() > 10) {
-                                            enqueue(mediaBrowserListenableFuture, itemsToQueue.subList(10, itemsToQueue.size()), false);
-                                        }
-                                    } else {
-                                        Log.d(TAG, "Cannot start playback: itemCount=" + itemCount + ", startIndex=" + startIndex);
-                                    }
-                                }
-                            };
-                            
-                            browser.addListener(timelineListener);
+                    new Handler(Looper.getMainLooper()).post(() -> {
+                        justStarted.set(true);
+                        browser.setMediaItems(initialMedia, 0, 0);
+                        browser.prepare();
+
+                        // Populate the remaining queue after playing starts
+                        browser.addListener(new Player.Listener() {
+                            @Override
+                            public void onIsPlayingChanged(boolean isPlaying) {
+                                enqueue(mediaBrowserListenableFuture, itemsToQueue.subList(10, itemsToQueue.size()), false);
+                                browser.removeListener(this);
+                            }
                         });
-                    }
-                } catch (ExecutionException | InterruptedException e) {
-                    Log.e(TAG, "Error in startQueue: " + e.getMessage(), e);
+
+                        int itemCount = browser.getMediaItemCount();
+                        if (itemCount > 0) {
+                            // If more than 10 songs were queued
+                            // add all the other media to the queue once the first song plays successfully
+                            if (itemsToQueue.size() > 10) {
+                                // Populate the remaining queue after playing starts
+                                browser.addListener(new Player.Listener() {
+                                    @Override
+                                    public void onIsPlayingChanged(boolean isPlaying) {
+                                        enqueue(mediaBrowserListenableFuture, itemsToQueue.subList(10, itemsToQueue.size()), false);
+                                        browser.removeListener(this);
+                                    }
+                                });
+                            }
+                            browser.seekTo(0, 0);
+                            browser.play();
+                            enqueueDatabase(initialItems, true, 0);
+                        } else {
+                            Log.d(TAG, "Cannot start playback: itemCount=" + itemCount + ", startIndex=" + startIndex);
+                        }
+                    });
                 }
-            }, MoreExecutors.directExecutor());
-        }
+            } catch (ExecutionException | InterruptedException e) {
+                Log.e(TAG, "Error in startQueue: " + e.getMessage(), e);
+            }
+        }, MoreExecutors.directExecutor());
     }
 
     public static void startQueue(ListenableFuture<MediaBrowser> mediaBrowserListenableFuture, Child media) {
@@ -326,21 +326,29 @@ public class MediaManager {
     public static void enqueue(ListenableFuture<MediaBrowser> mediaBrowserListenableFuture, List<Child> media, boolean playImmediatelyAfter) {
         if (mediaBrowserListenableFuture != null) {
             mediaBrowserListenableFuture.addListener(() -> {
-                try {
-                    if (mediaBrowserListenableFuture.isDone()) {
-                        Log.d(TAG, "enqueue");
-                        MediaBrowser browser = mediaBrowserListenableFuture.get();
-                        if (playImmediatelyAfter && browser.getNextMediaItemIndex() != -1) {
-                            enqueueDatabase(media, false, browser.getNextMediaItemIndex());
-                            browser.addMediaItems(browser.getNextMediaItemIndex(), MappingUtil.mapMediaItems(media));
-                        } else {
-                            enqueueDatabase(media, false, mediaBrowserListenableFuture.get().getMediaItemCount());
-                            mediaBrowserListenableFuture.get().addMediaItems(MappingUtil.mapMediaItems(media));
+                Executors.newSingleThreadExecutor().execute(() -> {
+                    // Map the media off the main thread
+                    final List<MediaItem> mediaItems = MappingUtil.mapMediaItems(media);
+                    // Return to main thread to update the media
+                    new Handler(Looper.getMainLooper()).post(() -> {
+                        try {
+                            if (mediaBrowserListenableFuture.isDone()) {
+                                Log.d(TAG, "enqueue");
+                                MediaBrowser browser = mediaBrowserListenableFuture.get();
+                                if (playImmediatelyAfter && browser.getNextMediaItemIndex() != -1) {
+                                    enqueueDatabase(media, false, browser.getNextMediaItemIndex());
+                                    browser.addMediaItems(browser.getNextMediaItemIndex(), mediaItems);
+                                } else {
+                                    enqueueDatabase(media, false, mediaBrowserListenableFuture.get().getMediaItemCount());
+
+                                    mediaBrowserListenableFuture.get().addMediaItems(mediaItems);
+                                }
+                            }
+                        } catch (ExecutionException | InterruptedException e) {
+                            e.printStackTrace();
                         }
-                    }
-                } catch (ExecutionException | InterruptedException e) {
-                    e.printStackTrace();
-                }
+                    });
+                });
             }, MoreExecutors.directExecutor());
         }
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
@@ -43,6 +43,11 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 
+// MS TEST IMPORTS
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
+
 public class MediaManager {
     private static final String TAG = "MediaManager";
     private static WeakReference<MediaBrowser> attachedBrowserRef = new WeakReference<>(null);
@@ -185,17 +190,32 @@ public class MediaManager {
 
     @OptIn(markerClass = UnstableApi.class)
     public static void startQueue(ListenableFuture<MediaBrowser> mediaBrowserListenableFuture, List<Child> media, int startIndex) {
+        Log.d(TAG, "media size=" + media.size() + ", startIndex=" + startIndex);
+        if (startIndex < 0 || startIndex >= media.size()) {
+            Log.e(TAG, "requested startIndex out of range: " + startIndex);
+            return;
+        }
         if (mediaBrowserListenableFuture != null) {
-
             mediaBrowserListenableFuture.addListener(() -> {
                 try {
                     if (mediaBrowserListenableFuture.isDone()) {
                         final MediaBrowser browser = mediaBrowserListenableFuture.get();
-                        final List<MediaItem> items = MappingUtil.mapMediaItems(media);
-                        
+                        // queing from startIndex is how spotify works and avoids loading excess data before playback
+                        final List<Child> itemsToQueue = media.subList(startIndex, media.size());
+                        // Instead of queing all media, only queue the first 10 tracks
+                        // after the users requested startIndex
+                        final List<Child> initialItems;
+                        if (itemsToQueue.size() > 10) {
+                            initialItems = itemsToQueue.subList(0, 10);
+                        } else {
+                            initialItems = itemsToQueue;
+                        }
+                        // map
+                        final List<MediaItem> initialMedia = MappingUtil.mapMediaItems(initialItems);
+
                         new Handler(Looper.getMainLooper()).post(() -> {
                             justStarted.set(true);
-                            browser.setMediaItems(items, startIndex, 0);
+                            browser.setMediaItems(initialMedia, 0, 0);
                             browser.prepare();
 
                             Player.Listener timelineListener = new Player.Listener() {
@@ -203,10 +223,16 @@ public class MediaManager {
                                 public void onTimelineChanged(Timeline timeline, int reason) {
                                     
                                     int itemCount = browser.getMediaItemCount();
-                                    if (itemCount > 0 && startIndex >= 0 && startIndex < itemCount) {
-                                        browser.seekTo(startIndex, 0);
+                                    if (itemCount > 0) {
+                                        browser.seekTo(0, 0);
                                         browser.play();
                                         browser.removeListener(this);
+                                        enqueueDatabase(initialItems, true, 0);
+                                        // If more than 10 songs were queued
+                                        // add all the other media to the queue if the first song plays successfully
+                                        if (itemsToQueue.size() > 10) {
+                                            enqueue(mediaBrowserListenableFuture, itemsToQueue.subList(10, itemsToQueue.size()), false);
+                                        }
                                     } else {
                                         Log.d(TAG, "Cannot start playback: itemCount=" + itemCount + ", startIndex=" + startIndex);
                                     }
@@ -214,11 +240,6 @@ public class MediaManager {
                             };
                             
                             browser.addListener(timelineListener);
-                        });
-
-                        backgroundExecutor.execute(() -> {
-                            Log.d(TAG, "Background: enqueuing to database");
-                            enqueueDatabase(media, true, 0);
                         });
                     }
                 } catch (ExecutionException | InterruptedException e) {

--- a/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
@@ -212,15 +212,6 @@ public class MediaManager {
                         browser.setMediaItems(initialMedia, 0, 0);
                         browser.prepare();
 
-                        // Populate the remaining queue after playing starts
-                        browser.addListener(new Player.Listener() {
-                            @Override
-                            public void onIsPlayingChanged(boolean isPlaying) {
-                                enqueue(mediaBrowserListenableFuture, itemsToQueue.subList(10, itemsToQueue.size()), false);
-                                browser.removeListener(this);
-                            }
-                        });
-
                         int itemCount = browser.getMediaItemCount();
                         if (itemCount > 0) {
                             // If more than 10 songs were queued
@@ -230,8 +221,10 @@ public class MediaManager {
                                 browser.addListener(new Player.Listener() {
                                     @Override
                                     public void onIsPlayingChanged(boolean isPlaying) {
-                                        enqueue(mediaBrowserListenableFuture, itemsToQueue.subList(10, itemsToQueue.size()), false);
-                                        browser.removeListener(this);
+                                        if (isPlaying) {
+                                            enqueue(mediaBrowserListenableFuture, itemsToQueue.subList(10, itemsToQueue.size()), false);
+                                            browser.removeListener(this);
+                                        }
                                     }
                                 });
                             }


### PR DESCRIPTION
This commit is the minimal changes I could make to start playing sooner when loading from a playlist by queuing a maximum of 10, then loading all the other media files separately, once something is playing. This mainly meant rewriting the `startQueue` function.

There was slight modification to `enqueue` also so that it collects the media metadata off the main thread and doesn't block the UI.

I left in the comments so you can see my reasoning but happy to remove if you prefer.

This reduced the start time for my 500 song playlist from 7 seconds to less than 1 second.

The only functional change is that previously playlists were loaded entirely into the player so you could skip back by up to 15 tracks if you started from any position other than the start of the playlist, but this causes delays for no reason, now the queue is from the selected song onward. This is how Spotify works as well when starting a playlist not from the first song.

closes #600 
