### PR TITLE
Add WiFi-only download constraint

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsContainerFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsContainerFragment.java
@@ -29,6 +29,8 @@ import androidx.core.content.ContextCompat;
 import androidx.core.os.LocaleListCompat;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.media3.common.util.UnstableApi;
+import androidx.media3.exoplayer.offline.DownloadService;
+import androidx.media3.exoplayer.scheduler.Requirements;
 import androidx.navigation.NavController;
 import androidx.navigation.NavOptions;
 import androidx.navigation.fragment.NavHostFragment;
@@ -48,6 +50,7 @@ import com.cappielloantonio.tempo.helper.ThemeHelper;
 import com.cappielloantonio.tempo.interfaces.DialogClickCallback;
 import com.cappielloantonio.tempo.interfaces.ScanCallback;
 import com.cappielloantonio.tempo.equalizer.EqualizerManager;
+import com.cappielloantonio.tempo.service.DownloaderService;
 import com.cappielloantonio.tempo.service.MediaService;
 import com.cappielloantonio.tempo.ui.activity.MainActivity;
 import com.cappielloantonio.tempo.ui.dialog.DeleteDownloadStorageDialog;
@@ -240,6 +243,21 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
                         }
                         return true;
                     });
+        }
+
+        SwitchPreference downloadWifiOnlyPreference = findPreference("download_wifi_only");
+        if (downloadWifiOnlyPreference != null) {
+            downloadWifiOnlyPreference.setOnPreferenceChangeListener((preference, newValue) -> {
+                if (newValue instanceof Boolean) {
+                    boolean enabled = (Boolean) newValue;
+                    Preferences.setDownloadWifiOnly(enabled);
+                    Requirements requirements = enabled
+                            ? new Requirements(Requirements.NETWORK_UNMETERED)
+                            : new Requirements(0);
+                    DownloadService.sendSetRequirements(requireContext(), DownloaderService.class, requirements, false);
+                }
+                return true;
+            });
         }
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/util/DownloadUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/DownloadUtil.java
@@ -21,6 +21,7 @@ import androidx.media3.exoplayer.DefaultRenderersFactory;
 import androidx.media3.exoplayer.RenderersFactory;
 import androidx.media3.exoplayer.offline.DownloadManager;
 import androidx.media3.exoplayer.offline.DownloadNotificationHelper;
+import androidx.media3.exoplayer.scheduler.Requirements;
 
 import com.cappielloantonio.tempo.service.DownloaderManager;
 
@@ -174,6 +175,10 @@ public final class DownloadUtil {
                     getHttpDataSourceFactory(),
                     Executors.newFixedThreadPool(6)
             );
+
+            if (Preferences.isDownloadWifiOnly()) {
+                downloadManager.setRequirements(new Requirements(Requirements.NETWORK_UNMETERED));
+            }
 
             downloaderManager = new DownloaderManager(context, getHttpDataSourceFactory(), downloadManager);
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -42,6 +42,7 @@ object Preferences {
     private const val AUDIO_TRANSCODE_FORMAT_WIFI = "audio_transcode_format_wifi"
     private const val AUDIO_TRANSCODE_FORMAT_MOBILE = "audio_transcode_format_mobile"
     private const val WIFI_ONLY = "wifi_only"
+    private const val DOWNLOAD_WIFI_ONLY = "download_wifi_only"
     private const val DATA_SAVING_MODE = "data_saving_mode"
     private const val SERVER_UNREACHABLE = "server_unreachable"
     private const val SYNC_STARRED_ARTISTS_FOR_OFFLINE_USE = "sync_starred_artists_for_offline_use"
@@ -417,6 +418,16 @@ object Preferences {
     @JvmStatic
     fun isWifiOnly(): Boolean {
         return App.getInstance().preferences.getBoolean(WIFI_ONLY, false)
+    }
+
+    @JvmStatic
+    fun isDownloadWifiOnly(): Boolean {
+        return App.getInstance().preferences.getBoolean(DOWNLOAD_WIFI_ONLY, false)
+    }
+
+    @JvmStatic
+    fun setDownloadWifiOnly(enabled: Boolean) {
+        App.getInstance().preferences.edit().putBoolean(DOWNLOAD_WIFI_ONLY, enabled).apply()
     }
 
     @JvmStatic

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -512,6 +512,8 @@
     <string name="settings_version_title">Version</string>
     <string name="settings_wifi_only_summary">Ask for user confirmation before streaming over mobile network.</string>
     <string name="settings_wifi_only_title">Stream via Wi-Fi only alert</string>
+    <string name="settings_download_wifi_only_summary">Downloads will pause on mobile data and resume automatically on Wi-Fi.</string>
+    <string name="settings_download_wifi_only_title">Download only on Wi-Fi</string>
     <string name="share_bottom_sheet_copy_link">Copy link</string>
     <string name="share_bottom_sheet_delete">Delete share</string>
     <string name="share_bottom_sheet_update">Update share</string>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -307,6 +307,12 @@
             android:key="wifi_only" />
 
         <SwitchPreference
+            android:title="@string/settings_download_wifi_only_title"
+            android:defaultValue="false"
+            android:summary="@string/settings_download_wifi_only_summary"
+            android:key="download_wifi_only" />
+
+        <SwitchPreference
             android:title="@string/settings_data_saving_mode_title"
             android:defaultValue="false"
             android:summary="@string/settings_data_saving_mode_summary"


### PR DESCRIPTION
Resolves #319
## Summary
Adds a new setting that pauses downloads on mobile data and auto-resumes on Wi-Fi using Media3's built-in 'Requirements' scheduler.

## Changes
- **UI**: Added `SwitchPreference` in Settings → Data ("Download only on Wi-Fi")
- **Preferences**: Added `isDownloadWifiOnly()` / `setDownloadWifiOnly()`
- **DownloadUtil**: Sets `Requirements.NETWORK_UNMETERED` on `DownloadManager` at startup when enabled
- **SettingsContainerFragment**: Calls `DownloadService.sendSetRequirements()` when the preference is toggled to update the running service dynamically

## Testing
1. Enable the new "Download only on Wi-Fi" setting
2. Start a download on Wi-Fi
3. Switch to mobile data. The notification should show "Waiting for network"
4. Reconnect to Wi-Fi. Downloads should resume automatically.

## Scope
Clean feature using existing Media3 infrastructure. No DB schema or architectural changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added a new "Download on Wi-Fi Only" setting to the settings menu. When enabled, the app restricts all downloads to Wi-Fi networks and automatically pauses downloads when switching to cellular data. This feature provides users with greater control over mobile data consumption while maintaining access to downloaded content for offline playback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->