### PR TITLE
fix: Use dynamic colors with pure black theme

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/helper/ThemeHelper.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/helper/ThemeHelper.java
@@ -19,7 +19,8 @@ public class ThemeHelper {
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_NO);
                 break;
             }
-            case DARK_MODE: {
+            case DARK_MODE:
+            case AMOLED_MODE: {
                 AppCompatDelegate.setDefaultNightMode(AppCompatDelegate.MODE_NIGHT_YES);
                 break;
             }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/activity/MainActivity.java
@@ -49,7 +49,6 @@ import com.cappielloantonio.tempo.util.Preferences;
 import com.cappielloantonio.tempo.viewmodel.MainViewModel;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
-import com.google.android.material.color.DynamicColors;
 import com.google.android.material.navigation.NavigationView;
 import com.google.common.util.concurrent.MoreExecutors;
 
@@ -87,7 +86,6 @@ public class MainActivity extends BaseActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         SplashScreen.installSplashScreen(this);
-        DynamicColors.applyToActivityIfAvailable(this);
 
         super.onCreate(savedInstanceState);
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/activity/base/BaseActivity.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/activity/base/BaseActivity.java
@@ -25,6 +25,7 @@ import com.cappielloantonio.tempo.service.MediaService;
 import com.cappielloantonio.tempo.ui.dialog.BatteryOptimizationDialog;
 import com.cappielloantonio.tempo.util.Flavors;
 import com.cappielloantonio.tempo.util.Preferences;
+import com.google.android.material.color.DynamicColors;
 import com.google.android.material.elevation.SurfaceColors;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -39,16 +40,24 @@ public class BaseActivity extends AppCompatActivity {
         String theme = Preferences.getTheme();
         String darkStyle = Preferences.getDarkThemeStyle();
         boolean isAmoled = ThemeHelper.AMOLED_MODE.equals(darkStyle);
+        boolean applyAmoled = false;
 
         if (ThemeHelper.DARK_MODE.equals(theme) || ThemeHelper.AMOLED_MODE.equals(theme)) {
             if (isAmoled) {
                 setTheme(R.style.AppTheme_Amoled);
+                applyAmoled = true;
             }
         } else if (ThemeHelper.DEFAULT_MODE.equals(theme)) {
             int nightModeFlags = getResources().getConfiguration().uiMode & Configuration.UI_MODE_NIGHT_MASK;
             if (nightModeFlags == Configuration.UI_MODE_NIGHT_YES && isAmoled) {
                 setTheme(R.style.AppTheme_Amoled);
+                applyAmoled = true;
             }
+        }
+
+        DynamicColors.applyToActivityIfAvailable(this);
+        if (applyAmoled) {
+            getTheme().applyStyle(R.style.ThemeOverlay_App_Amoled, true);
         }
 
         super.onCreate(savedInstanceState);

--- a/app/src/main/res/values-night/styles.xml
+++ b/app/src/main/res/values-night/styles.xml
@@ -97,4 +97,10 @@
         <item name="background">?attr/colorErrorContainer</item>
         <item name="android:textColor">?attr/colorOnErrorContainer</item>
     </style>
+
+    <style name="ThemeOverlay.App.Amoled" parent="">
+        <item name="android:colorBackground">@color/md_theme_amoled_background</item>
+        <item name="colorSurface">@color/md_theme_amoled_surface</item>
+        <item name="colorSurfaceVariant">@color/md_theme_amoled_surfaceVariant</item>
+    </style>
 </resources>


### PR DESCRIPTION
Fixed a bug where dynamic colors (Android 12+) weren't applied if pure black theme was set.