### PR TITLE
Persist sort order for starred artists, albums, and tracks

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/AlbumHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/AlbumHorizontalAdapter.java
@@ -29,6 +29,7 @@ public class AlbumHorizontalAdapter extends RecyclerView.Adapter<AlbumHorizontal
     private List<AlbumID3> albumsFull;
     private List<AlbumID3> albums;
     private String currentFilter;
+    private String currentSortOrder;
 
     private final Filter filtering = new Filter() {
         @Override
@@ -57,6 +58,7 @@ public class AlbumHorizontalAdapter extends RecyclerView.Adapter<AlbumHorizontal
         @Override
         protected void publishResults(CharSequence constraint, FilterResults results) {
             albums = (List<AlbumID3>) results.values;
+            if (currentSortOrder != null) applySortOrder(currentSortOrder);
             notifyDataSetChanged();
         }
     };
@@ -143,6 +145,12 @@ public class AlbumHorizontalAdapter extends RecyclerView.Adapter<AlbumHorizontal
     }
 
     public void sort(String order) {
+        currentSortOrder = order;
+        applySortOrder(order);
+        notifyDataSetChanged();
+    }
+
+    private void applySortOrder(String order) {
         switch (order) {
             case Constants.ALBUM_ORDER_BY_NAME:
                 albums.sort(Comparator.comparing(AlbumID3::getName));
@@ -152,10 +160,7 @@ public class AlbumHorizontalAdapter extends RecyclerView.Adapter<AlbumHorizontal
                 break;
             case Constants.ALBUM_ORDER_BY_LEAST_RECENTLY_STARRED:
                 albums.sort(Comparator.comparing(AlbumID3::getStarred, Comparator.nullsLast(Comparator.naturalOrder())));
-
                 break;
         }
-
-        notifyDataSetChanged();
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/ArtistHorizontalAdapter.java
@@ -29,6 +29,7 @@ public class ArtistHorizontalAdapter extends RecyclerView.Adapter<ArtistHorizont
     private List<ArtistID3> artistsFull;
     private List<ArtistID3> artists;
     private String currentFilter;
+    private String currentSortOrder;
 
     private final Filter filtering = new Filter() {
         @Override
@@ -57,6 +58,7 @@ public class ArtistHorizontalAdapter extends RecyclerView.Adapter<ArtistHorizont
         @Override
         protected void publishResults(CharSequence constraint, FilterResults results) {
             artists = (List<ArtistID3>) results.values;
+            if (currentSortOrder != null) applySortOrder(currentSortOrder);
             notifyDataSetChanged();
         }
     };
@@ -157,6 +159,12 @@ public class ArtistHorizontalAdapter extends RecyclerView.Adapter<ArtistHorizont
     }
 
     public void sort(String order) {
+        currentSortOrder = order;
+        applySortOrder(order);
+        notifyDataSetChanged();
+    }
+
+    private void applySortOrder(String order) {
         switch (order) {
             case Constants.ARTIST_ORDER_BY_NAME:
                 artists.sort(Comparator.comparing(ArtistID3::getName));
@@ -166,10 +174,7 @@ public class ArtistHorizontalAdapter extends RecyclerView.Adapter<ArtistHorizont
                 break;
             case Constants.ARTIST_ORDER_BY_LEAST_RECENTLY_STARRED:
                 artists.sort(Comparator.comparing(ArtistID3::getStarred, Comparator.nullsLast(Comparator.naturalOrder())));
-
                 break;
         }
-
-        notifyDataSetChanged();
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SongHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/SongHorizontalAdapter.java
@@ -49,6 +49,7 @@ public class SongHorizontalAdapter extends RecyclerView.Adapter<SongHorizontalAd
     private List<Child> songsFull;
     private List<Child> songs;
     private String currentFilter;
+    private String currentSortOrder;
 
     private String currentPlayingId;
     private boolean isPlaying;
@@ -82,6 +83,7 @@ public class SongHorizontalAdapter extends RecyclerView.Adapter<SongHorizontalAd
         @Override
         protected void publishResults(CharSequence constraint, FilterResults results) {
             songs = (List<Child>) results.values;
+            if (currentSortOrder != null) applySortOrder(currentSortOrder);
             notifyDataSetChanged();
 
             for (int pos : currentPlayingPositions) {
@@ -368,6 +370,12 @@ public class SongHorizontalAdapter extends RecyclerView.Adapter<SongHorizontalAd
     }
 
     public void sort(String order) {
+        currentSortOrder = order;
+        applySortOrder(order);
+        notifyDataSetChanged();
+    }
+
+    private void applySortOrder(String order) {
         switch (order) {
             case Constants.MEDIA_BY_TITLE:
                 songs.sort(Comparator.comparing(Child::getTitle));
@@ -379,8 +387,6 @@ public class SongHorizontalAdapter extends RecyclerView.Adapter<SongHorizontalAd
                 songs.sort(Comparator.comparing(Child::getStarred, Comparator.nullsLast(Comparator.naturalOrder())));
                 break;
         }
-
-        notifyDataSetChanged();
     }
 
     public void setMediaBrowserListenableFuture(ListenableFuture<MediaBrowser> mediaBrowserListenableFuture) {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumListPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumListPageFragment.java
@@ -31,6 +31,7 @@ import com.cappielloantonio.tempo.subsonic.models.AlbumID3;
 import com.cappielloantonio.tempo.ui.activity.MainActivity;
 import com.cappielloantonio.tempo.ui.adapter.AlbumHorizontalAdapter;
 import com.cappielloantonio.tempo.util.Constants;
+import com.cappielloantonio.tempo.util.Preferences;
 import com.cappielloantonio.tempo.viewmodel.AlbumListPageViewModel;
 
 import java.util.List;
@@ -143,6 +144,10 @@ public class AlbumListPageFragment extends Fragment implements ClickCallback {
             albumHorizontalAdapter.setItems(albums);
             setAlbumListPageSubtitle(albums);
             setAlbumListPageSorter();
+            if (albumListPageViewModel.title.equals(Constants.ALBUM_STARRED)) {
+                String savedSort = Preferences.getStarredAlbumSortOrder();
+                if (savedSort != null) albumHorizontalAdapter.sort(savedSort);
+            }
         });
 
         bind.albumListRecyclerView.setOnTouchListener((v, event) -> {
@@ -190,12 +195,15 @@ public class AlbumListPageFragment extends Fragment implements ClickCallback {
         popup.setOnMenuItemClickListener(menuItem -> {
             if (menuItem.getItemId() == R.id.menu_horizontal_album_sort_name) {
                 albumHorizontalAdapter.sort(Constants.ALBUM_ORDER_BY_NAME);
+                Preferences.setStarredAlbumSortOrder(Constants.ALBUM_ORDER_BY_NAME);
                 return true;
             } else if (menuItem.getItemId() == R.id.menu_horizontal_album_sort_most_recently_starred) {
                 albumHorizontalAdapter.sort(Constants.ALBUM_ORDER_BY_MOST_RECENTLY_STARRED);
+                Preferences.setStarredAlbumSortOrder(Constants.ALBUM_ORDER_BY_MOST_RECENTLY_STARRED);
                 return true;
             } else if (menuItem.getItemId() == R.id.menu_horizontal_album_sort_least_recently_starred) {
                 albumHorizontalAdapter.sort(Constants.ALBUM_ORDER_BY_LEAST_RECENTLY_STARRED);
+                Preferences.setStarredAlbumSortOrder(Constants.ALBUM_ORDER_BY_LEAST_RECENTLY_STARRED);
                 return true;
             }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistListPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistListPageFragment.java
@@ -31,6 +31,7 @@ import com.cappielloantonio.tempo.subsonic.models.ArtistID3;
 import com.cappielloantonio.tempo.ui.activity.MainActivity;
 import com.cappielloantonio.tempo.ui.adapter.ArtistHorizontalAdapter;
 import com.cappielloantonio.tempo.util.Constants;
+import com.cappielloantonio.tempo.util.Preferences;
 import com.cappielloantonio.tempo.viewmodel.ArtistListPageViewModel;
 
 import java.util.List;
@@ -120,6 +121,8 @@ public class ArtistListPageFragment extends Fragment implements ClickCallback {
             artistHorizontalAdapter.setItems(artists);
             setArtistListPageSubtitle(artists);
             setArtistListPageSorter();
+            String savedSort = Preferences.getStarredArtistSortOrder();
+            if (savedSort != null) artistHorizontalAdapter.sort(savedSort);
         });
 
         bind.artistListRecyclerView.setOnTouchListener((v, event) -> {
@@ -167,12 +170,15 @@ public class ArtistListPageFragment extends Fragment implements ClickCallback {
         popup.setOnMenuItemClickListener(menuItem -> {
             if (menuItem.getItemId() == R.id.menu_horizontal_artist_sort_name) {
                 artistHorizontalAdapter.sort(Constants.ARTIST_ORDER_BY_NAME);
+                Preferences.setStarredArtistSortOrder(Constants.ARTIST_ORDER_BY_NAME);
                 return true;
             } else if (menuItem.getItemId() == R.id.menu_horizontal_artist_sort_most_recently_starred) {
                 artistHorizontalAdapter.sort(Constants.ARTIST_ORDER_BY_MOST_RECENTLY_STARRED);
+                Preferences.setStarredArtistSortOrder(Constants.ARTIST_ORDER_BY_MOST_RECENTLY_STARRED);
                 return true;
             } else if (menuItem.getItemId() == R.id.menu_horizontal_artist_sort_least_recently_starred) {
                 artistHorizontalAdapter.sort(Constants.ARTIST_ORDER_BY_LEAST_RECENTLY_STARRED);
+                Preferences.setStarredArtistSortOrder(Constants.ARTIST_ORDER_BY_LEAST_RECENTLY_STARRED);
                 return true;
             }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SongListPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SongListPageFragment.java
@@ -37,6 +37,7 @@ import com.cappielloantonio.tempo.subsonic.models.Child;
 import com.cappielloantonio.tempo.ui.activity.MainActivity;
 import com.cappielloantonio.tempo.ui.adapter.SongHorizontalAdapter;
 import com.cappielloantonio.tempo.util.Constants;
+import com.cappielloantonio.tempo.util.Preferences;
 import com.cappielloantonio.tempo.viewmodel.PlaybackViewModel;
 import com.cappielloantonio.tempo.viewmodel.SongListPageViewModel;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -218,6 +219,10 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
             songHorizontalAdapter.setItems(songs);
             reapplyPlayback();
             setSongListPageSubtitle(songs);
+            if (Constants.MEDIA_STARRED.equals(songListPageViewModel.title)) {
+                String savedSort = Preferences.getStarredTrackSortOrder();
+                if (savedSort != null) songHorizontalAdapter.sort(savedSort);
+            }
         });
 
         bind.songListRecyclerView.addOnScrollListener(new PaginationScrollListener((LinearLayoutManager) bind.songListRecyclerView.getLayoutManager()) {
@@ -278,12 +283,15 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
         popup.setOnMenuItemClickListener(menuItem -> {
             if (menuItem.getItemId() == R.id.menu_song_sort_name) {
                 songHorizontalAdapter.sort(Constants.MEDIA_BY_TITLE);
+                Preferences.setStarredTrackSortOrder(Constants.MEDIA_BY_TITLE);
                 return true;
             } else if (menuItem.getItemId() == R.id.menu_song_sort_most_recently_starred) {
                 songHorizontalAdapter.sort(Constants.MEDIA_MOST_RECENTLY_STARRED);
+                Preferences.setStarredTrackSortOrder(Constants.MEDIA_MOST_RECENTLY_STARRED);
                 return true;
             } else if (menuItem.getItemId() == R.id.menu_song_sort_least_recently_starred) {
                 songHorizontalAdapter.sort(Constants.MEDIA_LEAST_RECENTLY_STARRED);
+                Preferences.setStarredTrackSortOrder(Constants.MEDIA_LEAST_RECENTLY_STARRED);
                 return true;
             }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -90,6 +90,9 @@ object Preferences {
     private const val ALBUM_DETAIL = "album_detail"
     private const val ALBUM_SORT_ORDER = "album_sort_order"
     private const val DEFAULT_ALBUM_SORT_ORDER = Constants.ALBUM_ORDER_BY_NAME
+    private const val STARRED_ALBUM_SORT_ORDER = "starred_album_sort_order"
+    private const val STARRED_ARTIST_SORT_ORDER = "starred_artist_sort_order"
+    private const val STARRED_TRACK_SORT_ORDER = "starred_track_sort_order"
     private const val ARTIST_SORT_BY_ALBUM_COUNT= "artist_sort_by_album_count"
     private const val SORT_SEARCH_CHRONOLOGICALLY= "sort_search_chronologically"
     private const val ARTIST_DISPLAY_BIOGRAPHY= "artist_display_biography"
@@ -780,6 +783,36 @@ object Preferences {
     @JvmStatic
     fun setAlbumSortOrder(sortOrder: String) {
         App.getInstance().preferences.edit().putString(ALBUM_SORT_ORDER, sortOrder).apply()
+    }
+
+    @JvmStatic
+    fun getStarredAlbumSortOrder(): String? {
+        return App.getInstance().preferences.getString(STARRED_ALBUM_SORT_ORDER, null)
+    }
+
+    @JvmStatic
+    fun setStarredAlbumSortOrder(sortOrder: String) {
+        App.getInstance().preferences.edit().putString(STARRED_ALBUM_SORT_ORDER, sortOrder).apply()
+    }
+
+    @JvmStatic
+    fun getStarredArtistSortOrder(): String? {
+        return App.getInstance().preferences.getString(STARRED_ARTIST_SORT_ORDER, null)
+    }
+
+    @JvmStatic
+    fun setStarredArtistSortOrder(sortOrder: String) {
+        App.getInstance().preferences.edit().putString(STARRED_ARTIST_SORT_ORDER, sortOrder).apply()
+    }
+
+    @JvmStatic
+    fun getStarredTrackSortOrder(): String? {
+        return App.getInstance().preferences.getString(STARRED_TRACK_SORT_ORDER, null)
+    }
+
+    @JvmStatic
+    fun setStarredTrackSortOrder(sortOrder: String) {
+        App.getInstance().preferences.edit().putString(STARRED_TRACK_SORT_ORDER, sortOrder).apply()
     }
 
     @JvmStatic


### PR DESCRIPTION
## Summary

- Saves the selected sort order to `SharedPreferences` whenever the user picks a sort option in the starred artists, albums, or tracks list pages
- Restores the saved sort on next visit so the list comes up pre-sorted without requiring the user to re-select it each time
- Three independent keys: `starred_album_sort_order`, `starred_artist_sort_order`, `starred_track_sort_order`

## Related issue

Closes #496

## Test plan

- [ ] Go to starred albums, pick "Name" sort, leave, return — confirm it's still sorted by name
- [ ] Go to starred artists, pick "Recently starred" sort, leave, return — confirm order is preserved
- [ ] Go to starred tracks, sort by "Least recently starred", kill the app, reopen — confirm sort is remembered
- [ ] Verify that other list pages (recently played, recently added, etc.) are unaffected