### PR TITLE
Add Auto option to transcode format settings

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
@@ -55,11 +55,11 @@ public class MusicUtil {
         String selectedBitrate = getBitratePreference();
         String selectedFormat = getTranscodingFormatPreference();
         Log.i(TAG, "DEBUG: Requesting Format: " + selectedFormat + " at Bitrate: " + selectedBitrate);
-        
+
         if (!Preferences.isServerPrioritized())
-            uri.append("&maxBitRate=").append(getBitratePreference());
-        if (!Preferences.isServerPrioritized())
-            uri.append("&format=").append(getTranscodingFormatPreference());
+            uri.append("&maxBitRate=").append(selectedBitrate);
+        if (!Preferences.isServerPrioritized() && !selectedFormat.equals("auto"))
+            uri.append("&format=").append(selectedFormat);
         if (timeOffset > 0)
             uri.append("&timeOffset=").append(timeOffset);
 
@@ -91,10 +91,11 @@ public class MusicUtil {
         Matcher m2 = FORMAT_PATTERN.matcher(s);
         s = m2.replaceAll("");
 
+        String updatedFormat = getTranscodingFormatPreference();
         if (!Preferences.isServerPrioritized())
             s += "&maxBitRate=" + getBitratePreference();
-        if (!Preferences.isServerPrioritized())
-            s += "&format=" + getTranscodingFormatPreference();
+        if (!Preferences.isServerPrioritized() && !updatedFormat.equals("auto"))
+            s += "&format=" + updatedFormat;
 
         return Uri.parse(s);
     }
@@ -154,10 +155,11 @@ public class MusicUtil {
         if (params.containsKey("c") && params.get("c") != null)
             uri.append("&c=").append(params.get("c"));
 
+        String downloadFormat = getTranscodingFormatPreferenceForDownload();
         if (!Preferences.isServerPrioritizedInTranscodedDownload())
             uri.append("&maxBitRate=").append(getBitratePreferenceForDownload());
-        if (!Preferences.isServerPrioritizedInTranscodedDownload())
-            uri.append("&format=").append(getTranscodingFormatPreferenceForDownload());
+        if (!Preferences.isServerPrioritizedInTranscodedDownload() && !downloadFormat.equals("auto"))
+            uri.append("&format=").append(downloadFormat);
 
         uri.append("&id=").append(id);
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -136,6 +136,7 @@
 
     <string-array name="audio_transcode_format_wifi_list_titles">
         <item>Direct play</item>
+        <item>Auto (server decides)</item>
         <item>Opus</item>
         <item>AAC</item>
         <item>Mp3</item>
@@ -143,6 +144,7 @@
     </string-array>
     <string-array name="audio_transcode_format_wifi_list_values">
         <item>raw</item>
+        <item>auto</item>
         <item>opus</item>
         <item>aac</item>
         <item>mp3</item>
@@ -151,6 +153,7 @@
 
     <string-array name="audio_transcode_format_mobile_list_titles">
         <item>Direct play</item>
+        <item>Auto (server decides)</item>
         <item>Opus</item>
         <item>AAC</item>
         <item>Mp3</item>
@@ -158,6 +161,7 @@
     </string-array>
     <string-array name="audio_transcode_format_mobile_list_values">
         <item>raw</item>
+        <item>auto</item>
         <item>opus</item>
         <item>aac</item>
         <item>mp3</item>
@@ -166,6 +170,7 @@
 
     <string-array name="audio_transcode_format_download_list_titles">
         <item>Direct download</item>
+        <item>Auto (server decides)</item>
         <item>Opus</item>
         <item>AAC</item>
         <item>Mp3</item>
@@ -173,6 +178,7 @@
     </string-array>
     <string-array name="audio_transcode_format_download_list_values">
         <item>raw</item>
+        <item>auto</item>
         <item>opus</item>
         <item>aac</item>
         <item>mp3</item>


### PR DESCRIPTION
## Summary

- Adds an "Auto (server decides)" / `auto` option to all three transcode format preference lists (Wi-Fi, mobile, download)
- When selected, the `&format=` parameter is omitted from stream/download URLs entirely, letting the server choose the format
- No change to existing format selections — behaviour is identical when any other format is chosen

## Related issue

Closes #534

## Test plan

- [ ] Open Settings → Streaming, verify "Auto (server decides)" appears at the top of the Wi-Fi and mobile format pickers
- [ ] Open Settings → Download, verify "Auto (server decides)" appears in the download format picker
- [ ] Select Auto for each and confirm playback/download proceeds without a `&format=` in the URL (check server logs or proxy)
- [ ] Select any other format (e.g. MP3) and confirm `&format=mp3` still appears in the URL