### PR TITLE
feat: add sleep timer (like YouTube Music)

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -128,6 +128,9 @@ dependencies {
     implementation 'com.squareup.retrofit2:converter-gson:2.11.0'
 
     implementation 'com.intuit.sdp:sdp-android:1.1.1'
+
+    // Unit testing
+    testImplementation 'junit:junit:4.13.2'
 }
 java {
     toolchain {

--- a/app/src/main/java/com/cappielloantonio/tempo/service/SleepTimerManager.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/SleepTimerManager.kt
@@ -1,0 +1,128 @@
+package com.cappielloantonio.tempo.service
+
+import android.os.Handler
+import android.os.Looper
+
+/**
+ * Manages a sleep timer that stops playback after a specified duration or at the end of the
+ * current song — similar to the sleep timer feature in YouTube Music.
+ *
+ * The [scheduler] and [clock] parameters are injectable to make unit testing straightforward
+ * without requiring a real [android.os.Looper].
+ */
+class SleepTimerManager(
+    private val clock: () -> Long = { System.currentTimeMillis() },
+    private val scheduler: Scheduler = HandlerScheduler()
+) {
+
+    // ----- Public state -----------------------------------------------------------------------
+
+    /** True when a countdown or end-of-song timer is currently armed. */
+    var isActive: Boolean = false
+        private set
+
+    /** True when the timer is set to fire at the end of the current song. */
+    var isEndOfSong: Boolean = false
+        private set
+
+    // ----- Private state ----------------------------------------------------------------------
+
+    private var expiresAtMs: Long = -1L
+    private var runnable: Runnable? = null
+    private var onExpireCallback: Runnable? = null
+
+    // ----- Public API -------------------------------------------------------------------------
+
+    /**
+     * Starts a countdown timer.  Any previously active timer is cancelled first.
+     *
+     * @param durationMs  Duration in milliseconds before playback is stopped.
+     * @param onExpire    Callback invoked on the main thread when the timer fires.
+     */
+    fun startCountdown(durationMs: Long, onExpire: Runnable) {
+        cancelTimer()
+        isEndOfSong = false
+        expiresAtMs = clock() + durationMs
+        onExpireCallback = onExpire
+        val r = Runnable {
+            expiresAtMs = -1L
+            isActive = false
+            onExpireCallback?.run()
+        }
+        runnable = r
+        scheduler.schedule(durationMs, r)
+        isActive = true
+    }
+
+    /**
+     * Arms the "end of song" mode.  Playback will stop when [notifyEndOfSong] is called
+     * (typically from a [androidx.media3.common.Player.Listener.onPlaybackStateChanged] callback).
+     *
+     * @param onExpire  Callback invoked when the current song ends.
+     */
+    fun startEndOfSong(onExpire: Runnable) {
+        cancelTimer()
+        isEndOfSong = true
+        onExpireCallback = onExpire
+        isActive = true
+    }
+
+    /**
+     * Cancels any active timer without triggering the expire callback.
+     */
+    fun cancelTimer() {
+        runnable?.let { scheduler.cancel(it) }
+        runnable = null
+        expiresAtMs = -1L
+        isEndOfSong = false
+        isActive = false
+        onExpireCallback = null
+    }
+
+    /**
+     * Returns the number of milliseconds remaining until the timer fires, or -1 if no
+     * countdown is active (e.g. end-of-song mode, or no timer set).
+     */
+    fun getRemainingMs(): Long {
+        if (!isActive || isEndOfSong || expiresAtMs < 0) return -1L
+        return maxOf(0L, expiresAtMs - clock())
+    }
+
+    /**
+     * Should be called when the current song reaches its natural end.  If the timer is in
+     * end-of-song mode, this triggers the expire callback and resets state.
+     */
+    fun notifyEndOfSong() {
+        if (!isActive || !isEndOfSong) return
+        val cb = onExpireCallback
+        cancelTimer()
+        cb?.run()
+    }
+
+    // ----- Scheduler abstraction (for testability) -------------------------------------------
+
+    interface Scheduler {
+        fun schedule(delayMs: Long, action: Runnable)
+        fun cancel(action: Runnable)
+    }
+
+    /** Production scheduler backed by a main-thread [Handler]. */
+    class HandlerScheduler : Scheduler {
+        // Lazy so that Looper.getMainLooper() is not called at class-load time,
+        // which lets pure-JVM unit tests load SleepTimerManager without crashing.
+        private val handler by lazy { Handler(Looper.getMainLooper()) }
+        override fun schedule(delayMs: Long, action: Runnable) {
+            handler.postDelayed(action, delayMs)
+        }
+        override fun cancel(action: Runnable) {
+            handler.removeCallbacks(action)
+        }
+    }
+
+    // ----- Singleton --------------------------------------------------------------------------
+
+    companion object {
+        @JvmField
+        val instance: SleepTimerManager = SleepTimerManager()
+    }
+}

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/SleepTimerDialog.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/dialog/SleepTimerDialog.java
@@ -1,0 +1,102 @@
+package com.cappielloantonio.tempo.ui.dialog;
+
+import android.app.Dialog;
+import android.os.Bundle;
+
+import androidx.annotation.NonNull;
+import androidx.fragment.app.DialogFragment;
+
+import com.cappielloantonio.tempo.R;
+import com.cappielloantonio.tempo.service.SleepTimerManager;
+import com.google.android.material.dialog.MaterialAlertDialogBuilder;
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Dialog that lets the user choose a sleep-timer duration — similar to the sleep timer in
+ * YouTube Music.  Options include fixed durations and an "end of current song" mode.
+ */
+public class SleepTimerDialog extends DialogFragment {
+
+    private static final String TAG = "SleepTimerDialog";
+
+    // -1 marks the "end of song" entry; 0 marks the "cancel timer" entry.
+    private static final long[] DURATION_VALUES_MS = {
+            TimeUnit.MINUTES.toMillis(5),
+            TimeUnit.MINUTES.toMillis(10),
+            TimeUnit.MINUTES.toMillis(15),
+            TimeUnit.MINUTES.toMillis(30),
+            TimeUnit.MINUTES.toMillis(45),
+            TimeUnit.MINUTES.toMillis(60),
+            -1L,  // End of song
+            0L    // Cancel timer
+    };
+
+    public interface SleepTimerListener {
+        /** Called when the user selects a fixed-duration option. */
+        void onSleepTimerSet(long durationMs);
+
+        /** Called when the user selects "End of song". */
+        void onSleepTimerEndOfSong();
+
+        /** Called when the user cancels / clears the current timer. */
+        void onSleepTimerCancelled();
+    }
+
+    private SleepTimerListener listener;
+
+    public void setSleepTimerListener(SleepTimerListener listener) {
+        this.listener = listener;
+    }
+
+    @NonNull
+    @Override
+    public Dialog onCreateDialog(Bundle savedInstanceState) {
+        String[] labels = buildLabels();
+        int selectedIndex = findCurrentSelection();
+
+        return new MaterialAlertDialogBuilder(requireActivity())
+                .setTitle(R.string.sleep_timer_dialog_title)
+                .setSingleChoiceItems(labels, selectedIndex, (dialog, which) -> {
+                    long value = DURATION_VALUES_MS[which];
+                    if (value > 0) {
+                        if (listener != null) listener.onSleepTimerSet(value);
+                    } else if (value == -1L) {
+                        if (listener != null) listener.onSleepTimerEndOfSong();
+                    } else {
+                        if (listener != null) listener.onSleepTimerCancelled();
+                    }
+                    dialog.dismiss();
+                })
+                .setNegativeButton(R.string.sleep_timer_dialog_negative_button,
+                        (dialog, id) -> dialog.cancel())
+                .create();
+    }
+
+    private String[] buildLabels() {
+        return new String[]{
+                getString(R.string.sleep_timer_5_min),
+                getString(R.string.sleep_timer_10_min),
+                getString(R.string.sleep_timer_15_min),
+                getString(R.string.sleep_timer_30_min),
+                getString(R.string.sleep_timer_45_min),
+                getString(R.string.sleep_timer_60_min),
+                getString(R.string.sleep_timer_end_of_song),
+                getString(R.string.sleep_timer_cancel)
+        };
+    }
+
+    /** Returns the index matching the current timer state, or -1 for no pre-selection. */
+    private int findCurrentSelection() {
+        SleepTimerManager mgr = SleepTimerManager.instance;
+        if (!mgr.isActive()) return -1;
+        if (mgr.isEndOfSong()) return 6; // "End of song"
+        long remaining = mgr.getRemainingMs();
+        for (int i = 0; i < DURATION_VALUES_MS.length; i++) {
+            if (DURATION_VALUES_MS[i] > 0 && Math.abs(DURATION_VALUES_MS[i] - remaining) < TimeUnit.MINUTES.toMillis(1)) {
+                return i;
+            }
+        }
+        return -1;
+    }
+}

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
@@ -46,8 +46,10 @@ import com.cappielloantonio.tempo.databinding.InnerFragmentPlayerControllerBindi
 import com.cappielloantonio.tempo.service.EqualizerManager;
 import com.cappielloantonio.tempo.service.MediaService;
 import com.cappielloantonio.tempo.ui.activity.MainActivity;
+import com.cappielloantonio.tempo.service.SleepTimerManager;
 import com.cappielloantonio.tempo.ui.dialog.PlaybackSpeedDialog;
 import com.cappielloantonio.tempo.ui.dialog.RatingDialog;
+import com.cappielloantonio.tempo.ui.dialog.SleepTimerDialog;
 import com.cappielloantonio.tempo.ui.dialog.TrackInfoDialog;
 import com.cappielloantonio.tempo.ui.fragment.pager.PlayerControllerHorizontalPager;
 import com.cappielloantonio.tempo.util.AssetLinkUtil;
@@ -86,6 +88,7 @@ public class PlayerControllerFragment extends Fragment {
     private ImageButton playerTrackInfo;
     private LinearLayout ratingContainer;
     private ImageButton equalizerButton;
+    private ImageButton sleepTimerButton;
     private ChipGroup assetLinkChipGroup;
     private Chip playerSongLinkChip;
     private Chip playerAlbumLinkChip;
@@ -115,6 +118,7 @@ public class PlayerControllerFragment extends Fragment {
         initMediaLabelButton();
         initArtistLabelButton();
         initEqualizerButton();
+        initSleepTimerButton();
 
         return view;
     }
@@ -153,6 +157,7 @@ public class PlayerControllerFragment extends Fragment {
         songRatingBar =  bind.getRoot().findViewById(R.id.song_rating_bar);
         ratingContainer = bind.getRoot().findViewById(R.id.rating_container);
         equalizerButton = bind.getRoot().findViewById(R.id.player_open_equalizer_button);
+        sleepTimerButton = bind.getRoot().findViewById(R.id.player_sleep_timer_button);
         assetLinkChipGroup = bind.getRoot().findViewById(R.id.asset_link_chip_group);
         playerSongLinkChip = bind.getRoot().findViewById(R.id.asset_link_song_chip);
         playerAlbumLinkChip = bind.getRoot().findViewById(R.id.asset_link_album_chip);
@@ -169,6 +174,65 @@ public class PlayerControllerFragment extends Fragment {
                 playerBottomSheetFragment.goToQueuePage();
             }
         });
+    }
+
+    private void initSleepTimerButton() {
+        updateSleepTimerButtonTint();
+
+        sleepTimerButton.setOnClickListener(v -> {
+            SleepTimerDialog dialog = new SleepTimerDialog();
+            dialog.setSleepTimerListener(new SleepTimerDialog.SleepTimerListener() {
+                @Override
+                public void onSleepTimerSet(long durationMs) {
+                    SleepTimerManager.instance.startCountdown(durationMs, () -> {
+                        pausePlayback();
+                        updateSleepTimerButtonTint();
+                    });
+                    updateSleepTimerButtonTint();
+                }
+
+                @Override
+                public void onSleepTimerEndOfSong() {
+                    SleepTimerManager.instance.startEndOfSong(() -> {
+                        pausePlayback();
+                        updateSleepTimerButtonTint();
+                    });
+                    updateSleepTimerButtonTint();
+                }
+
+                @Override
+                public void onSleepTimerCancelled() {
+                    SleepTimerManager.instance.cancelTimer();
+                    updateSleepTimerButtonTint();
+                }
+            });
+            dialog.show(getParentFragmentManager(), "SleepTimerDialog");
+        });
+    }
+
+    /** Highlights the sleep-timer button when a timer is active. */
+    private void updateSleepTimerButtonTint() {
+        if (sleepTimerButton == null) return;
+        int colorAttr = SleepTimerManager.instance.isActive()
+                ? com.google.android.material.R.attr.colorPrimary
+                : com.google.android.material.R.attr.colorOnPrimaryContainer;
+        android.content.res.TypedArray ta = requireContext().obtainStyledAttributes(new int[]{colorAttr});
+        int color = ta.getColor(0, 0);
+        ta.recycle();
+        androidx.core.widget.ImageViewCompat.setImageTintList(
+                sleepTimerButton,
+                android.content.res.ColorStateList.valueOf(color)
+        );
+    }
+
+    /** Pauses the current player via the MediaBrowser. */
+    private void pausePlayback() {
+        if (mediaBrowserListenableFuture == null || !mediaBrowserListenableFuture.isDone()) return;
+        try {
+            mediaBrowserListenableFuture.get().pause();
+        } catch (Exception e) {
+            Log.e(TAG, "pausePlayback failed", e);
+        }
     }
 
     private void initializeBrowser() {
@@ -215,6 +279,14 @@ public class PlayerControllerFragment extends Fragment {
             @Override
             public void onRepeatModeChanged(int repeatMode) {
                 Preferences.setRepeatMode(repeatMode);
+            }
+
+            @Override
+            public void onPlaybackStateChanged(int playbackState) {
+                // Notify sleep timer when the current song finishes naturally
+                if (playbackState == Player.STATE_ENDED || playbackState == Player.STATE_IDLE) {
+                    SleepTimerManager.instance.notifyEndOfSong();
+                }
             }
         });
     }

--- a/app/src/main/res/drawable/ic_sleep_timer.xml
+++ b/app/src/main/res/drawable/ic_sleep_timer.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M12,3a9,9 0,0 0,0 18,9 9,0 0,0 9,-9 1,1 0,0 0,-1 -1 0.5,0.5 0,0 1,-0.5 -0.5 7,7 0,0 1,-7 -7 1,1 0,0 0,-0.5 -0.5z" />
+</vector>

--- a/app/src/main/res/layout-land/inner_fragment_player_controller_layout.xml
+++ b/app/src/main/res/layout-land/inner_fragment_player_controller_layout.xml
@@ -398,7 +398,7 @@
             android:layout_height="wrap_content"
             android:padding="16dp"
             android:background="?attr/selectableItemBackgroundBorderless"
-            app:layout_constraintStart_toEndOf="@+id/player_open_equalizer_button"
+            app:layout_constraintStart_toEndOf="@+id/player_sleep_timer_button"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -411,10 +411,25 @@
             android:padding="16dp"
             android:background="?attr/selectableItemBackgroundBorderless"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/player_open_queue_button"
+            app:layout_constraintEnd_toStartOf="@+id/player_sleep_timer_button"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:srcCompat="@drawable/ic_eq" />
+
+    
+        <ImageButton
+            android:id="@+id/player_sleep_timer_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="16dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/sleep_timer_button_description"
+            app:layout_constraintStart_toEndOf="@+id/player_open_equalizer_button"
+            app:layout_constraintEnd_toStartOf="@+id/player_open_queue_button"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:srcCompat="@drawable/ic_sleep_timer"
+            app:tint="?attr/colorOnPrimaryContainer" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout-sw600dp-land/inner_fragment_player_controller_layout.xml
+++ b/app/src/main/res/layout-sw600dp-land/inner_fragment_player_controller_layout.xml
@@ -392,7 +392,7 @@
             android:layout_height="wrap_content"
             android:padding="16dp"
             android:background="?attr/selectableItemBackgroundBorderless"
-            app:layout_constraintStart_toEndOf="@+id/player_open_equalizer_button"
+            app:layout_constraintStart_toEndOf="@+id/player_sleep_timer_button"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -405,10 +405,25 @@
             android:padding="16dp"
             android:background="?attr/selectableItemBackgroundBorderless"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/player_open_queue_button"
+            app:layout_constraintEnd_toStartOf="@+id/player_sleep_timer_button"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:srcCompat="@drawable/ic_eq" />
+
+    
+        <ImageButton
+            android:id="@+id/player_sleep_timer_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="16dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/sleep_timer_button_description"
+            app:layout_constraintStart_toEndOf="@+id/player_open_equalizer_button"
+            app:layout_constraintEnd_toStartOf="@+id/player_open_queue_button"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:srcCompat="@drawable/ic_sleep_timer"
+            app:tint="?attr/colorOnPrimaryContainer" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout-sw600dp/inner_fragment_player_controller_layout.xml
+++ b/app/src/main/res/layout-sw600dp/inner_fragment_player_controller_layout.xml
@@ -404,7 +404,7 @@
             android:layout_height="wrap_content"
             android:padding="16dp"
             android:background="?attr/selectableItemBackgroundBorderless"
-            app:layout_constraintStart_toEndOf="@+id/player_open_equalizer_button"
+            app:layout_constraintStart_toEndOf="@+id/player_sleep_timer_button"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -417,10 +417,25 @@
             android:padding="16dp"
             android:background="?attr/selectableItemBackgroundBorderless"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/player_open_queue_button"
+            app:layout_constraintEnd_toStartOf="@+id/player_sleep_timer_button"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:srcCompat="@drawable/ic_eq" />
+
+    
+        <ImageButton
+            android:id="@+id/player_sleep_timer_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="16dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/sleep_timer_button_description"
+            app:layout_constraintStart_toEndOf="@+id/player_open_equalizer_button"
+            app:layout_constraintEnd_toStartOf="@+id/player_open_queue_button"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:srcCompat="@drawable/ic_sleep_timer"
+            app:tint="?attr/colorOnPrimaryContainer" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/inner_fragment_player_controller_layout.xml
+++ b/app/src/main/res/layout/inner_fragment_player_controller_layout.xml
@@ -401,7 +401,7 @@
             android:layout_height="wrap_content"
             android:padding="16dp"
             android:background="?attr/selectableItemBackgroundBorderless"
-            app:layout_constraintStart_toEndOf="@+id/player_open_equalizer_button"
+            app:layout_constraintStart_toEndOf="@+id/player_sleep_timer_button"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
@@ -414,10 +414,24 @@
             android:padding="16dp"
             android:background="?attr/selectableItemBackgroundBorderless"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/player_open_queue_button"
+            app:layout_constraintEnd_toStartOf="@+id/player_sleep_timer_button"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"
             app:srcCompat="@drawable/ic_eq" />
+
+        <ImageButton
+            android:id="@+id/player_sleep_timer_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:padding="16dp"
+            android:background="?attr/selectableItemBackgroundBorderless"
+            android:contentDescription="@string/sleep_timer_button_description"
+            app:layout_constraintStart_toEndOf="@+id/player_open_equalizer_button"
+            app:layout_constraintEnd_toStartOf="@+id/player_open_queue_button"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:srcCompat="@drawable/ic_sleep_timer"
+            app:tint="?attr/colorOnPrimaryContainer" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -640,4 +640,18 @@
 
     <string name="nav_drawer_index">Index</string>
 
+    <!-- Sleep Timer -->
+    <string name="sleep_timer_dialog_title">Sleep timer</string>
+    <string name="sleep_timer_dialog_negative_button">Dismiss</string>
+    <string name="sleep_timer_5_min">5 minutes</string>
+    <string name="sleep_timer_10_min">10 minutes</string>
+    <string name="sleep_timer_15_min">15 minutes</string>
+    <string name="sleep_timer_30_min">30 minutes</string>
+    <string name="sleep_timer_45_min">45 minutes</string>
+    <string name="sleep_timer_60_min">60 minutes</string>
+    <string name="sleep_timer_end_of_song">End of song</string>
+    <string name="sleep_timer_cancel">Cancel timer</string>
+    <string name="sleep_timer_button_description">Sleep timer</string>
+    <string name="sleep_timer_active_label">%d min</string>
+
 </resources>

--- a/app/src/test/java/com/cappielloantonio/tempo/service/SleepTimerManagerTest.kt
+++ b/app/src/test/java/com/cappielloantonio/tempo/service/SleepTimerManagerTest.kt
@@ -1,0 +1,213 @@
+package com.cappielloantonio.tempo.service
+
+import org.junit.Assert.*
+import org.junit.Before
+import org.junit.Test
+
+/**
+ * Unit tests for [SleepTimerManager].
+ *
+ * A fake [SleepTimerManager.Scheduler] and a fake clock are injected so that no real
+ * [android.os.Handler] or [android.os.Looper] is needed, keeping these as pure JVM tests.
+ */
+class SleepTimerManagerTest {
+
+    // ---- Fake clock ----------------------------------------------------------
+    private var fakeNowMs: Long = 0L
+
+    // ---- Fake scheduler that records and immediately fires on demand ----------
+    private val scheduledActions = mutableListOf<Pair<Long, Runnable>>()
+    private val cancelledActions = mutableListOf<Runnable>()
+
+    private val fakeScheduler = object : SleepTimerManager.Scheduler {
+        override fun schedule(delayMs: Long, action: Runnable) {
+            scheduledActions.add(delayMs to action)
+        }
+        override fun cancel(action: Runnable) {
+            cancelledActions.add(action)
+            scheduledActions.removeAll { it.second === action }
+        }
+    }
+
+    private lateinit var manager: SleepTimerManager
+
+    @Before
+    fun setUp() {
+        fakeNowMs = 0L
+        scheduledActions.clear()
+        cancelledActions.clear()
+        manager = SleepTimerManager(clock = { fakeNowMs }, scheduler = fakeScheduler)
+    }
+
+    // ---- Initial state -------------------------------------------------------
+
+    @Test
+    fun `initial state is not active`() {
+        assertFalse(manager.isActive)
+    }
+
+    @Test
+    fun `initial isEndOfSong is false`() {
+        assertFalse(manager.isEndOfSong)
+    }
+
+    @Test
+    fun `getRemainingMs returns -1 when no timer is set`() {
+        assertEquals(-1L, manager.getRemainingMs())
+    }
+
+    // ---- startCountdown ------------------------------------------------------
+
+    @Test
+    fun `startCountdown sets isActive to true`() {
+        manager.startCountdown(60_000L) {}
+        assertTrue(manager.isActive)
+    }
+
+    @Test
+    fun `startCountdown does not set isEndOfSong`() {
+        manager.startCountdown(60_000L) {}
+        assertFalse(manager.isEndOfSong)
+    }
+
+    @Test
+    fun `startCountdown schedules exactly one action`() {
+        manager.startCountdown(30_000L) {}
+        assertEquals(1, scheduledActions.size)
+        assertEquals(30_000L, scheduledActions[0].first)
+    }
+
+    @Test
+    fun `getRemainingMs reflects elapsed clock time`() {
+        fakeNowMs = 0L
+        manager.startCountdown(60_000L) {}
+        fakeNowMs = 20_000L
+        assertEquals(40_000L, manager.getRemainingMs())
+    }
+
+    @Test
+    fun `getRemainingMs returns 0 when time is up but runnable not yet fired`() {
+        fakeNowMs = 0L
+        manager.startCountdown(60_000L) {}
+        fakeNowMs = 70_000L
+        assertEquals(0L, manager.getRemainingMs())
+    }
+
+    @Test
+    fun `startCountdown callback is invoked when scheduled runnable fires`() {
+        var fired = false
+        manager.startCountdown(5_000L) { fired = true }
+        // Simulate the Handler firing the runnable
+        scheduledActions[0].second.run()
+        assertTrue(fired)
+    }
+
+    @Test
+    fun `isActive becomes false after countdown runnable fires`() {
+        manager.startCountdown(5_000L) {}
+        scheduledActions[0].second.run()
+        assertFalse(manager.isActive)
+    }
+
+    @Test
+    fun `startCountdown cancels existing timer before starting new one`() {
+        manager.startCountdown(60_000L) {}
+        manager.startCountdown(30_000L) {}
+        // The first runnable should have been cancelled
+        assertEquals(1, cancelledActions.size)
+        // Only one active scheduled action
+        assertEquals(1, scheduledActions.size)
+        assertEquals(30_000L, scheduledActions[0].first)
+    }
+
+    // ---- startEndOfSong ------------------------------------------------------
+
+    @Test
+    fun `startEndOfSong sets isActive to true`() {
+        manager.startEndOfSong {}
+        assertTrue(manager.isActive)
+    }
+
+    @Test
+    fun `startEndOfSong sets isEndOfSong to true`() {
+        manager.startEndOfSong {}
+        assertTrue(manager.isEndOfSong)
+    }
+
+    @Test
+    fun `getRemainingMs returns -1 in end-of-song mode`() {
+        manager.startEndOfSong {}
+        assertEquals(-1L, manager.getRemainingMs())
+    }
+
+    @Test
+    fun `startEndOfSong does not schedule any runnable`() {
+        manager.startEndOfSong {}
+        assertTrue(scheduledActions.isEmpty())
+    }
+
+    // ---- cancelTimer ---------------------------------------------------------
+
+    @Test
+    fun `cancelTimer clears isActive`() {
+        manager.startCountdown(60_000L) {}
+        manager.cancelTimer()
+        assertFalse(manager.isActive)
+    }
+
+    @Test
+    fun `cancelTimer clears isEndOfSong`() {
+        manager.startEndOfSong {}
+        manager.cancelTimer()
+        assertFalse(manager.isEndOfSong)
+    }
+
+    @Test
+    fun `cancelTimer removes scheduled runnable`() {
+        manager.startCountdown(60_000L) {}
+        manager.cancelTimer()
+        assertTrue(scheduledActions.isEmpty())
+        assertEquals(1, cancelledActions.size)
+    }
+
+    @Test
+    fun `cancelTimer is safe when no timer is active`() {
+        // Should not throw
+        manager.cancelTimer()
+        assertFalse(manager.isActive)
+    }
+
+    // ---- notifyEndOfSong -----------------------------------------------------
+
+    @Test
+    fun `notifyEndOfSong triggers callback in end-of-song mode`() {
+        var called = false
+        manager.startEndOfSong { called = true }
+        manager.notifyEndOfSong()
+        assertTrue(called)
+    }
+
+    @Test
+    fun `notifyEndOfSong resets state after firing`() {
+        manager.startEndOfSong {}
+        manager.notifyEndOfSong()
+        assertFalse(manager.isActive)
+        assertFalse(manager.isEndOfSong)
+    }
+
+    @Test
+    fun `notifyEndOfSong does nothing when countdown mode is active`() {
+        var called = false
+        manager.startCountdown(60_000L) { called = true }
+        manager.notifyEndOfSong()
+        assertFalse(called)
+        assertTrue(manager.isActive)
+    }
+
+    @Test
+    fun `notifyEndOfSong does nothing when no timer is set`() {
+        // Should not throw and state remains unchanged
+        manager.notifyEndOfSong()
+        assertFalse(manager.isActive)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds a **sleep timer** to the player — similar to the one in YouTube Music — that automatically pauses playback after a user-chosen duration or at the end of the current song.
- A new moon-icon button sits between the Equalizer and Queue buttons in the player quick-action bar; it highlights when a timer is active.
- A Material 3 single-choice dialog lets users pick **5 / 10 / 15 / 30 / 45 / 60 minutes**, **End of song**, or **Cancel timer**.

## Changes

| File | What changed |
|---|---|
| `SleepTimerManager.kt` | New singleton; manages countdown + end-of-song modes with an injectable `Scheduler` for testability |
| `SleepTimerDialog.java` | New `DialogFragment` following the existing `PlaybackSpeedDialog` pattern |
| `PlayerControllerFragment.java` | Wires up the new button, opens the dialog, highlights the button when active, and calls `SleepTimerManager.notifyEndOfSong()` from `onPlaybackStateChanged` |
| `ic_sleep_timer.xml` | New crescent-moon vector drawable |
| `inner_fragment_player_controller_layout.xml` (×4) | Sleep timer `ImageButton` added to all layout variants |
| `strings.xml` | 12 new string resources |
| `build.gradle` | `testImplementation 'junit:junit:4.13.2'` added |
| `SleepTimerManagerTest.kt` | **23 passing pure-JVM unit tests** covering all public API methods |

## Test plan

- [x] 23 unit tests pass (`./gradlew testTempusDebugUnitTest`)
- [ ] Build and install on a device/emulator
- [ ] Open the full-screen player → tap the moon button → choose a duration → verify playback pauses when the timer fires
- [ ] Choose "End of song" → verify playback pauses after the current track finishes
- [ ] Choose "Cancel timer" → verify the timer is cleared and the button un-highlights
- [ ] Verify button tint changes (highlighted = timer active, default = no timer)
- [ ] Test on landscape and tablet layouts