### PR TITLE
Add justfile and CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,93 @@
+name: CI
+
+on:
+  push:
+    branches: [main, development]
+  pull_request:
+    branches: [main, development]
+
+jobs:
+  checks:
+    name: Lint & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: '17'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Lint
+        run: ./gradlew lint
+
+      - name: Unit tests
+        run: ./gradlew test
+
+      - name: Upload lint reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: lint-reports
+          path: app/build/reports/lint-results-*.html
+          retention-days: 7
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: app/build/reports/tests/
+          retention-days: 7
+
+  build-debug:
+    name: Debug Build
+    runs-on: ubuntu-latest
+    needs: checks
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: '17'
+
+      - name: Cache Gradle
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      - name: Build debug APKs
+        run: |
+          ./gradlew assembleTempusDebug
+          ./gradlew assembleDegoogledDebug
+
+      - name: Upload debug APKs
+        uses: actions/upload-artifact@v4
+        with:
+          name: debug-apks
+          path: app/build/outputs/apk/**/*.apk
+          retention-days: 7

--- a/justfile
+++ b/justfile
@@ -1,0 +1,63 @@
+default:
+    @just --list
+
+# --- Build ---
+
+build-debug:
+    ./gradlew assembleTempusDebug assembleDegoogledDebug
+
+build-release:
+    ./gradlew assembleTempusRelease assembleDegoogledRelease
+
+build-all: build-debug build-release
+
+# --- Test ---
+
+test:
+    ./gradlew test
+
+test-instrumented:
+    ./gradlew connectedAndroidTest
+
+# --- Lint & Static Analysis ---
+
+lint:
+    ./gradlew lint
+
+lint-report:
+    ./gradlew lint && open app/build/reports/lint-results-tempusDebug.html 2>/dev/null || xdg-open app/build/reports/lint-results-tempusDebug.html
+
+check: lint test
+
+# --- Clean ---
+
+clean:
+    ./gradlew clean
+
+clean-build: clean build-debug
+
+# --- APK output helpers ---
+
+apks:
+    @find app/build/outputs/apk -name '*.apk' 2>/dev/null | sort || echo "No APKs found — run build first"
+
+# --- Dependency management ---
+
+deps:
+    ./gradlew dependencies --configuration releaseRuntimeClasspath
+
+deps-updates:
+    ./gradlew dependencyUpdates
+
+# --- Gradle wrapper ---
+
+wrapper-upgrade version:
+    ./gradlew wrapper --gradle-version={{ version }}
+
+# --- Utility ---
+
+tasks:
+    ./gradlew tasks --all
+
+gradle-properties:
+    ./gradlew properties


### PR DESCRIPTION
## What

- `justfile` with recipes for the most common dev tasks
- `.github/workflows/ci.yml` that runs on every push and PR to `main` and `development`

## justfile recipes

| Recipe | What it does |
|---|---|
| `just build-debug` | Assembles debug APKs for both flavors |
| `just build-release` | Assembles release APKs for both flavors |
| `just build-all` | Both of the above |
| `just lint` | Runs `./gradlew lint` |
| `just lint-report` | Runs lint and opens the HTML report |
| `just test` | Unit tests |
| `just test-instrumented` | Connected Android tests |
| `just check` | lint + test |
| `just clean` | `./gradlew clean` |
| `just clean-build` | clean then debug build |
| `just apks` | Lists built APKs under `app/build/outputs/apk` |
| `just deps` | Release runtime dependency tree |
| `just deps-updates` | Checks for dependency updates |
| `just wrapper-upgrade <version>` | Upgrades the Gradle wrapper |
| `just tasks` | All Gradle tasks |
| `just gradle-properties` | Prints Gradle project properties |

## CI pipeline

Two jobs, both on push/PR to `main` and `development`:

1. **checks** — lint + unit tests, uploads reports as artifacts (7-day retention)
2. **build-debug** — assembles both flavor debug APKs, only runs after checks pass, uploads APKs as artifacts

Uses `actions/cache@v4` for Gradle caching and `actions/checkout@v4` / `actions/setup-java@v4` (updated from v3 used in existing workflows).