### PR TITLE
feat: add option to disable hiding of system bars in landscape mode

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/activity/MainActivity.java
@@ -293,24 +293,19 @@ public class MainActivity extends BaseActivity {
 
     public void toggleBottomNavigationBarVisibilityOnOrientationChange() {
         float displayDensity = getResources().getDisplayMetrics().density;
-        // Ignore orientation change, bottom navbar always hidden
-        if (Preferences.getHideBottomNavbarOnPortrait()) {
+
+        if (Preferences.getHideBottomNavbarOnPortrait() || isLandscape) {
             navigationController.setNavbarVisibility(false);
             bottomSheetController.setPeekHeight(56, displayDensity);
-            navigationController.setSystemBarsVisibility(this, !isLandscape);
-            return;
+        } else {
+            navigationController.setNavbarVisibility(true);
+            bottomSheetController.setPeekHeight(136, displayDensity);
         }
 
-        if (!isLandscape) {
-            // Show app navbar + show system bars
-            bottomSheetController.setPeekHeight(136, displayDensity);
-            navigationController.setNavbarVisibility(true);
-            navigationController.setSystemBarsVisibility(this, true);
-        } else {
-            // Hide app navbar + hide system bars
-            bottomSheetController.setPeekHeight(56, displayDensity);
-            navigationController.setNavbarVisibility(false);
+        if (Preferences.getHideSystemBarsOnLandscape() && isLandscape) {
             navigationController.setSystemBarsVisibility(this, false);
+        } else {
+            navigationController.setSystemBarsVisibility(this, true);
         }
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/EqualizerFragment.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/EqualizerFragment.kt
@@ -84,7 +84,9 @@ class EqualizerFragment : Fragment() {
         activity.setBottomNavigationBarVisibility(false)
         activity.setBottomSheetVisibility(false)
         activity.setNavigationDrawerLock(true)
-        activity.setSystemBarsVisibility(!activity.isLandscape)
+        if (Preferences.getHideSystemBarsOnLandscape() && activity.isLandscape) {
+            activity.setSystemBarsVisibility(false)
+        }
     }
 
     @OptIn(UnstableApi::class)

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsFragment.java
@@ -97,7 +97,9 @@ public class SettingsFragment extends Fragment {
         activity.setBottomNavigationBarVisibility(false);
         activity.setBottomSheetVisibility(false);
         activity.setNavigationDrawerLock(true);
-        activity.setSystemBarsVisibility(!activity.isLandscape);
+        if (Preferences.getHideSystemBarsOnLandscape() && activity.isLandscape) {
+            activity.setSystemBarsVisibility(false);
+        }
     }
 
     @Override

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -35,6 +35,7 @@ object Preferences {
     private const val LANDSCAPE_ITEMS_PER_ROW = "landscape_items_per_row"
     private const val ENABLE_DRAWER_ON_PORTRAIT = "enable_drawer_on_portrait"
     private const val HIDE_BOTTOM_NAVBAR_ON_PORTRAIT = "hide_bottom_navbar_on_portrait"
+    private const val HIDE_SYSTEM_BARS_ON_LANDSCAPE = "hide_system_bars_on_landscape"
     private const val IMAGE_SIZE = "image_size"
     private const val MAX_BITRATE_WIFI = "max_bitrate_wifi"
     private const val MAX_BITRATE_MOBILE = "max_bitrate_mobile"
@@ -366,6 +367,11 @@ object Preferences {
     @JvmStatic
     fun getHideBottomNavbarOnPortrait(): Boolean {
         return App.getInstance().preferences.getBoolean(HIDE_BOTTOM_NAVBAR_ON_PORTRAIT, false)
+    }
+
+    @JvmStatic
+    fun getHideSystemBarsOnLandscape(): Boolean {
+        return App.getInstance().preferences.getBoolean(HIDE_SYSTEM_BARS_ON_LANDSCAPE, true)
     }
 
     @JvmStatic

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -419,6 +419,8 @@
     <string name="settings_enable_drawer_on_landscape_summary">Разблокирует боковое меню в портретной ориентации. Изменения вступят в силу после перезапуска.</string>
     <string name="settings_hide_bottom_navbar_on_portrait">Скрывать нижнюю панель в портретном режиме [Экспериментально]</string>
     <string name="settings_hide_bottom_navbar_on_portrait_summary">Увеличивает вертикальное пространство, убирая нижнюю панель. Изменения вступят в силу после перезапуска.</string>
+    <string name="settings_hide_system_bars_on_landscape">Скрывать системные панели в горизонтальном режиме [Экспериментально]</string>
+    <string name="settings_hide_system_bars_on_landscape_summary">Увеличивает рабочее пространство, убирая панели состоянии и навигации.</string>
     <string name="settings_auto_download_lyrics">Автоматически скачивать тексты песен</string>
     <string name="settings_auto_download_lyrics_summary">Тексты будут автоматически сохраняться, чтобы их можно было просматривать офлайн.</string>
     <string name="settings_replay_gain">Режим ReplayGain</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -436,6 +436,8 @@
     <string name="settings_enable_drawer_on_landscape_summary">Unlocks the lateral landscape menu drawer on portrait.</string>
     <string name="settings_hide_bottom_navbar_on_portrait">Hide bottom navbar on portrait [Experimental]</string>
     <string name="settings_hide_bottom_navbar_on_portrait_summary">Increases vertical space by removing the bottom navbar. The changes will take effect on restart.</string>
+    <string name="settings_hide_system_bars_on_landscape">Hide system bars on landscape [Experimental]</string>
+    <string name="settings_hide_system_bars_on_landscape_summary">Increases vertical and horizontal space by removing the system bars.</string>
     <string name="settings_auto_download_lyrics">Auto download lyrics</string>
     <string name="settings_auto_download_lyrics_summary">Automatically save lyrics when they are available so they can be shown while offline.</string>
     <string name="settings_replay_gain">Set replay gain mode</string>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -62,6 +62,12 @@
             android:summary="@string/settings_hide_bottom_navbar_on_portrait_summary"/>
         
         <SwitchPreference
+            android:title="@string/settings_hide_system_bars_on_landscape"
+            android:key="hide_system_bars_on_landscape"
+            android:summary="@string/settings_hide_system_bars_on_landscape_summary"
+            android:defaultValue="true" />
+
+        <SwitchPreference
             android:layout_height="match_parent"
             android:defaultValue="true"
             android:key="rounded_corner"


### PR DESCRIPTION
### What was the problem?
The app forced full‑screen mode (hiding status bar and navigation bar) in landscape orientation. On some devices – particularly my car head unit with custom system bars – this caused UI elements to overlap and become unusable.

### What was done?
Added a settings option to enable or disable full‑screen mode in landscape. It allows the user to decide whether the app should hide the system bars when the device is rotated horizontally.

### How to test / verify
1. Open the app Settings and locate the new toggle (e.g., “Full‑screen in landscape”).
2. Turn the toggle off.
3. Rotate the phone to landscape orientation.
4. The status bar and navigation bar should remain visible, and no overlapping should occur.

### Additional notes
The fix does not affect portrait mode.
Works on standard phones/tablets and on my car head unit mentioned in #629 .