### PR TITLE
Rename buffering strategy options to show actual durations

### DIFF
--- a/app/src/main/res/values-b+es+419/arrays.xml
+++ b/app/src/main/res/values-b+es+419/arrays.xml
@@ -228,10 +228,10 @@
     </string-array>
 
     <string-array name="buffering_strategy_titles">
-        <item>Mínimo</item>
-        <item>Moderado</item>
-        <item>Agresivo</item>
-        <item>Extremo</item>
+        <item>5 sec</item>
+        <item>50 sec</item>
+        <item>3 min 20 sec</item>
+        <item>6 min 40 sec</item>
     </string-array>
     <string-array name="buffering_strategy_values">
         <item>.1</item>

--- a/app/src/main/res/values-ca/arrays.xml
+++ b/app/src/main/res/values-ca/arrays.xml
@@ -229,10 +229,10 @@
     </string-array>
 
     <string-array name="buffering_strategy_titles">
-        <item>Mínima</item>
-        <item>Moderada</item>
-        <item>Agressiva</item>
-        <item>Extrema</item>
+        <item>5 sec</item>
+        <item>50 sec</item>
+        <item>3 min 20 sec</item>
+        <item>6 min 40 sec</item>
     </string-array>
     <string-array name="buffering_strategy_values">
         <item>.1</item>

--- a/app/src/main/res/values-de/arrays.xml
+++ b/app/src/main/res/values-de/arrays.xml
@@ -228,10 +228,10 @@
     </string-array>
 
     <string-array name="buffering_strategy_titles">
-        <item>Minmal</item>
-        <item>Moderat</item>
-        <item>Aggressiv</item>
-        <item>Extrem</item>
+        <item>5 sec</item>
+        <item>50 sec</item>
+        <item>3 min 20 sec</item>
+        <item>6 min 40 sec</item>
     </string-array>
     <string-array name="buffering_strategy_values">
         <item>.1</item>

--- a/app/src/main/res/values-es-rES/arrays.xml
+++ b/app/src/main/res/values-es-rES/arrays.xml
@@ -228,10 +228,10 @@
     </string-array>
 
     <string-array name="buffering_strategy_titles">
-        <item>Mínimo</item>
-        <item>Moderado</item>
-        <item>Agresivo</item>
-        <item>Extremo</item>
+        <item>5 sec</item>
+        <item>50 sec</item>
+        <item>3 min 20 sec</item>
+        <item>6 min 40 sec</item>
     </string-array>
     <string-array name="buffering_strategy_values">
         <item>.1</item>

--- a/app/src/main/res/values-fr/arrays.xml
+++ b/app/src/main/res/values-fr/arrays.xml
@@ -228,10 +228,10 @@
     </string-array>
 
     <string-array name="buffering_strategy_titles">
-        <item>Minimum</item>
-        <item>Modérée</item>
-        <item>Agressive</item>
-        <item>Extrême</item>
+        <item>5 sec</item>
+        <item>50 sec</item>
+        <item>3 min 20 sec</item>
+        <item>6 min 40 sec</item>
     </string-array>
     <string-array name="buffering_strategy_values">
         <item>.1</item>

--- a/app/src/main/res/values-it/arrays.xml
+++ b/app/src/main/res/values-it/arrays.xml
@@ -228,10 +228,10 @@
     </string-array>
 
     <string-array name="buffering_strategy_titles">
-        <item>Minimo</item>
-        <item>Moderato</item>
-        <item>Aggressivo</item>
-        <item>Estremo</item>
+        <item>5 sec</item>
+        <item>50 sec</item>
+        <item>3 min 20 sec</item>
+        <item>6 min 40 sec</item>
     </string-array>
     <string-array name="buffering_strategy_values">
         <item>.1</item>

--- a/app/src/main/res/values-ko/arrays.xml
+++ b/app/src/main/res/values-ko/arrays.xml
@@ -213,10 +213,10 @@
     </string-array>
 
     <string-array name="buffering_strategy_titles">
-        <item>최소한</item>
-        <item>보통</item>
-        <item>적극적</item>
-        <item>최대한</item>
+        <item>5 sec</item>
+        <item>50 sec</item>
+        <item>3 min 20 sec</item>
+        <item>6 min 40 sec</item>
     </string-array>
     <string-array name="buffering_strategy_values">
         <item>.1</item>

--- a/app/src/main/res/values-pl/arrays.xml
+++ b/app/src/main/res/values-pl/arrays.xml
@@ -228,10 +228,10 @@
     </string-array>
 
     <string-array name="buffering_strategy_titles">
-        <item>Minimalna</item>
-        <item>Średnia</item>
-        <item>Agresywna</item>
-        <item>Ekstremalna</item>
+        <item>5 sec</item>
+        <item>50 sec</item>
+        <item>3 min 20 sec</item>
+        <item>6 min 40 sec</item>
     </string-array>
     <string-array name="buffering_strategy_values">
         <item>.1</item>

--- a/app/src/main/res/values-pt/arrays.xml
+++ b/app/src/main/res/values-pt/arrays.xml
@@ -213,10 +213,10 @@
     </string-array>
 
     <string-array name="buffering_strategy_titles">
-        <item>Mínimo</item>
-        <item>Moderado</item>
-        <item>Agressivo</item>
-        <item>Extremo</item>
+        <item>5 sec</item>
+        <item>50 sec</item>
+        <item>3 min 20 sec</item>
+        <item>6 min 40 sec</item>
     </string-array>
     <string-array name="buffering_strategy_values">
         <item>.1</item>

--- a/app/src/main/res/values-ro/arrays.xml
+++ b/app/src/main/res/values-ro/arrays.xml
@@ -229,10 +229,10 @@
     </string-array>
 
     <string-array name="buffering_strategy_titles">
-        <item>Minim</item>
-        <item>Moderat</item>
-        <item>Agresiv</item>
-        <item>Extrem</item>
+        <item>5 sec</item>
+        <item>50 sec</item>
+        <item>3 min 20 sec</item>
+        <item>6 min 40 sec</item>
     </string-array>
     <string-array name="buffering_strategy_values">
         <item>.1</item>

--- a/app/src/main/res/values-ru/arrays.xml
+++ b/app/src/main/res/values-ru/arrays.xml
@@ -228,10 +228,10 @@
     </string-array>
 
     <string-array name="buffering_strategy_titles">
-        <item>Минимум</item>
-        <item>Умеренно</item>
-        <item>Агрессивно</item>
-        <item>Экстремально</item>
+        <item>5 sec</item>
+        <item>50 sec</item>
+        <item>3 min 20 sec</item>
+        <item>6 min 40 sec</item>
     </string-array>
     <string-array name="buffering_strategy_values">
         <item>.1</item>

--- a/app/src/main/res/values-tr/arrays.xml
+++ b/app/src/main/res/values-tr/arrays.xml
@@ -228,10 +228,10 @@
     </string-array>
 
     <string-array name="buffering_strategy_titles">
-        <item>Minimum</item>
-        <item>Moderate</item>
-        <item>Agrasif</item>
-        <item>Aşırı</item>
+        <item>5 sec</item>
+        <item>50 sec</item>
+        <item>3 min 20 sec</item>
+        <item>6 min 40 sec</item>
     </string-array>
     <string-array name="buffering_strategy_values">
         <item>.1</item>

--- a/app/src/main/res/values-zh-rTW/arrays.xml
+++ b/app/src/main/res/values-zh-rTW/arrays.xml
@@ -228,10 +228,10 @@
     </string-array>
 
     <string-array name="buffering_strategy_titles">
-        <item>最小</item>
-        <item>適中</item>
-        <item>積極</item>
-        <item>極端</item>
+        <item>5 sec</item>
+        <item>50 sec</item>
+        <item>3 min 20 sec</item>
+        <item>6 min 40 sec</item>
     </string-array>
     <string-array name="buffering_strategy_values">
         <item>.1</item>

--- a/app/src/main/res/values-zh/arrays.xml
+++ b/app/src/main/res/values-zh/arrays.xml
@@ -228,10 +228,10 @@
     </string-array>
 
     <string-array name="buffering_strategy_titles">
-        <item>最小</item>
-        <item>适中</item>
-        <item>积极</item>
-        <item>极端</item>
+        <item>5 sec</item>
+        <item>50 sec</item>
+        <item>3 min 20 sec</item>
+        <item>6 min 40 sec</item>
     </string-array>
     <string-array name="buffering_strategy_values">
         <item>.1</item>

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -228,10 +228,10 @@
     </string-array>
 
     <string-array name="buffering_strategy_titles">
-        <item>Minimum</item>
-        <item>Moderate</item>
-        <item>Aggressive</item>
-        <item>Extreme</item>
+        <item>5 sec</item>
+        <item>50 sec</item>
+        <item>3 min 20 sec</item>
+        <item>6 min 40 sec</item>
     </string-array>
     <string-array name="buffering_strategy_values">
         <item>.1</item>


### PR DESCRIPTION
## Summary

- Replaces vague buffering labels ("Minimum", "Moderate", "Aggressive", "Extreme") with the actual buffer durations they map to ("5 sec", "50 sec", "3 min 20 sec", "6 min 40 sec") in English and all 15 locale files
- Makes the setting immediately meaningful — users can see exactly how much audio will be buffered without having to guess

## Related issue

Closes #472

## Test plan

- [ ] Open Settings → Streaming, verify the buffering strategy dropdown shows the duration-based labels in English
- [ ] Switch device locale to any of the 15 translated languages and verify the labels appear correctly
- [ ] Select each option and confirm the buffer behaviour is unchanged (only the display strings changed)