### PR TITLE
fix: Bug album month

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/models/ItemDate.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/models/ItemDate.kt
@@ -26,7 +26,7 @@ open class ItemDate(
             SimpleDateFormat("MMMM dd, yyyy", Locale.getDefault())
         }
 
-        calendar.set(year ?: 0, month ?: 1, day ?: 1)
+        calendar.set(year ?: 0, (month ?: 1) - 1, day ?: 1)
 
         return dateFormat.format(calendar.time)
     }


### PR DESCRIPTION
Fixes #698 

This was happening because `calendar.set(int year, int month, int date)` uses month in 0 based index. 0 for January.

See [documentation.](https://docs.oracle.com/javase/8/docs/api/java/util/Calendar.html#set-int-int-int-)

<details>
<summary> Tested with same album </summary>
<img width="500" height="750" alt="Screenshot_2026_0522_173243" src="https://github.com/user-attachments/assets/00c398dc-36e2-4fe3-a46c-ae126ffd7c69" />
</details>
