### PR TITLE
Refactor: Custom Commands for degoogled and Tempus flavors

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -1,6 +1,5 @@
 package com.cappielloantonio.tempo.service
 
-import android.annotation.SuppressLint
 import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.app.PendingIntent.FLAG_UPDATE_CURRENT
 import android.app.TaskStackBuilder
@@ -30,14 +29,10 @@ import androidx.media3.session.MediaSession.ControllerInfo
 import androidx.media3.extractor.metadata.icy.IcyInfo
 import androidx.media3.extractor.metadata.id3.TextInformationFrame
 import androidx.media3.extractor.metadata.vorbis.VorbisComment
-import com.cappielloantonio.tempo.R
 import com.cappielloantonio.tempo.repository.QueueRepository
 import com.cappielloantonio.tempo.ui.activity.MainActivity
 import com.cappielloantonio.tempo.util.*
 import com.cappielloantonio.tempo.widget.WidgetUpdateManager
-import com.google.common.collect.ImmutableList
-import com.google.common.util.concurrent.Futures
-import com.google.common.util.concurrent.ListenableFuture
 import java.net.HttpURLConnection
 import java.net.URL
 import java.util.concurrent.Executors
@@ -50,16 +45,6 @@ private const val TAG = "BaseMediaService"
 @UnstableApi
 open class BaseMediaService : MediaLibraryService() {
     companion object {
-        private const val CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_ON =
-            "android.media3.session.demo.SHUFFLE_ON"
-        private const val CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_OFF =
-            "android.media3.session.demo.SHUFFLE_OFF"
-        private const val CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_OFF =
-            "android.media3.session.demo.REPEAT_OFF"
-        private const val CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ONE =
-            "android.media3.session.demo.REPEAT_ONE"
-        private const val CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ALL =
-            "android.media3.session.demo.REPEAT_ALL"
         const val ACTION_BIND_EQUALIZER = "com.cappielloantonio.tempo.service.BIND_EQUALIZER"
         const val ACTION_EQUALIZER_UPDATED = "com.cappielloantonio.tempo.service.EQUALIZER_UPDATED"
     }
@@ -99,7 +84,7 @@ open class BaseMediaService : MediaLibraryService() {
     }
 
     open fun getMediaLibrarySessionCallback(): MediaLibrarySession.Callback {
-        return CustomMediaLibrarySessionCallback(baseContext)
+        return BaseSessionCallback(baseContext)
     }
 
     fun updateMediaItems(player: Player) {
@@ -770,143 +755,6 @@ open class BaseMediaService : MediaLibraryService() {
     }
 
     private fun getMediaSourceFactory(): MediaSource.Factory = DynamicMediaSourceFactory(this)
-
-    @UnstableApi
-    private class CustomMediaLibrarySessionCallback : MediaLibrarySession.Callback {
-        private val shuffleCommands: List<CommandButton>
-        private val repeatCommands: List<CommandButton>
-
-        constructor(ctx: Context) {
-            shuffleCommands = listOf(
-                CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_ON,
-                CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_OFF
-            )
-                .map { getShuffleCommandButton(SessionCommand(it, Bundle.EMPTY), ctx) }
-            repeatCommands = listOf(
-                CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_OFF,
-                CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ONE,
-                CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ALL
-            )
-                .map { getRepeatCommandButton(SessionCommand(it, Bundle.EMPTY), ctx) }
-        }
-
-        override fun onConnect(
-            session: MediaSession,
-            controller: ControllerInfo
-        ): MediaSession.ConnectionResult {
-            val connectionResult = super.onConnect(session, controller)
-            val availableSessionCommands = connectionResult.availableSessionCommands.buildUpon()
-
-            (shuffleCommands + repeatCommands).forEach { commandButton ->
-                commandButton.sessionCommand?.let { availableSessionCommands.add(it) }
-            }
-
-            val result = MediaSession.ConnectionResult.AcceptedResultBuilder(session)
-                .setAvailableSessionCommands(availableSessionCommands.build())
-                .setAvailablePlayerCommands(connectionResult.availablePlayerCommands)
-                .setMediaButtonPreferences(buildCustomLayout(session.player))
-                .build()
-            return result
-        }
-
-        override fun onCustomCommand(
-            session: MediaSession,
-            controller: ControllerInfo,
-            customCommand: SessionCommand,
-            args: Bundle
-        ): ListenableFuture<SessionResult> {
-            Log.d(TAG, "onCustomCommand")
-            when (customCommand.customAction) {
-                CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_ON -> session.player.shuffleModeEnabled = true
-                CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_OFF -> session.player.shuffleModeEnabled = false
-                CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_OFF,
-                CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ALL,
-                CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ONE -> {
-                    val nextMode = when (session.player.repeatMode) {
-                        Player.REPEAT_MODE_ONE -> Player.REPEAT_MODE_ALL
-                        Player.REPEAT_MODE_OFF -> Player.REPEAT_MODE_ONE
-                        else -> Player.REPEAT_MODE_OFF
-                    }
-                    session.player.repeatMode = nextMode
-                }
-            }
-
-            session.setMediaButtonPreferences(buildCustomLayout(session.player))
-            return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
-        }
-
-        override fun onAddMediaItems(
-            mediaSession: MediaSession,
-            controller: ControllerInfo,
-            mediaItems: List<MediaItem>
-        ): ListenableFuture<List<MediaItem>> {
-            Log.d(TAG, "onAddMediaItems")
-            val updatedMediaItems = mediaItems.map { mediaItem ->
-                val mediaMetadata = mediaItem.mediaMetadata
-                val newMetadata = mediaMetadata.buildUpon()
-                    .setArtist(
-                        if (mediaMetadata.artist != null) mediaMetadata.artist
-                        else mediaMetadata.extras?.getString("uri") ?: ""
-                    )
-                    .build()
-
-                mediaItem.buildUpon()
-                    .setUri(mediaItem.requestMetadata.mediaUri)
-                    .setMediaMetadata(newMetadata)
-                    .setMimeType(MimeTypes.BASE_TYPE_AUDIO)
-                    .build()
-            }
-            return Futures.immediateFuture(updatedMediaItems)
-        }
-
-        @SuppressLint("PrivateResource")
-        private fun getShuffleCommandButton(
-            sessionCommand: SessionCommand,
-            ctx: Context
-        ): CommandButton {
-            val isOn = sessionCommand.customAction == CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_ON
-            return CommandButton.Builder(if (isOn) CommandButton.ICON_SHUFFLE_OFF else CommandButton.ICON_SHUFFLE_ON)
-                .setSessionCommand(sessionCommand)
-                .setDisplayName(
-                    ctx.getString(
-                        if (isOn) R.string.exo_controls_shuffle_on_description
-                        else R.string.exo_controls_shuffle_off_description
-                    )
-                )
-                .build()
-        }
-
-        @SuppressLint("PrivateResource")
-        private fun getRepeatCommandButton(
-            sessionCommand: SessionCommand,
-            ctx: Context
-        ): CommandButton {
-            val icon = when (sessionCommand.customAction) {
-                CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ONE -> CommandButton.ICON_REPEAT_ONE
-                CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ALL -> CommandButton.ICON_REPEAT_ALL
-                else -> CommandButton.ICON_REPEAT_OFF
-            }
-            val description = when (sessionCommand.customAction) {
-                CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ONE -> R.string.exo_controls_repeat_one_description
-                CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ALL -> R.string.exo_controls_repeat_all_description
-                else -> R.string.exo_controls_repeat_off_description
-            }
-            return CommandButton.Builder(icon)
-                .setSessionCommand(sessionCommand)
-                .setDisplayName(ctx.getString(description))
-                .build()
-        }
-
-        private fun buildCustomLayout(player: Player): ImmutableList<CommandButton> {
-            val shuffle = shuffleCommands[if (player.shuffleModeEnabled) 1 else 0]
-            val repeat = when (player.repeatMode) {
-                Player.REPEAT_MODE_ONE -> repeatCommands[1]
-                Player.REPEAT_MODE_ALL -> repeatCommands[2]
-                else -> repeatCommands[0]
-            }
-            return ImmutableList.of(shuffle, repeat)
-        }
-    }
 
     private inner class CustomNetworkCallback : ConnectivityManager.NetworkCallback() {
         var wasWifi = false

--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseSessionCallback.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseSessionCallback.kt
@@ -1,0 +1,357 @@
+package com.cappielloantonio.tempo.service
+
+import android.annotation.SuppressLint
+import android.content.Context
+import android.os.Bundle
+import android.util.Log
+import androidx.annotation.OptIn
+import androidx.media3.common.HeartRating
+import androidx.media3.common.MediaItem
+import androidx.media3.common.MediaMetadata
+import androidx.media3.common.MimeTypes
+import androidx.media3.common.Player
+import androidx.media3.common.Rating
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.session.CommandButton
+import androidx.media3.session.MediaLibraryService
+import androidx.media3.session.MediaSession
+import androidx.media3.session.SessionCommand
+import androidx.media3.session.SessionError
+import androidx.media3.session.SessionResult
+import com.cappielloantonio.tempo.App
+import com.cappielloantonio.tempo.R
+import com.cappielloantonio.tempo.subsonic.base.ApiResponse
+import com.cappielloantonio.tempo.util.Constants
+import com.cappielloantonio.tempo.util.Preferences
+import com.google.common.collect.ImmutableList
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.SettableFuture
+import retrofit2.Call
+import retrofit2.Callback
+import retrofit2.Response
+
+private const val TAG = "BaseSessionCallback"
+
+@UnstableApi
+open class BaseSessionCallback(protected val context: Context) :
+    MediaLibraryService.MediaLibrarySession.Callback {
+
+    // ─────────────────────────────────────────────────────────────
+    // CommandButtons
+    // ─────────────────────────────────────────────────────────────
+
+    @SuppressLint("PrivateResource")
+    private val customCommandToggleShuffleModeOn =
+        CommandButton.Builder(CommandButton.ICON_SHUFFLE_OFF)
+            .setDisplayName(context.getString(R.string.exo_controls_shuffle_on_description))
+            .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_ON, Bundle.EMPTY))
+            .build()
+
+    @SuppressLint("PrivateResource")
+    private val customCommandToggleShuffleModeOff =
+        CommandButton.Builder(CommandButton.ICON_SHUFFLE_ON)
+            .setDisplayName(context.getString(R.string.exo_controls_shuffle_off_description))
+            .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_OFF, Bundle.EMPTY))
+            .build()
+
+    @SuppressLint("PrivateResource")
+    private val customCommandToggleRepeatModeOff =
+        CommandButton.Builder(CommandButton.ICON_REPEAT_OFF)
+            .setDisplayName(context.getString(R.string.exo_controls_repeat_off_description))
+            .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_OFF, Bundle.EMPTY))
+            .build()
+
+    @SuppressLint("PrivateResource")
+    private val customCommandToggleRepeatModeOne =
+        CommandButton.Builder(CommandButton.ICON_REPEAT_ONE)
+            .setDisplayName(context.getString(R.string.exo_controls_repeat_one_description))
+            .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ONE, Bundle.EMPTY))
+            .build()
+
+    @SuppressLint("PrivateResource")
+    private val customCommandToggleRepeatModeAll =
+        CommandButton.Builder(CommandButton.ICON_REPEAT_ALL)
+            .setDisplayName(context.getString(R.string.exo_controls_repeat_all_description))
+            .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ALL, Bundle.EMPTY))
+            .build()
+
+    @Suppress("DEPRECATION")
+    private val customCommandToggleHeartOn =
+        CommandButton.Builder(CommandButton.ICON_UNDEFINED)
+            .setDisplayName(context.getString(R.string.exo_controls_heart_on_description))
+            .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_HEART_ON, Bundle.EMPTY))
+            .setIconResId(R.drawable.ic_favorite)
+            .build()
+
+    @Suppress("DEPRECATION")
+    private val customCommandToggleHeartOff =
+        CommandButton.Builder(CommandButton.ICON_UNDEFINED)
+            .setDisplayName(context.getString(R.string.exo_controls_heart_off_description))
+            .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_HEART_OFF, Bundle.EMPTY))
+            .setIconResId(R.drawable.ic_favorites_outlined)
+            .build()
+
+    @Suppress("DEPRECATION")
+    private val customCommandToggleHeartLoading =
+        CommandButton.Builder(CommandButton.ICON_UNDEFINED)
+            .setDisplayName(context.getString(R.string.cast_expanded_controller_loading))
+            .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_HEART_LOADING, Bundle.EMPTY))
+            .setIconResId(R.drawable.ic_bookmark_sync)
+            .build()
+
+    private val customLayoutCommandButtons = listOf(
+        customCommandToggleShuffleModeOn,
+        customCommandToggleShuffleModeOff,
+        customCommandToggleRepeatModeOff,
+        customCommandToggleRepeatModeOne,
+        customCommandToggleRepeatModeAll,
+        customCommandToggleHeartOn,
+        customCommandToggleHeartOff,
+        customCommandToggleHeartLoading,
+    )
+
+    @OptIn(UnstableApi::class)
+    val mediaNotificationSessionCommands =
+        MediaSession.ConnectionResult.DEFAULT_SESSION_AND_LIBRARY_COMMANDS.buildUpon()
+            .also { builder ->
+                customLayoutCommandButtons.forEach { commandButton ->
+                    commandButton.sessionCommand?.let { builder.add(it) }
+                }
+            }.build()
+
+    // ─────────────────────────────────────────────────────────────
+    // onConnect
+    // ─────────────────────────────────────────────────────────────
+
+    @OptIn(UnstableApi::class)
+    override fun onConnect(
+        session: MediaSession,
+        controller: MediaSession.ControllerInfo
+    ): MediaSession.ConnectionResult {
+        session.player.addListener(object : Player.Listener {
+            override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
+                updateMediaNotificationCustomLayout(session)
+            }
+
+            override fun onRepeatModeChanged(repeatMode: Int) {
+                updateMediaNotificationCustomLayout(session)
+            }
+
+            override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
+                updateMediaNotificationCustomLayout(session)
+            }
+
+            override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
+                updateMediaNotificationCustomLayout(session)
+            }
+        })
+
+        if (session.isMediaNotificationController(controller) ||
+            session.isAutomotiveController(controller) ||
+            session.isAutoCompanionController(controller)
+        ) {
+            return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
+                .setAvailableSessionCommands(mediaNotificationSessionCommands)
+                .setCustomLayout(buildCustomLayout(session.player))
+                .build()
+        }
+
+        return MediaSession.ConnectionResult.AcceptedResultBuilder(session).build()
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Custom layout
+    // ─────────────────────────────────────────────────────────────
+
+    @OptIn(UnstableApi::class)
+    protected fun updateMediaNotificationCustomLayout(
+        session: MediaSession,
+        isRatingPending: Boolean = false
+    ) {
+        session.setCustomLayout(
+            session.mediaNotificationControllerInfo!!,
+            buildCustomLayout(session.player, isRatingPending)
+        )
+    }
+
+    protected fun buildCustomLayout(
+        player: Player,
+        isRatingPending: Boolean = false
+    ): ImmutableList<CommandButton> {
+        val customLayout = mutableListOf<CommandButton>()
+
+        val showShuffle = Preferences.showShuffleInsteadOfHeart()
+
+        if (!showShuffle) {
+            if (player.currentMediaItem != null && !isRatingPending) {
+                if ((player.mediaMetadata.userRating as HeartRating?)?.isHeart == true) {
+                    customLayout.add(customCommandToggleHeartOn)
+                } else {
+                    customLayout.add(customCommandToggleHeartOff)
+                }
+            }
+        } else {
+            customLayout.add(
+                if (player.shuffleModeEnabled) customCommandToggleShuffleModeOff
+                else customCommandToggleShuffleModeOn
+            )
+        }
+
+        val repeatButton = when (player.repeatMode) {
+            Player.REPEAT_MODE_ONE -> customCommandToggleRepeatModeOne
+            Player.REPEAT_MODE_ALL -> customCommandToggleRepeatModeAll
+            else -> customCommandToggleRepeatModeOff
+        }
+        customLayout.add(repeatButton)
+
+        return ImmutableList.copyOf(customLayout)
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Rating (heart)
+    // ─────────────────────────────────────────────────────────────
+
+    override fun onSetRating(
+        session: MediaSession,
+        controller: MediaSession.ControllerInfo,
+        rating: Rating
+    ): ListenableFuture<SessionResult> {
+        return onSetRating(
+            session,
+            controller,
+            session.player.currentMediaItem!!.mediaId,
+            rating
+        )
+    }
+
+    override fun onSetRating(
+        session: MediaSession,
+        controller: MediaSession.ControllerInfo,
+        mediaId: String,
+        rating: Rating
+    ): ListenableFuture<SessionResult> {
+        val isStarring = (rating as HeartRating).isHeart
+
+        val networkCall = if (isStarring)
+            App.getSubsonicClientInstance(false)
+                .mediaAnnotationClient
+                .star(mediaId, null, null)
+        else
+            App.getSubsonicClientInstance(false)
+                .mediaAnnotationClient
+                .unstar(mediaId, null, null)
+
+        val future = SettableFuture.create<SessionResult>()
+
+        networkCall.enqueue(object : Callback<ApiResponse?> {
+            @OptIn(UnstableApi::class)
+            override fun onResponse(call: Call<ApiResponse?>, response: Response<ApiResponse?>) {
+                if (response.isSuccessful) {
+                    for (i in 0 until session.player.mediaItemCount) {
+                        val mediaItem = session.player.getMediaItemAt(i)
+                        if (mediaItem.mediaId == mediaId) {
+                            val newMetadata = mediaItem.mediaMetadata.buildUpon()
+                                .setUserRating(HeartRating(isStarring)).build()
+                            session.player.replaceMediaItem(
+                                i,
+                                mediaItem.buildUpon().setMediaMetadata(newMetadata).build()
+                            )
+                        }
+                    }
+                    updateMediaNotificationCustomLayout(session)
+                    future.set(SessionResult(SessionResult.RESULT_SUCCESS))
+                } else {
+                    updateMediaNotificationCustomLayout(session)
+                    future.set(SessionResult(SessionError(response.code(), response.message())))
+                }
+            }
+
+            @OptIn(UnstableApi::class)
+            override fun onFailure(call: Call<ApiResponse?>, t: Throwable) {
+                updateMediaNotificationCustomLayout(session)
+                future.set(SessionResult(SessionError(SessionError.ERROR_UNKNOWN, "An error has occurred")))
+            }
+        })
+
+        return future
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // Custom commands dispatcher
+    // ─────────────────────────────────────────────────────────────
+
+    @OptIn(UnstableApi::class)
+    override fun onCustomCommand(
+        session: MediaSession,
+        controller: MediaSession.ControllerInfo,
+        customCommand: SessionCommand,
+        args: Bundle
+    ): ListenableFuture<SessionResult> {
+        Log.d(TAG, "onCustomCommand: ${customCommand.customAction}")
+
+        return when (customCommand.customAction) {
+            Constants.CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_ON -> {
+                session.player.shuffleModeEnabled = true
+                updateMediaNotificationCustomLayout(session)
+                Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+            }
+            Constants.CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_OFF -> {
+                session.player.shuffleModeEnabled = false
+                updateMediaNotificationCustomLayout(session)
+                Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+            }
+            Constants.CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_OFF,
+            Constants.CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ONE,
+            Constants.CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ALL -> {
+                val nextMode = when (session.player.repeatMode) {
+                    Player.REPEAT_MODE_ONE -> Player.REPEAT_MODE_ALL
+                    Player.REPEAT_MODE_OFF -> Player.REPEAT_MODE_ONE
+                    else -> Player.REPEAT_MODE_OFF
+                }
+                session.player.repeatMode = nextMode
+                updateMediaNotificationCustomLayout(session)
+                Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+            }
+            Constants.CUSTOM_COMMAND_TOGGLE_HEART_ON,
+            Constants.CUSTOM_COMMAND_TOGGLE_HEART_OFF -> {
+                val currentRating = session.player.mediaMetadata.userRating as? HeartRating
+                val isCurrentlyLiked = currentRating?.isHeart ?: false
+                updateMediaNotificationCustomLayout(session, isRatingPending = true)
+                onSetRating(session, controller, HeartRating(!isCurrentlyLiked))
+            }
+            else -> Futures.immediateFuture(
+                SessionResult(SessionError(SessionError.ERROR_NOT_SUPPORTED, customCommand.customAction))
+            )
+        }
+    }
+
+    // ─────────────────────────────────────────────────────────────
+    // onAddMediaItems — basic version (without AA)
+    // should be override in MediaLibrarySessionCallback for full Tempus release
+    // ─────────────────────────────────────────────────────────────
+
+    override fun onAddMediaItems(
+        mediaSession: MediaSession,
+        controller: MediaSession.ControllerInfo,
+        mediaItems: List<MediaItem>
+    ): ListenableFuture<List<MediaItem>> {
+        Log.d(TAG, "onAddMediaItems")
+        val updatedMediaItems = mediaItems.map { mediaItem ->
+            val mediaMetadata = mediaItem.mediaMetadata
+            val newMetadata = mediaMetadata.buildUpon()
+                .setArtist(
+                    mediaMetadata.artist
+                        ?: mediaMetadata.extras?.getString("uri")
+                        ?: ""
+                )
+                .build()
+            mediaItem.buildUpon()
+                .setUri(mediaItem.requestMetadata.mediaUri)
+                .setMediaMetadata(newMetadata)
+                .setMimeType(MimeTypes.BASE_TYPE_AUDIO)
+                .build()
+        }
+        return Futures.immediateFuture(updatedMediaItems)
+    }
+}

--- a/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/service/MediaLibraryServiceCallback.kt
@@ -1,347 +1,38 @@
 package com.cappielloantonio.tempo.service
 
-import android.annotation.SuppressLint
 import android.content.Context
 import android.os.Bundle
 import android.util.Log
-import androidx.annotation.OptIn
-import androidx.concurrent.futures.CallbackToFutureAdapter
-import androidx.media3.common.HeartRating
 import androidx.media3.common.MediaItem
-import androidx.media3.common.MediaMetadata
-import androidx.media3.common.Player
-import androidx.media3.common.Rating
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.session.CommandButton
 import androidx.media3.session.LibraryResult
 import androidx.media3.session.MediaLibraryService
 import androidx.media3.session.MediaSession
-import androidx.media3.session.SessionCommand
-import androidx.media3.session.SessionError
-import androidx.media3.session.SessionResult
-import com.cappielloantonio.tempo.App
-import com.cappielloantonio.tempo.R
 import com.cappielloantonio.tempo.repository.AutomotiveRepository
 import com.cappielloantonio.tempo.repository.QueueRepository
-import com.cappielloantonio.tempo.subsonic.base.ApiResponse
 import com.cappielloantonio.tempo.util.Constants
-import com.cappielloantonio.tempo.util.Constants.CUSTOM_COMMAND_TOGGLE_HEART_LOADING
-import com.cappielloantonio.tempo.util.Constants.CUSTOM_COMMAND_TOGGLE_HEART_OFF
-import com.cappielloantonio.tempo.util.Constants.CUSTOM_COMMAND_TOGGLE_HEART_ON
-import com.cappielloantonio.tempo.util.Constants.CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ALL
-import com.cappielloantonio.tempo.util.Constants.CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_OFF
-import com.cappielloantonio.tempo.util.Constants.CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ONE
-import com.cappielloantonio.tempo.util.Constants.CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_OFF
-import com.cappielloantonio.tempo.util.Constants.CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_ON
 import com.cappielloantonio.tempo.util.MappingUtil
-import com.cappielloantonio.tempo.util.Preferences
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
 import com.google.common.util.concurrent.MoreExecutors
-import retrofit2.Call
-import retrofit2.Callback
-import retrofit2.Response
 import java.util.concurrent.ConcurrentHashMap
 
-private const val TAG = "MediaLibraryServiceCallback"
+private const val TAG = "MediaLibrarySessionCallback"
 private val queueSourceCache = ConcurrentHashMap<String, List<MediaItem>>()
-@UnstableApi
-open class MediaLibrarySessionCallback(
-    private val context: Context,
-    private val automotiveRepository: AutomotiveRepository
-) :
-    MediaLibraryService.MediaLibrarySession.Callback {
 
+@UnstableApi
+class MediaLibrarySessionCallback(
+    context: Context,
+    private val automotiveRepository: AutomotiveRepository
+) : BaseSessionCallback(context) {
     init {
         MediaBrowserTree.initialize(context, automotiveRepository)
     }
 
-    @SuppressLint("PrivateResource")
-    private val customCommandToggleShuffleModeOn = CommandButton.Builder(CommandButton.ICON_SHUFFLE_OFF)
-        .setDisplayName(context.getString(R.string.exo_controls_shuffle_on_description))
-        .setSessionCommand(SessionCommand(CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_ON, Bundle.EMPTY))
-        .build()
-
-    @SuppressLint("PrivateResource")
-    private val customCommandToggleShuffleModeOff = CommandButton.Builder(CommandButton.ICON_SHUFFLE_ON)
-        .setDisplayName(context.getString(R.string.exo_controls_shuffle_off_description))
-        .setSessionCommand(SessionCommand(CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_OFF, Bundle.EMPTY))
-        .build()
-
-    @SuppressLint("PrivateResource")
-    private val customCommandToggleRepeatModeOff = CommandButton.Builder(CommandButton.ICON_REPEAT_OFF)
-        .setDisplayName(context.getString(R.string.exo_controls_repeat_off_description))
-        .setSessionCommand(SessionCommand(CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_OFF, Bundle.EMPTY))
-        .build()
-
-    @SuppressLint("PrivateResource")
-    private val customCommandToggleRepeatModeOne = CommandButton.Builder(CommandButton.ICON_REPEAT_ONE)
-        .setDisplayName(context.getString(R.string.exo_controls_repeat_one_description))
-        .setSessionCommand(SessionCommand(CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ONE, Bundle.EMPTY))
-        .build()
-
-    @SuppressLint("PrivateResource")
-    private val customCommandToggleRepeatModeAll = CommandButton.Builder(CommandButton.ICON_REPEAT_ALL)
-        .setDisplayName(context.getString(R.string.exo_controls_repeat_all_description))
-        .setSessionCommand(SessionCommand(CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ALL, Bundle.EMPTY))
-        .build()
-
-    @Suppress("DEPRECATION")
-    private val customCommandToggleHeartOn = CommandButton.Builder(CommandButton.ICON_UNDEFINED)
-        .setDisplayName(context.getString(R.string.exo_controls_heart_on_description))
-        .setSessionCommand(SessionCommand(CUSTOM_COMMAND_TOGGLE_HEART_ON, Bundle.EMPTY))
-        .setIconResId(R.drawable.ic_favorite)
-        .build()
-
-    @Suppress("DEPRECATION")
-    private val customCommandToggleHeartOff = CommandButton.Builder(CommandButton.ICON_UNDEFINED)
-        .setDisplayName(context.getString(R.string.exo_controls_heart_off_description))
-        .setSessionCommand(SessionCommand(CUSTOM_COMMAND_TOGGLE_HEART_OFF, Bundle.EMPTY))
-        .setIconResId(R.drawable.ic_favorites_outlined)
-        .build()
-
-    // Fake Command while waiting for like update command
-    @Suppress("DEPRECATION")
-    private val customCommandToggleHeartLoading = CommandButton.Builder(CommandButton.ICON_UNDEFINED)
-        .setDisplayName(context.getString(R.string.cast_expanded_controller_loading))
-        .setSessionCommand(SessionCommand(CUSTOM_COMMAND_TOGGLE_HEART_LOADING, Bundle.EMPTY))
-        .setIconResId(R.drawable.ic_bookmark_sync)
-        .build()
-
-    private val customLayoutCommandButtons = listOf(
-        customCommandToggleShuffleModeOn,
-        customCommandToggleShuffleModeOff,
-        customCommandToggleRepeatModeOff,
-        customCommandToggleRepeatModeOne,
-        customCommandToggleRepeatModeAll,
-        customCommandToggleHeartOn,
-        customCommandToggleHeartOff,
-        customCommandToggleHeartLoading,
-    )
-
-    @OptIn(UnstableApi::class)
-    val mediaNotificationSessionCommands =
-        MediaSession.ConnectionResult.DEFAULT_SESSION_AND_LIBRARY_COMMANDS.buildUpon()
-            .also { builder ->
-                customLayoutCommandButtons.forEach { commandButton ->
-                    commandButton.sessionCommand?.let { builder.add(it) }
-                }
-            }.build()
-
-    @OptIn(UnstableApi::class)
-    override fun onConnect(
-        session: MediaSession, controller: MediaSession.ControllerInfo
-    ): MediaSession.ConnectionResult {
-        session.player.addListener(object : Player.Listener {
-            override fun onShuffleModeEnabledChanged(shuffleModeEnabled: Boolean) {
-                updateMediaNotificationCustomLayout(session)
-            }
-
-            override fun onRepeatModeChanged(repeatMode: Int) {
-                updateMediaNotificationCustomLayout(session)
-            }
-
-            override fun onMediaMetadataChanged(mediaMetadata: MediaMetadata) {
-                updateMediaNotificationCustomLayout(session)
-            }
-
-            override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
-                updateMediaNotificationCustomLayout(session)
-            }
-        })
-
-        // System controllers (media notification, Android Auto, Auto Companion) require
-        // specific session commands and a custom layout to function correctly.
-        // Other controllers (e.g. third-party apps) get default permissions only.
-        if (session.isMediaNotificationController(controller) || session.isAutomotiveController(
-                controller
-            ) || session.isAutoCompanionController(controller)
-        ) {
-            return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
-                .setAvailableSessionCommands(mediaNotificationSessionCommands)
-                .setCustomLayout(buildCustomLayout(session.player))
-                .build()
-        }
-
-        return MediaSession.ConnectionResult.AcceptedResultBuilder(session).build()
-    }
-
-    // Update the mediaNotification after some changes
-    @OptIn(UnstableApi::class)
-    private fun updateMediaNotificationCustomLayout(
-        session: MediaSession,
-        isRatingPending: Boolean = false
-    ) {
-        session.setCustomLayout(
-            session.mediaNotificationControllerInfo!!,
-            buildCustomLayout(session.player, isRatingPending)
-        )
-    }
-
-    private fun buildCustomLayout(player: Player, isRatingPending: Boolean = false): ImmutableList<CommandButton> {
-        val customLayout = mutableListOf<CommandButton>()
-
-        val showShuffle = Preferences.showShuffleInsteadOfHeart()
-
-        if (!showShuffle) {
-            if (player.currentMediaItem != null && !isRatingPending) {
-                if ((player.mediaMetadata.userRating as HeartRating?)?.isHeart == true) {
-                    customLayout.add(customCommandToggleHeartOn)
-                } else {
-                    customLayout.add(customCommandToggleHeartOff)
-                }
-            }
-        } else {
-            customLayout.add(
-                if (player.shuffleModeEnabled) customCommandToggleShuffleModeOff else customCommandToggleShuffleModeOn
-            )
-        }
-
-        // Add repeat button
-        val repeatButton = when (player.repeatMode) {
-            Player.REPEAT_MODE_ONE -> customCommandToggleRepeatModeOne
-            Player.REPEAT_MODE_ALL -> customCommandToggleRepeatModeAll
-            else -> customCommandToggleRepeatModeOff
-        }
-
-        customLayout.add(repeatButton)
-        return ImmutableList.copyOf(customLayout)
-    }
-
-    // Setting rating without a mediaId will set the currently listened mediaId
-    override fun onSetRating(
-        session: MediaSession,
-        controller: MediaSession.ControllerInfo,
-        rating: Rating
-    ): ListenableFuture<SessionResult> {
-        return onSetRating(session, controller, session.player.currentMediaItem!!.mediaId, rating)
-    }
-
-    override fun onSetRating(
-        session: MediaSession,
-        controller: MediaSession.ControllerInfo,
-        mediaId: String,
-        rating: Rating
-    ): ListenableFuture<SessionResult> {
-        val isStaring = (rating as HeartRating).isHeart
-
-        val networkCall = if (isStaring)
-            App.getSubsonicClientInstance(false)
-                .mediaAnnotationClient
-                .star(mediaId, null, null)
-        else
-            App.getSubsonicClientInstance(false)
-                .mediaAnnotationClient
-                .unstar(mediaId, null, null)
-
-        return CallbackToFutureAdapter.getFuture { completer ->
-            networkCall.enqueue(object : Callback<ApiResponse?> {
-                @OptIn(UnstableApi::class)
-                override fun onResponse(
-                    call: Call<ApiResponse?>,
-                    response: Response<ApiResponse?>
-                ) {
-                    if (response.isSuccessful) {
-
-                        // Search if the media item in the player should be updated
-                        for (i in 0 until session.player.mediaItemCount) {
-                            val mediaItem = session.player.getMediaItemAt(i)
-                            if (mediaItem.mediaId == mediaId) {
-                                val newMetadata = mediaItem.mediaMetadata.buildUpon()
-                                    .setUserRating(HeartRating(isStaring)).build()
-                                session.player.replaceMediaItem(
-                                    i,
-                                    mediaItem.buildUpon().setMediaMetadata(newMetadata).build()
-                                )
-                            }
-                        }
-
-                        updateMediaNotificationCustomLayout(session)
-                        completer.set(SessionResult(SessionResult.RESULT_SUCCESS))
-                    } else {
-                        updateMediaNotificationCustomLayout(session)
-                        completer.set(
-                            SessionResult(
-                                SessionError(
-                                    response.code(),
-                                    response.message()
-                                )
-                            )
-                        )
-                    }
-                }
-
-                @OptIn(UnstableApi::class)
-                override fun onFailure(call: Call<ApiResponse?>, t: Throwable) {
-                    updateMediaNotificationCustomLayout(session)
-                    completer.set(
-                        SessionResult(
-                            SessionError(
-                                SessionError.ERROR_UNKNOWN,
-                                "An error as occurred"
-                            )
-                        )
-                    )
-                }
-            })
-        }
-    }
-
-    @OptIn(UnstableApi::class)
-    override fun onCustomCommand(
-        session: MediaSession,
-        controller: MediaSession.ControllerInfo,
-        customCommand: SessionCommand,
-        args: Bundle
-    ): ListenableFuture<SessionResult> {
-
-        when (customCommand.customAction) {
-            CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_ON -> {
-                session.player.shuffleModeEnabled = true
-                updateMediaNotificationCustomLayout(session)
-                return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
-            }
-            CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_OFF -> {
-                session.player.shuffleModeEnabled = false
-                updateMediaNotificationCustomLayout(session)
-                return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
-            }
-            CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_OFF,
-            CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ALL,
-            CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ONE -> {
-                val nextMode = when (session.player.repeatMode) {
-                    Player.REPEAT_MODE_ONE -> Player.REPEAT_MODE_ALL
-                    Player.REPEAT_MODE_OFF -> Player.REPEAT_MODE_ONE
-                    else -> Player.REPEAT_MODE_OFF
-                }
-                session.player.repeatMode = nextMode
-                updateMediaNotificationCustomLayout(session)
-                return Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
-            }
-            CUSTOM_COMMAND_TOGGLE_HEART_ON,
-            CUSTOM_COMMAND_TOGGLE_HEART_OFF -> {
-                val currentRating = session.player.mediaMetadata.userRating as? HeartRating
-                val isCurrentlyLiked = currentRating?.isHeart ?: false
-
-                val newLikedState = !isCurrentlyLiked
-
-                updateMediaNotificationCustomLayout(
-                    session,
-                    isRatingPending = true // Show loading state
-                )
-                return onSetRating(session, controller, HeartRating(newLikedState))
-            }
-            else -> return Futures.immediateFuture(
-                SessionResult(
-                    SessionError(
-                        SessionError.ERROR_NOT_SUPPORTED,
-                        customCommand.customAction
-                    )
-                )
-            )
-        }
-    }
+    // ─────────────────────────────────────────────────────────────
+    // Android Auto — browse
+    // ─────────────────────────────────────────────────────────────
 
     override fun onGetLibraryRoot(
         session: MediaLibraryService.MediaLibrarySession,
@@ -370,6 +61,10 @@ open class MediaLibrarySessionCallback(
             result
         }, MoreExecutors.directExecutor())
     }
+
+    // ─────────────────────────────────────────────────────────────
+    // Android Auto — queue resolution
+    // ─────────────────────────────────────────────────────────────
 
     override fun onSetMediaItems(
         mediaSession: MediaSession,
@@ -567,6 +262,10 @@ open class MediaLibrarySessionCallback(
             MoreExecutors.directExecutor()
         )
     }
+
+    // ─────────────────────────────────────────────────────────────
+    // Android Auto — search
+    // ─────────────────────────────────────────────────────────────
 
     override fun onSearch(
         session: MediaLibraryService.MediaLibrarySession,


### PR DESCRIPTION
This PR refactors Custom Commands to have same functions for both degoogled and Tempus flavors, thanks to the new class BaseSessionCallback.

This solves issue https://github.com/eddyizm/tempus/issues/212
It also reduces code duplication and improves maintainability.

Before:
<img width="508" height="224" alt="Screenshot_20260509_130310_Tempus" src="https://github.com/user-attachments/assets/22236605-a61a-401e-be0c-cb1da0a0bc9d" />
After:
<img width="508" height="224" alt="Screenshot_20260509_130539_Tempus" src="https://github.com/user-attachments/assets/6ec07945-873b-4738-9a51-96a0c441376b" />

