### PR TITLE
fix: restore nav bar and drawer state on equalizer exit

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/EqualizerFragment.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/EqualizerFragment.kt
@@ -101,7 +101,10 @@ class EqualizerFragment : Fragment() {
             receiverRegistered = false
         }
 
-        activity.setBottomSheetVisibility(true);
+        activity.setBottomSheetVisibility(true)
+        activity.setBottomNavigationBarVisibility(true)
+        activity.setNavigationDrawerLock(false)
+        activity.setSystemBarsVisibility(true)
     }
 
     override fun onCreateView(


### PR DESCRIPTION
Fixes #625.

## What was happening

`EqualizerFragment.onStart()` hides the bottom nav bar, hides the bottom sheet, locks the navigation drawer, and adjusts system bars visibility. `onStop()` only restored the bottom sheet — the other three were never reset, leaving the nav bar hidden and the drawer locked after closing the equalizer.

## Fix

Add the three missing restore calls to `onStop()`:

```kotlin
activity.setBottomNavigationBarVisibility(true)
activity.setNavigationDrawerLock(false)
activity.setSystemBarsVisibility(true)
```