### PR TITLE
Fallback to random track if getsimilar returns empty

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/repository/SongRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/SongRepository.java
@@ -239,27 +239,51 @@ public class SongRepository {
     }
 
 
-    public MutableLiveData<List<Child>> getContinuousMix(String id, int count) {
-        MutableLiveData<List<Child>> instantMix = new MutableLiveData<>();
+    public MutableLiveData<List<Child>> getContinuousMix(String trackId, String artistId, int count) {
+        MutableLiveData<List<Child>> continuousMix = new MutableLiveData<>();
 
+        if (artistId != null && !artistId.isEmpty()) {
+            App.getSubsonicClientInstance(false)
+                    .getBrowsingClient()
+                    .getSimilarSongs2(artistId, count)
+                    .enqueue(new Callback<ApiResponse>() {
+                        @Override
+                        public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
+                            List<Child> songs = extractSongs(response, "similarSongs2");
+                            if (!songs.isEmpty()) {
+                                continuousMix.postValue(songs);
+                            } else {
+                                fetchContinuousFallback(trackId, count, continuousMix);
+                            }
+                        }
+
+                        @Override
+                        public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
+                            fetchContinuousFallback(trackId, count, continuousMix);
+                        }
+                    });
+        } else {
+            fetchContinuousFallback(trackId, count, continuousMix);
+        }
+
+        return continuousMix;
+    }
+
+    private void fetchContinuousFallback(String trackId, int count, MutableLiveData<List<Child>> target) {
         App.getSubsonicClientInstance(false)
                 .getBrowsingClient()
-                .getSimilarSongs(id, count)
+                .getSimilarSongs(trackId, count)
                 .enqueue(new Callback<ApiResponse>() {
                     @Override
                     public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
-                        if (response.isSuccessful() && response.body() != null && response.body().getSubsonicResponse().getSimilarSongs() != null) {
-                            instantMix.setValue(response.body().getSubsonicResponse().getSimilarSongs().getSongs());
-                        }
+                        target.postValue(extractSongs(response, "similarSongs"));
                     }
 
                     @Override
                     public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
-                        instantMix.setValue(null);
+                        target.postValue(new ArrayList<>());
                     }
                 });
-
-        return instantMix;
     }
 
     private List<Child> extractSongs(Response<ApiResponse> response, String type) {

--- a/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
@@ -35,7 +35,9 @@ import com.google.common.util.concurrent.MoreExecutors;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
@@ -500,49 +502,75 @@ public class MediaManager {
                 }
             }, MoreExecutors.directExecutor());
         }
+        String trackId = mediaItem.mediaId;
+        String artistId = mediaItem.mediaMetadata.extras != null
+                ? mediaItem.mediaMetadata.extras.getString("artistId")
+                : null;
 
         LiveData<List<Child>> instantMix =
-                getSongRepository().getContinuousMix(mediaItem.mediaId, 25);
+                getSongRepository().getContinuousMix(trackId, artistId, 25);
 
         instantMix.observeForever(new Observer<List<Child>>() {
             @Override
             public void onChanged(List<Child> media) {
-                if (media == null || media.isEmpty()) {
-                    Log.w(TAG, "Continuous Play: no similar track found. Is server correctly configured?");
-                }
-                else
-                {
-                    if (existingBrowserFuture != null) {
-                        Log.d(TAG, "Continuous Play: found " + media.size() + " similar tracks");
+                instantMix.removeObserver(this);
 
-                        final MediaBrowser browser;
-                        try {
-                            browser = existingBrowserFuture.get();
-                        } catch (ExecutionException | InterruptedException e) {
-                            Log.e(TAG, "Continuous Play: browser unavailable", e);
-                            instantMix.removeObserver(this);
-                            continuousPlayIsRunning.set(false);
-                            return;
-                        }
-
-                        List<Child> filteredMedia;
-                        List<String> currentIds = new ArrayList<>();
-                        for (int i = 0; i < Objects.requireNonNull(browser).getMediaItemCount(); i++) {
-                            currentIds.add(browser.getMediaItemAt(i).mediaId);
-                        }
-                        filteredMedia = media.stream()
-                                .filter(child -> !currentIds.contains(child.getId()))
-                                .collect(Collectors.toList());
-
-                        Log.d(TAG, "Continuous Play: adding " + filteredMedia.size() + " tracks to queue");
-                        enqueue(existingBrowserFuture, filteredMedia, true);
+                // Filter against current queue before deciding if we need fallback.
+                // getSimilarSongs2 doesn't know what's already queued, so it may
+                // return tracks we already have. Filter first, then decide.
+                if (media != null && !media.isEmpty()) {
+                    List<Child> filtered = dedupAgainstQueue(media, existingBrowserFuture);
+                    if (!filtered.isEmpty()) {
+                        Log.d(TAG, "Continuous Play: adding " + filtered.size() + " similar tracks");
+                        enqueue(existingBrowserFuture, filtered, true);
+                        continuousPlayIsRunning.set(false);
+                        return;
                     }
                 }
-                instantMix.removeObserver(this);
-                continuousPlayIsRunning.set(false);
-                if (onComplete != null) onComplete.run();
+
+                Log.w(TAG, "Continuous Play: no new similar tracks, falling back to random songs");
+                LiveData<List<Child>> randomSongs = getSongRepository().getRandomSample(25, null, null);
+                randomSongs.observeForever(new Observer<List<Child>>() {
+                    @Override
+                    public void onChanged(List<Child> random) {
+                        randomSongs.removeObserver(this);
+                        if (random != null && !random.isEmpty()) {
+                            List<Child> filtered = dedupAgainstQueue(random, existingBrowserFuture);
+                            if (!filtered.isEmpty()) {
+                                Log.d(TAG, "Continuous Play: adding " + filtered.size() + " random tracks");
+                                enqueue(existingBrowserFuture, filtered, true);
+                            } else {
+                                Log.w(TAG, "Continuous Play: random tracks already in queue");
+                            }
+                        } else {
+                            Log.w(TAG, "Continuous Play: random fallback also empty");
+                        }
+                        continuousPlayIsRunning.set(false);
+                    }
+                });
             }
         });
+    }
+
+    private static List<Child> dedupAgainstQueue(List<Child> candidates,
+                                                  ListenableFuture<MediaBrowser> existingBrowserFuture) {
+        if (existingBrowserFuture == null) return new ArrayList<>(candidates);
+
+        final MediaBrowser browser;
+        try {
+            browser = existingBrowserFuture.get();
+        } catch (ExecutionException | InterruptedException e) {
+            return new ArrayList<>(candidates);
+        }
+
+        Set<String> currentIds = new HashSet<>();
+        for (int i = 0; i < Objects.requireNonNull(browser).getMediaItemCount(); i++) {
+            currentIds.add(browser.getMediaItemAt(i).mediaId);
+        }
+
+        return candidates.stream()
+                .filter(child -> !currentIds.contains(child.getId()))
+                .collect(Collectors.toList());
     }
 
     public static void saveChronology(MediaItem mediaItem) {

--- a/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
@@ -528,26 +528,31 @@ public class MediaManager {
                     }
                 }
 
-                Log.w(TAG, "Continuous Play: no new similar tracks, falling back to random songs");
-                LiveData<List<Child>> randomSongs = getSongRepository().getRandomSample(25, null, null);
-                randomSongs.observeForever(new Observer<List<Child>>() {
-                    @Override
-                    public void onChanged(List<Child> random) {
-                        randomSongs.removeObserver(this);
-                        if (random != null && !random.isEmpty()) {
-                            List<Child> filtered = dedupAgainstQueue(random, existingBrowserFuture);
-                            if (!filtered.isEmpty()) {
-                                Log.d(TAG, "Continuous Play: adding " + filtered.size() + " random tracks");
-                                enqueue(existingBrowserFuture, filtered, true);
+                if (Preferences.isFallbackToRandomTracksEnabled()) {
+                    Log.w(TAG, "Continuous Play: no new similar tracks, falling back to random songs");
+                    LiveData<List<Child>> randomSongs = getSongRepository().getRandomSample(25, null, null);
+                    randomSongs.observeForever(new Observer<List<Child>>() {
+                        @Override
+                        public void onChanged(List<Child> random) {
+                            randomSongs.removeObserver(this);
+                            if (random != null && !random.isEmpty()) {
+                                List<Child> filtered = dedupAgainstQueue(random, existingBrowserFuture);
+                                if (!filtered.isEmpty()) {
+                                    Log.d(TAG, "Continuous Play: adding " + filtered.size() + " random tracks");
+                                    enqueue(existingBrowserFuture, filtered, true);
+                                } else {
+                                    Log.w(TAG, "Continuous Play: random tracks already in queue");
+                                }
                             } else {
-                                Log.w(TAG, "Continuous Play: random tracks already in queue");
+                                Log.w(TAG, "Continuous Play: random fallback also empty");
                             }
-                        } else {
-                            Log.w(TAG, "Continuous Play: random fallback also empty");
+                            continuousPlayIsRunning.set(false);
                         }
-                        continuousPlayIsRunning.set(false);
-                    }
-                });
+                    });
+                } else {
+                    Log.w(TAG, "Continuous Play: no new similar tracks, random fallback disabled");
+                    continuousPlayIsRunning.set(false);
+                }
             }
         });
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -82,6 +82,7 @@ object Preferences {
     private const val GITHUB_UPDATE_CHECK = "github_update_check"
     private const val CONTINUOUS_PLAY = "continuous_play"
     private const val NUMBER_TRACKS_KEEP_IN_QUEUE = "number_tracks_keep_in_queue"
+    private const val FALLBACK_TO_RANDOM_TRACKS = "fallback_to_random_tracks"
     private const val LAST_INSTANT_MIX = "last_instant_mix"
     private const val ALLOW_PLAYLIST_DUPLICATES = "allow_playlist_duplicates"
     private const val HOME_SORT_PLAYLISTS = "home_sort_playlists"
@@ -733,6 +734,19 @@ object Preferences {
     fun getNumberOfTracksKeepInQueue(): Int {
         return App.getInstance().preferences.getInt(NUMBER_TRACKS_KEEP_IN_QUEUE, 30) - 1
     }
+
+    @JvmStatic
+    fun isFallbackToRandomTracksEnabled(): Boolean {
+        return App.getInstance().preferences.getBoolean(FALLBACK_TO_RANDOM_TRACKS, false)
+    }
+
+    @JvmStatic
+    fun setFallbackToRandomTracksEnabled(enabled: Boolean) {
+        App.getInstance().preferences.edit()
+            .putBoolean(FALLBACK_TO_RANDOM_TRACKS, enabled)
+            .apply()
+    }
+
     @JvmStatic
     fun setLastInstantMix() {
         App.getInstance().preferences.edit().putLong(LAST_INSTANT_MIX, System.currentTimeMillis()).apply()

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -402,6 +402,8 @@
     <string name="settings_continuous_play_title">Continuous play</string>
     <string name="settings_number_tracks_keep_in_queue">Number of tracks to keep in queue</string>
     <string name="settings_number_tracks_keep_in_queue_summary">Adjust the number of tracks to keep in queue before starting to add tracks with continuous play</string>
+    <string name="settings_fallback_to_random_tracks_summary">Play random songs as a fallback when similar tracks are unavailable</string>
+    <string name="settings_fallback_to_random_tracks_title">Fallback to random tracks</string>
     <string name="settings_covers_cache">Size of artwork cache</string>
     <string name="settings_data_saving_mode_summary">In order to reduce data consumption, avoid downloading covers.</string>
     <string name="settings_data_saving_mode_title">Limit mobile data usage</string>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -237,6 +237,12 @@
             app:showSeekBarValue="true"
             app:adjustable="true" />
 
+        <SwitchPreference
+            android:title="@string/settings_fallback_to_random_tracks_title"
+            android:defaultValue="false"
+            android:summary="@string/settings_fallback_to_random_tracks_summary"
+            android:key="fallback_to_random_tracks" />
+
         <ListPreference
             app:defaultValue="[heartID]"
             app:dialogTitle="@string/settings_custom_command_first_button"


### PR DESCRIPTION
Hi, I found that for some tracks that lack similarities with other tracks, Tempus will not add any track into the current queue when continuous play is active.
My proposal was to fallback to random tracks so it will continue playing regardless.

This PR make `getContinuousMix` use `getSimilarSongs2` as the main functionality and fallback to `getSimilarSongs` if that fail. After that the result of it is filtered against the current queue, if it returns empty then we fallback to random 25 songs.