### PR TITLE
fix: album art missing for same-album tracks over Bluetooth on Tesla (#470)

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -58,6 +58,7 @@ open class BaseMediaService : MediaLibraryService() {
 
     protected lateinit var exoplayer: ExoPlayer
     protected lateinit var mediaLibrarySession: MediaLibrarySession
+    private lateinit var bitmapLoader: SyncBitmapLoader
     private lateinit var networkCallback: CustomNetworkCallback
     private lateinit var equalizerManager: EqualizerManager
     private val widgetUpdateHandler = Handler(Looper.getMainLooper())
@@ -173,7 +174,7 @@ open class BaseMediaService : MediaLibraryService() {
                 if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_SEEK || reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) {
                     MediaManager.setLastPlayedTimestamp(mediaItem)
                 }
-                
+
                 // Restart header checks for radio streams when media item changes
                 val mediaType = mediaItem.mediaMetadata.extras?.getString("type")
                 if (mediaType == Constants.MEDIA_TYPE_RADIO && player.isPlaying) {
@@ -182,7 +183,7 @@ open class BaseMediaService : MediaLibraryService() {
                 } else if (mediaType != Constants.MEDIA_TYPE_RADIO) {
                     stopRadioHeaderChecks()
                 }
-                
+
                 updateWidget(player)
             }
 
@@ -192,6 +193,12 @@ open class BaseMediaService : MediaLibraryService() {
                     ReplayGainUtil.prefetchQueueGains(player)
                 } catch (t: Throwable) {
                     Log.w(TAG, "prefetchQueueGains failed: $t")
+                }
+                if (timeline.isEmpty) return
+                val window = Timeline.Window()
+                for (i in 0 until timeline.windowCount) {
+                    timeline.getWindow(i, window)
+                    window.mediaItem.mediaMetadata.artworkUri?.let { bitmapLoader.prewarm(it) }
                 }
             }
 
@@ -488,6 +495,7 @@ open class BaseMediaService : MediaLibraryService() {
         stopWidgetUpdates()
         stopRadioHeaderChecks()
         radioHeaderCheckExecutor.shutdown()
+        if (::bitmapLoader.isInitialized) bitmapLoader.shutdown()
         releasePlayers()
         mediaLibrarySession.release()
         super.onDestroy()
@@ -552,10 +560,13 @@ open class BaseMediaService : MediaLibraryService() {
                 getPendingIntent(0, FLAG_IMMUTABLE or FLAG_UPDATE_CURRENT)
             }
 
+        bitmapLoader = SyncBitmapLoader(applicationContext)
+
         mediaLibrarySession =
             MediaLibrarySession.Builder(this, player, getMediaLibrarySessionCallback())
                 .setSessionActivity(sessionActivityPendingIntent)
                 .setPeriodicPositionUpdateEnabled(false)
+                .setBitmapLoader(bitmapLoader)
                 .build()
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/service/SyncBitmapLoader.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/SyncBitmapLoader.kt
@@ -57,7 +57,7 @@ class SyncBitmapLoader(
                 val bitmap = Glide.with(context)
                     .asBitmap()
                     .load(uri)
-                    .submit()
+                    .submit(MAX_ART_SIZE, MAX_ART_SIZE)
                     .get()
                 cache.put(uri, bitmap)
                 future.set(bitmap)
@@ -76,7 +76,7 @@ class SyncBitmapLoader(
                 val bitmap = Glide.with(context)
                     .asBitmap()
                     .load(uri)
-                    .submit()
+                    .submit(MAX_ART_SIZE, MAX_ART_SIZE)
                     .get()
                 cache.put(uri, bitmap)
             } catch (_: Exception) {
@@ -90,6 +90,9 @@ class SyncBitmapLoader(
 
     companion object {
         private const val TAG = "SyncBitmapLoader"
-        private const val CACHE_SIZE = 50
+        private const val CACHE_SIZE = 20
+        // Cap decode dimensions: album art over AVRCP only needs a modest cover
+        // image, and bounding this keeps the LRU cache's worst-case heap small.
+        private const val MAX_ART_SIZE = 512
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/service/SyncBitmapLoader.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/SyncBitmapLoader.kt
@@ -1,0 +1,95 @@
+package com.cappielloantonio.tempo.service
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.BitmapFactory
+import android.net.Uri
+import android.util.LruCache
+import android.util.Log
+import androidx.media3.common.util.BitmapLoader
+import androidx.media3.common.util.UnstableApi
+import com.bumptech.glide.Glide
+import com.google.common.util.concurrent.Futures
+import com.google.common.util.concurrent.ListenableFuture
+import com.google.common.util.concurrent.SettableFuture
+import java.io.IOException
+import java.util.concurrent.ExecutorService
+import java.util.concurrent.Executors
+
+// Custom BitmapLoader that returns immediateFuture on cache hits. Works around
+// Media3 MediaSessionLegacyStub pushing an initial setMetadata(bitmap=null) to
+// the legacy AVRCP bridge whenever loadBitmapFromMetadata returns a non-done
+// future — Tesla's Bluetooth stack latches on that null-bitmap push and then
+// ignores the later bitmap arrival when the new bitmap is pixel-identical to
+// the previous track's (same-album tracks on issue #470).
+@UnstableApi
+class SyncBitmapLoader(
+    private val context: Context
+) : BitmapLoader {
+
+    private val cache = LruCache<Uri, Bitmap>(CACHE_SIZE)
+    private val executor: ExecutorService = Executors.newFixedThreadPool(2)
+
+    override fun supportsMimeType(mimeType: String): Boolean {
+        return mimeType.startsWith("image/")
+    }
+
+    override fun decodeBitmap(data: ByteArray): ListenableFuture<Bitmap> {
+        return try {
+            val bitmap = BitmapFactory.decodeByteArray(data, 0, data.size)
+                ?: return Futures.immediateFailedFuture(
+                    IOException("BitmapFactory returned null for ${data.size}B")
+                )
+            Futures.immediateFuture(bitmap)
+        } catch (e: Exception) {
+            Log.w(TAG, "decodeBitmap failed", e)
+            Futures.immediateFailedFuture(e)
+        }
+    }
+
+    override fun loadBitmap(uri: Uri): ListenableFuture<Bitmap> {
+        cache.get(uri)?.let {
+            return Futures.immediateFuture(it)
+        }
+        val future = SettableFuture.create<Bitmap>()
+        executor.execute {
+            try {
+                val bitmap = Glide.with(context)
+                    .asBitmap()
+                    .load(uri)
+                    .submit()
+                    .get()
+                cache.put(uri, bitmap)
+                future.set(bitmap)
+            } catch (e: Exception) {
+                future.setException(e)
+            }
+        }
+        return future
+    }
+
+    fun prewarm(uri: Uri) {
+        if (cache.get(uri) != null) return
+        executor.execute {
+            if (cache.get(uri) != null) return@execute
+            try {
+                val bitmap = Glide.with(context)
+                    .asBitmap()
+                    .load(uri)
+                    .submit()
+                    .get()
+                cache.put(uri, bitmap)
+            } catch (_: Exception) {
+            }
+        }
+    }
+
+    fun shutdown() {
+        executor.shutdown()
+    }
+
+    companion object {
+        private const val TAG = "SyncBitmapLoader"
+        private const val CACHE_SIZE = 50
+    }
+}


### PR DESCRIPTION
## Problem

On a Tesla (phone paired over Bluetooth), album art is shown only for the **first** track of an album. Every following track on the same album shows no art. Switching to a track from a different album restores the art; returning to the same album drops it again. Reproducible every time.

## Root cause

Album art reaches the car over AVRCP/BIP, which the app feeds indirectly through Media3's `MediaSession`. On a track change, `MediaSessionLegacyStub.updateMetadataIfChanged` loads the artwork via a `BitmapLoader` and pushes metadata to the legacy/AVRCP bridge roughly like this ([media3 1.8.0, L1628–1704](https://github.com/androidx/media/blob/1.8.0/libraries/session/src/main/java/androidx/media3/session/MediaSessionLegacyStub.java#L1628-L1704)):

```
Bitmap bitmap = null;
if (bitmapFuture.isDone()) {
    bitmap = bitmapFuture.get();
} else {
    bitmapFuture.addListener(() -> setMetadata(..., bitmapFuture.get())); // pushed later
}
setMetadata(..., bitmap); // fires now, possibly with a null bitmap
```

The default `BitmapLoader` always resolves on a background thread, so `isDone()` is `false` when Media3 checks it. Every track change therefore pushes metadata twice: once immediately with a `null` bitmap, then again with the real bitmap once it finishes loading.

- **Different album:** the follow-up bitmap differs from what the car last had, so Tesla redraws and art appears.
- **Same album:** the follow-up bitmap is byte-identical to the previous track's. After the initial `null` push, the car's dedup (AVRCP image-handle caching / BIP) treats the identical bytes as "nothing changed" and draws nothing.

For comparison, DSub2000 (a Subsonic client that works on Tesla) attaches the bitmap synchronously per track and never produces the null-first push.

## Fix

Add a custom `BitmapLoader` (`SyncBitmapLoader`) so that `isDone()` is `true` on the first check. Media3 then takes its synchronous branch and the first `setMetadata` already carries the bitmap — the intermediate `null` state never leaves the phone.

- `loadBitmap(uri)` checks an LRU cache and returns an already-completed future on a hit; falls back to async loading on a miss.
- `decodeBitmap(bytes)` decodes inline and returns an immediate future.
- The cache is **prewarmed** from `onTimelineChanged`: when the queue changes, artwork for every queued item is fetched in the background, so the bitmap is almost always cached before the user advances to the next track.

Registered via `MediaLibrarySession.Builder.setBitmapLoader(...)`.

The change is additive and does not modify any Media3 internals. The library's null-first code path still exists; the inputs we hand Media3 simply land in the `isDone() == true` branch, so that path is not reached.

## Scope

- New file: `SyncBitmapLoader.kt`
- `BaseMediaService.kt` (+15 lines): build and register the loader, prewarm in `onTimelineChanged`, shut down the executor in `onDestroy`.

## Testing

Tested on a Tesla Model 3 over Bluetooth for several weeks. Album art now displays for every track, including consecutive same-album tracks. No regressions observed for notification, lock-screen, or Android Auto artwork.

Fixes #470.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**New Features**
- Artwork bitmap caching system improves media library performance by optimizing how album artwork loads and displays throughout your collection
- Automatic artwork prewarming during library initialization ensures faster, more responsive display when browsing and selecting media
- Enhanced media library session initialization with improved artwork handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->