### PR TITLE
Move sleep timer logic from PlayerControllerFragment to BaseMediaService

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -112,7 +112,7 @@ open class BaseMediaService : MediaLibraryService() {
         initializeExoPlayer()
         initializeMediaLibrarySession(exoplayer)
         initializePlayerListener(exoplayer)
-        initializeSleepTimer(exoplayer)
+        initializeSleepTimer()
         setPlayer(null, exoplayer)
     }
 
@@ -456,20 +456,20 @@ open class BaseMediaService : MediaLibraryService() {
      * that fade-out and pause happen in the service regardless of whether the
      * Fragment is attached. Call once after the player is ready.
      */
-    private fun initializeSleepTimer(player: Player) {
+    private fun initializeSleepTimer() {
         SleepTimerManager.getInstance().setServiceActionListener(object : SleepTimerManager.ServiceActionListener {
             override fun onTick(expired: Boolean) {
-                if (expired) startFadeOutThenPause(player)
+                if (expired) startFadeOutThenPause(mediaLibrarySession.player)
             }
             override fun onEndOfTrackArmed() {
-                armEndOfTrackFadePoller(player)
+                armEndOfTrackFadePoller(mediaLibrarySession.player)
             }
         })
         // If end-of-track was already armed when the service restarted (state
         // restored from SharedPreferences), re-arm the poller against the live player.
         if (SleepTimerManager.getInstance().isActive &&
                 SleepTimerManager.getInstance().isEndOfTrack) {
-            armEndOfTrackFadePoller(player)
+            armEndOfTrackFadePoller(mediaLibrarySession.player)
         }
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -84,23 +84,6 @@ open class BaseMediaService : MediaLibraryService() {
 
     private val binder = LocalBinder()
 
-    // -------------------------------------------------------------------------
-    // Sleep timer — fade-out and end-of-track poller live here so they survive
-    // the Fragment lifecycle during background playback.
-    // -------------------------------------------------------------------------
-
-    private val sleepTimerHandler = Handler(Looper.getMainLooper())
-
-    /** Duration of the volume fade-out in milliseconds. */
-    private val FADE_DURATION_MS = 10_000L
-    /** Number of discrete volume steps during the fade. */
-    private val FADE_STEPS = 40
-
-    /** Set to true to abort an in-progress fade (e.g. track transition fired early). */
-    @Volatile private var abortCurrentFade = false
-
-    private var endOfTrackPoller: Runnable? = null
-
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
             ACTION_RELOAD_EQUALIZER -> reloadEqualizer()
@@ -198,8 +181,7 @@ open class BaseMediaService : MediaLibraryService() {
                 // trigger the fade), abort any in-progress fade and pause immediately.
                 if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO &&
                     SleepTimerManager.getInstance().isEndOfTrack) {
-                    abortCurrentFade = true
-                    stopEndOfTrackPoller()
+                    SleepTimerManager.getInstance().stopEndOfTrackPoller()
                     SleepTimerManager.getInstance().cancelTimer()
                     player.volume = 1f
                     player.pause()
@@ -448,7 +430,7 @@ open class BaseMediaService : MediaLibraryService() {
     }
 
     // -------------------------------------------------------------------------
-    // Sleep timer — fade-out and end-of-track polling
+    // Sleep timer
     // -------------------------------------------------------------------------
 
     /**
@@ -459,88 +441,18 @@ open class BaseMediaService : MediaLibraryService() {
     private fun initializeSleepTimer() {
         SleepTimerManager.getInstance().setServiceActionListener(object : SleepTimerManager.ServiceActionListener {
             override fun onTick(expired: Boolean) {
-                if (expired) startFadeOutThenPause(mediaLibrarySession.player)
+                if (expired) SleepTimerManager.getInstance().startFadeOutThenPause(mediaLibrarySession.player)
             }
             override fun onEndOfTrackArmed() {
-                armEndOfTrackFadePoller(mediaLibrarySession.player)
+                SleepTimerManager.getInstance().armEndOfTrackFadePoller(mediaLibrarySession.player)
             }
         })
         // If end-of-track was already armed when the service restarted (state
         // restored from SharedPreferences), re-arm the poller against the live player.
         if (SleepTimerManager.getInstance().isActive &&
                 SleepTimerManager.getInstance().isEndOfTrack) {
-            armEndOfTrackFadePoller(mediaLibrarySession.player)
+            SleepTimerManager.getInstance().armEndOfTrackFadePoller(mediaLibrarySession.player)
         }
-    }
-
-    /**
-     * Gradually lowers the player volume to zero over [FADE_DURATION_MS], then
-     * pauses and restores full volume. Respects [abortCurrentFade].
-     */
-    private fun startFadeOutThenPause(player: Player) {
-        val stepMs = FADE_DURATION_MS / FADE_STEPS
-        val decrement = 1f / FADE_STEPS
-        val volume = floatArrayOf(1f)
-
-        abortCurrentFade = false
-
-        val fadeStep = object : Runnable {
-            override fun run() {
-                if (abortCurrentFade) {
-                    player.volume = 1f
-                    return
-                }
-                volume[0] = maxOf(0f, volume[0] - decrement)
-                player.volume = volume[0]
-                if (volume[0] > 0f) {
-                    sleepTimerHandler.postDelayed(this, stepMs)
-                } else {
-                    // Fade complete — cancel the timer and pause.
-                    SleepTimerManager.getInstance().cancelTimer()
-                    player.pause()
-                    sleepTimerHandler.postDelayed({ player.volume = 1f }, 300)
-                }
-            }
-        }
-        sleepTimerHandler.post(fadeStep)
-    }
-
-    /**
-     * Polls playback position every 500 ms while end-of-track is armed.
-     * Kicks off [startFadeOutThenPause] when [FADE_DURATION_MS] or fewer
-     * milliseconds remain on the current track.
-     */
-    private fun armEndOfTrackFadePoller(player: Player) {
-        stopEndOfTrackPoller()
-        abortCurrentFade = false
-
-        endOfTrackPoller = object : Runnable {
-            var fadeStarted = false
-
-            override fun run() {
-                if (!SleepTimerManager.getInstance().isEndOfTrack) return
-                if (fadeStarted) return
-
-                val duration = player.duration
-                val position = player.currentPosition
-
-                if (duration > 0 && duration != C.TIME_UNSET) {
-                    val remaining = duration - position
-                    if (remaining in 1..FADE_DURATION_MS) {
-                        fadeStarted = true
-                        startFadeOutThenPause(player)
-                        return
-                    }
-                }
-                sleepTimerHandler.postDelayed(this, 500)
-            }
-        }
-        sleepTimerHandler.post(endOfTrackPoller!!)
-    }
-
-    private fun stopEndOfTrackPoller() {
-        endOfTrackPoller?.let { sleepTimerHandler.removeCallbacks(it) }
-        endOfTrackPoller = null
     }
 
     open fun onInstantMix(session: MediaSession, onComplete: Runnable? = null) {
@@ -614,7 +526,7 @@ open class BaseMediaService : MediaLibraryService() {
         ReplayGainUtil.release()
         stopWidgetUpdates()
         stopRadioHeaderChecks()
-        stopEndOfTrackPoller()
+        SleepTimerManager.getInstance().stopEndOfTrackPoller()
         SleepTimerManager.getInstance().setServiceActionListener(null)
         radioHeaderCheckExecutor.shutdown()
         releasePlayers()

--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -37,6 +37,7 @@ import com.cappielloantonio.tempo.equalizer.DefaultBackend
 import com.cappielloantonio.tempo.repository.QueueRepository
 import com.cappielloantonio.tempo.ui.activity.MainActivity
 import com.cappielloantonio.tempo.util.*
+import com.cappielloantonio.tempo.util.SleepTimerManager
 import com.cappielloantonio.tempo.widget.WidgetUpdateManager
 import java.net.HttpURLConnection
 import java.net.URL
@@ -83,6 +84,23 @@ open class BaseMediaService : MediaLibraryService() {
 
     private val binder = LocalBinder()
 
+    // -------------------------------------------------------------------------
+    // Sleep timer — fade-out and end-of-track poller live here so they survive
+    // the Fragment lifecycle during background playback.
+    // -------------------------------------------------------------------------
+
+    private val sleepTimerHandler = Handler(Looper.getMainLooper())
+
+    /** Duration of the volume fade-out in milliseconds. */
+    private val FADE_DURATION_MS = 10_000L
+    /** Number of discrete volume steps during the fade. */
+    private val FADE_STEPS = 40
+
+    /** Set to true to abort an in-progress fade (e.g. track transition fired early). */
+    @Volatile private var abortCurrentFade = false
+
+    private var endOfTrackPoller: Runnable? = null
+
     override fun onStartCommand(intent: Intent?, flags: Int, startId: Int): Int {
         when (intent?.action) {
             ACTION_RELOAD_EQUALIZER -> reloadEqualizer()
@@ -94,6 +112,7 @@ open class BaseMediaService : MediaLibraryService() {
         initializeExoPlayer()
         initializeMediaLibrarySession(exoplayer)
         initializePlayerListener(exoplayer)
+        initializeSleepTimer(exoplayer)
         setPlayer(null, exoplayer)
     }
 
@@ -172,6 +191,18 @@ open class BaseMediaService : MediaLibraryService() {
                 // --- End add for AA ---
                 if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_SEEK || reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) {
                     MediaManager.setLastPlayedTimestamp(mediaItem)
+                }
+
+                // Safety net: if a track transition fires while end-of-track is armed
+                // (e.g. stream with unknown duration that ended before the poller could
+                // trigger the fade), abort any in-progress fade and pause immediately.
+                if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO &&
+                    SleepTimerManager.getInstance().isEndOfTrack) {
+                    abortCurrentFade = true
+                    stopEndOfTrackPoller()
+                    SleepTimerManager.getInstance().cancelTimer()
+                    player.volume = 1f
+                    player.pause()
                 }
                 
                 // Restart header checks for radio streams when media item changes
@@ -416,6 +447,102 @@ open class BaseMediaService : MediaLibraryService() {
         }
     }
 
+    // -------------------------------------------------------------------------
+    // Sleep timer — fade-out and end-of-track polling
+    // -------------------------------------------------------------------------
+
+    /**
+     * Registers a [SleepTimerManager.ServiceActionListener] on the singleton so
+     * that fade-out and pause happen in the service regardless of whether the
+     * Fragment is attached. Call once after the player is ready.
+     */
+    private fun initializeSleepTimer(player: Player) {
+        SleepTimerManager.getInstance().setServiceActionListener(object : SleepTimerManager.ServiceActionListener {
+            override fun onTick(expired: Boolean) {
+                if (expired) startFadeOutThenPause(player)
+            }
+            override fun onEndOfTrackArmed() {
+                armEndOfTrackFadePoller(player)
+            }
+        })
+        // If end-of-track was already armed when the service restarted (state
+        // restored from SharedPreferences), re-arm the poller against the live player.
+        if (SleepTimerManager.getInstance().isActive &&
+                SleepTimerManager.getInstance().isEndOfTrack) {
+            armEndOfTrackFadePoller(player)
+        }
+    }
+
+    /**
+     * Gradually lowers the player volume to zero over [FADE_DURATION_MS], then
+     * pauses and restores full volume. Respects [abortCurrentFade].
+     */
+    private fun startFadeOutThenPause(player: Player) {
+        val stepMs = FADE_DURATION_MS / FADE_STEPS
+        val decrement = 1f / FADE_STEPS
+        val volume = floatArrayOf(1f)
+
+        abortCurrentFade = false
+
+        val fadeStep = object : Runnable {
+            override fun run() {
+                if (abortCurrentFade) {
+                    player.volume = 1f
+                    return
+                }
+                volume[0] = maxOf(0f, volume[0] - decrement)
+                player.volume = volume[0]
+                if (volume[0] > 0f) {
+                    sleepTimerHandler.postDelayed(this, stepMs)
+                } else {
+                    // Fade complete — cancel the timer and pause.
+                    SleepTimerManager.getInstance().cancelTimer()
+                    player.pause()
+                    sleepTimerHandler.postDelayed({ player.volume = 1f }, 300)
+                }
+            }
+        }
+        sleepTimerHandler.post(fadeStep)
+    }
+
+    /**
+     * Polls playback position every 500 ms while end-of-track is armed.
+     * Kicks off [startFadeOutThenPause] when [FADE_DURATION_MS] or fewer
+     * milliseconds remain on the current track.
+     */
+    private fun armEndOfTrackFadePoller(player: Player) {
+        stopEndOfTrackPoller()
+        abortCurrentFade = false
+
+        endOfTrackPoller = object : Runnable {
+            var fadeStarted = false
+
+            override fun run() {
+                if (!SleepTimerManager.getInstance().isEndOfTrack) return
+                if (fadeStarted) return
+
+                val duration = player.duration
+                val position = player.currentPosition
+
+                if (duration > 0 && duration != C.TIME_UNSET) {
+                    val remaining = duration - position
+                    if (remaining in 1..FADE_DURATION_MS) {
+                        fadeStarted = true
+                        startFadeOutThenPause(player)
+                        return
+                    }
+                }
+                sleepTimerHandler.postDelayed(this, 500)
+            }
+        }
+        sleepTimerHandler.post(endOfTrackPoller!!)
+    }
+
+    private fun stopEndOfTrackPoller() {
+        endOfTrackPoller?.let { sleepTimerHandler.removeCallbacks(it) }
+        endOfTrackPoller = null
+    }
+
     open fun onInstantMix(session: MediaSession, onComplete: Runnable? = null) {
         val player = session.player
         val currentMediaItem = player.currentMediaItem
@@ -487,6 +614,8 @@ open class BaseMediaService : MediaLibraryService() {
         ReplayGainUtil.release()
         stopWidgetUpdates()
         stopRadioHeaderChecks()
+        stopEndOfTrackPoller()
+        SleepTimerManager.getInstance().setServiceActionListener(null)
         radioHeaderCheckExecutor.shutdown()
         releasePlayers()
         mediaLibrarySession.release()

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
@@ -6,8 +6,6 @@ import android.content.Intent;
 import android.content.ServiceConnection;
 import android.os.Bundle;
 import android.os.IBinder;
-import android.os.Handler;
-import android.os.Looper;
 import android.text.TextUtils;
 import android.util.Log;
 import android.view.Gravity;
@@ -231,7 +229,6 @@ public class PlayerControllerFragment extends Fragment {
 
     private void releaseBrowser() {
         SleepTimerManager.getInstance().setTickListener(null);
-        stopEndOfTrackPoller();
         MediaBrowser.releaseFuture(mediaBrowserListenableFuture);
     }
 
@@ -266,18 +263,7 @@ public class PlayerControllerFragment extends Fragment {
 
             @Override
             public void onMediaItemTransition(@androidx.annotation.Nullable androidx.media3.common.MediaItem mediaItem, int reason) {
-                if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO
-                        && SleepTimerManager.getInstance().isEndOfTrack()) {
-                    // Safety net: fires when the track ended before the position
-                    // poller could trigger the fade (e.g. unknown duration on a
-                    // stream).  Abort any in-progress fade, cancel the timer,
-                    // and pause immediately.
-                    abortCurrentFade = true;
-                    stopEndOfTrackPoller();
-                    SleepTimerManager.getInstance().cancelTimer();
-                    mediaBrowser.setVolume(1.0f);
-                    mediaBrowser.pause();
-                }
+                // End-of-track abort and fade logic now handled by BaseMediaService.
             }
 
             @Override
@@ -636,7 +622,6 @@ public class PlayerControllerFragment extends Fragment {
                 public void onEndOfTrackSet() {
                     SleepTimerManager.getInstance().startEndOfTrack();
                     connectSleepTimerTick(mediaBrowser);
-                    armEndOfTrackFadePoller(mediaBrowser);
                 }
             });
             dialog.show(requireActivity().getSupportFragmentManager(), null);
@@ -646,114 +631,13 @@ public class PlayerControllerFragment extends Fragment {
     }
 
     /**
-     * (Re-)registers the tick listener with {@link SleepTimerManager}.
+     * (Re-)registers the UI tick listener with {@link SleepTimerManager}.
      * Called on first bind and whenever the fragment reconnects after rotation.
-     *
-     * <p>When the timer expires (countdown or end-of-track), a 10-second
-     * fade-out is applied before the player is paused, giving a much more
-     * pleasant user experience than an abrupt stop.
+     * Fade-out and pause are now handled by BaseMediaService via its own
+     * ServiceActionListener — this callback only refreshes the UI label.
      */
     private void connectSleepTimerTick(MediaBrowser mediaBrowser) {
-        SleepTimerManager.getInstance().setTickListener(expired -> {
-            if (expired) {
-                startFadeOutThenPause(mediaBrowser);
-            }
-            updateSleepTimerUI();
-        });
-    }
-
-    // -------------------------------------------------------------------------
-    // Fade-out (called when sleep timer expires)
-    // -------------------------------------------------------------------------
-
-    /** Duration of the fade-out in milliseconds. */
-    private static final long FADE_DURATION_MS = 10_000L;
-    /** Number of volume steps during the fade. */
-    private static final int  FADE_STEPS       = 40;
-
-    // End-of-track fade poller — polls position to start the fade on the right track.
-    private final Handler endOfTrackHandler = new Handler(Looper.getMainLooper());
-    private Runnable endOfTrackPoller = null;
-    /** Signals a running fade to stop and restore volume (e.g. when a transition fires early). */
-    private volatile boolean abortCurrentFade = false;
-
-    /**
-     * Gradually lowers the player volume to zero over {@link #FADE_DURATION_MS},
-     * then pauses playback and restores full volume.
-     * Respects {@link #abortCurrentFade}: if set before a step runs, the fade
-     * stops and volume is immediately restored (used when a track transition
-     * fires before the fade finishes).
-     */
-    private void startFadeOutThenPause(MediaBrowser mediaBrowser) {
-        final long stepMs     = FADE_DURATION_MS / FADE_STEPS;
-        final float decrement = 1.0f / FADE_STEPS;
-        final float[] volume  = {1.0f}; // always fade from full regardless of current value
-
-        abortCurrentFade = false;
-
-        Handler fadeHandler = new Handler(Looper.getMainLooper());
-        Runnable fadeStep = new Runnable() {
-            @Override
-            public void run() {
-                if (!isAdded() || abortCurrentFade) {
-                    mediaBrowser.setVolume(1.0f);
-                    return;
-                }
-                volume[0] = Math.max(0f, volume[0] - decrement);
-                mediaBrowser.setVolume(volume[0]);
-                if (volume[0] > 0f) {
-                    fadeHandler.postDelayed(this, stepMs);
-                } else {
-                    // Fade complete — cancel the timer (no-op if countdown already
-                    // expired) and pause.  This also resets the UI via the tick listener.
-                    SleepTimerManager.getInstance().cancelTimer();
-                    mediaBrowser.pause();
-                    fadeHandler.postDelayed(() -> mediaBrowser.setVolume(1.0f), 300);
-                }
-            }
-        };
-        fadeHandler.post(fadeStep);
-    }
-
-    /**
-     * Polls playback position every 500 ms while end-of-track is armed.
-     * Triggers {@link #startFadeOutThenPause} when the current track has
-     * {@link #FADE_DURATION_MS} or fewer milliseconds remaining, ensuring
-     * the fade happens on the correct track rather than the next one.
-     */
-    private void armEndOfTrackFadePoller(MediaBrowser mediaBrowser) {
-        stopEndOfTrackPoller();
-        abortCurrentFade = false;
-        endOfTrackPoller = new Runnable() {
-            boolean fadeStarted = false;
-
-            @Override
-            public void run() {
-                if (!isAdded() || !SleepTimerManager.getInstance().isEndOfTrack()) return;
-                if (fadeStarted) return; // fade is already running — stop polling
-
-                long duration = mediaBrowser.getDuration();
-                long position = mediaBrowser.getCurrentPosition();
-
-                if (duration > 0 && duration != androidx.media3.common.C.TIME_UNSET) {
-                    long remaining = duration - position;
-                    if (remaining > 0 && remaining <= FADE_DURATION_MS) {
-                        fadeStarted = true;
-                        startFadeOutThenPause(mediaBrowser);
-                        return; // don't reschedule — fade has taken over
-                    }
-                }
-                endOfTrackHandler.postDelayed(this, 500);
-            }
-        };
-        endOfTrackHandler.post(endOfTrackPoller);
-    }
-
-    private void stopEndOfTrackPoller() {
-        if (endOfTrackPoller != null) {
-            endOfTrackHandler.removeCallbacks(endOfTrackPoller);
-            endOfTrackPoller = null;
-        }
+        SleepTimerManager.getInstance().setTickListener(expired -> updateSleepTimerUI());
     }
 
     /**

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
@@ -262,11 +262,6 @@ public class PlayerControllerFragment extends Fragment {
             }
 
             @Override
-            public void onMediaItemTransition(@androidx.annotation.Nullable androidx.media3.common.MediaItem mediaItem, int reason) {
-                // End-of-track abort and fade logic now handled by BaseMediaService.
-            }
-
-            @Override
             public void onShuffleModeEnabledChanged(boolean shuffleModeEnabled) {
                 Preferences.setShuffleModeEnabled(shuffleModeEnabled);
             }

--- a/app/src/main/java/com/cappielloantonio/tempo/util/SleepTimerManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/SleepTimerManager.java
@@ -38,6 +38,20 @@ public class SleepTimerManager {
         void onTick(boolean expired);
     }
 
+    /**
+     * Listener registered by {@link com.cappielloantonio.tempo.service.BaseMediaService}
+     * to drive the fade-out and pause actions from the service process.
+     * Receives the same expired signal as {@link TickListener} but is kept
+     * separate so UI concerns (tick label refresh) and playback actions
+     * (fade, pause) are decoupled.
+     */
+    public interface ServiceActionListener {
+        /** Called every second for countdown updates, and with expired=true when the timer fires. */
+        void onTick(boolean expired);
+        /** Called immediately when end-of-track mode is armed, so the service can start its poller. */
+        void onEndOfTrackArmed();
+    }
+
     // SharedPreferences keys
     private static final String PREF_END_TIME_MS = "sleep_timer_end_time_ms";
     private static final String PREF_END_OF_TRACK = "sleep_timer_end_of_track";
@@ -52,6 +66,7 @@ public class SleepTimerManager {
     private boolean endOfTrack = false;
 
     private TickListener tickListener;
+    private ServiceActionListener serviceActionListener;
 
     private SleepTimerManager() {
         restoreFromPreferences();
@@ -90,6 +105,7 @@ public class SleepTimerManager {
         persistState();
         // Notify immediately so the UI can reflect the active state.
         if (tickListener != null) tickListener.onTick(false);
+        if (serviceActionListener != null) serviceActionListener.onEndOfTrackArmed();
     }
 
     /**
@@ -120,6 +136,14 @@ public class SleepTimerManager {
         long minutes = ms / 60_000;
         long seconds = (ms % 60_000) / 1000;
         return String.format("%d:%02d", minutes, seconds);
+    }
+
+    /**
+     * Attach or detach the service-side action listener.
+     * Pass {@code null} when the service is destroyed.
+     */
+    public void setServiceActionListener(ServiceActionListener listener) {
+        this.serviceActionListener = listener;
     }
 
     /**
@@ -167,8 +191,10 @@ public class SleepTimerManager {
                 scheduledTick = null;
                 clearPersistedState();
                 if (tickListener != null) tickListener.onTick(true);
+                if (serviceActionListener != null) serviceActionListener.onTick(true);
             } else {
                 if (tickListener != null) tickListener.onTick(false);
+                if (serviceActionListener != null) serviceActionListener.onTick(false);
                 scheduleNextTick();
             }
         };

--- a/app/src/main/java/com/cappielloantonio/tempo/util/SleepTimerManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/SleepTimerManager.java
@@ -4,6 +4,9 @@ import android.content.SharedPreferences;
 import android.os.Handler;
 import android.os.Looper;
 
+import androidx.media3.common.C;
+import androidx.media3.common.Player;
+
 import com.cappielloantonio.tempo.App;
 
 /**
@@ -22,10 +25,15 @@ import com.cappielloantonio.tempo.App;
  * in-process tick loop from the correct wall-clock end time.
  *
  * <h3>End-of-track mode</h3>
- * {@link #startEndOfTrack()} arms a one-shot stop that fires the next time
- * the caller invokes {@link #notifyTrackEnded()}.  This is deliberately
- * driven from the outside (the UI layer owns the player listener) so that
- * this class stays free of Android-framework player dependencies.
+ * {@link #startEndOfTrack()} arms a one-shot stop.  Once armed,
+ * {@link #armEndOfTrackFadePoller(Player)} polls playback position and
+ * triggers a fade-out when the track is about to end.
+ *
+ * <h3>Fade-out</h3>
+ * {@link #startFadeOutThenPause(Player)} and {@link #armEndOfTrackFadePoller(Player)}
+ * live here (not in BaseMediaService) so that all sleep-timer logic is
+ * consolidated in one place and BaseMediaService stays free of auxiliary
+ * sleep-timer state.
  */
 public class SleepTimerManager {
 
@@ -48,7 +56,10 @@ public class SleepTimerManager {
     public interface ServiceActionListener {
         /** Called every second for countdown updates, and with expired=true when the timer fires. */
         void onTick(boolean expired);
-        /** Called immediately when end-of-track mode is armed, so the service can start its poller. */
+        /**
+         * Called immediately when end-of-track mode is armed, so the service can
+         * call {@link SleepTimerManager#armEndOfTrackFadePoller(Player)} against the live player.
+         */
         void onEndOfTrackArmed();
     }
 
@@ -60,6 +71,16 @@ public class SleepTimerManager {
 
     private final Handler handler = new Handler(Looper.getMainLooper());
     private Runnable scheduledTick;
+
+    /** Duration of the volume fade-out in milliseconds. */
+    private static final long FADE_DURATION_MS = 10_000L;
+    /** Number of discrete volume steps during the fade. */
+    private static final int FADE_STEPS = 40;
+
+    /** Set to true to abort an in-progress fade (e.g. track transition fired early). */
+    private volatile boolean abortCurrentFade = false;
+
+    private Runnable endOfTrackPoller;
 
     private long endTimeMs = 0;
     private boolean active = false;
@@ -158,6 +179,85 @@ public class SleepTimerManager {
     }
 
     // -------------------------------------------------------------------------
+    // Fade-out and end-of-track polling
+    // -------------------------------------------------------------------------
+
+    /**
+     * Gradually lowers the player volume to zero over {@link #FADE_DURATION_MS}, then
+     * pauses and restores full volume. Respects {@link #abortCurrentFade}.
+     */
+    public void startFadeOutThenPause(Player player) {
+        long stepMs = FADE_DURATION_MS / FADE_STEPS;
+        float decrement = 1f / FADE_STEPS;
+        float[] volume = {1f};
+
+        abortCurrentFade = false;
+
+        Runnable fadeStep = new Runnable() {
+            @Override
+            public void run() {
+                if (abortCurrentFade) {
+                    player.setVolume(1f);
+                    return;
+                }
+                volume[0] = Math.max(0f, volume[0] - decrement);
+                player.setVolume(volume[0]);
+                if (volume[0] > 0f) {
+                    handler.postDelayed(this, stepMs);
+                } else {
+                    // Fade complete — cancel the timer and pause.
+                    cancelTimer();
+                    player.pause();
+                    handler.postDelayed(() -> player.setVolume(1f), 300);
+                }
+            }
+        };
+        handler.post(fadeStep);
+    }
+
+    /**
+     * Polls playback position every 500 ms while end-of-track is armed.
+     * Kicks off {@link #startFadeOutThenPause(Player)} when {@link #FADE_DURATION_MS}
+     * or fewer milliseconds remain on the current track.
+     */
+    public void armEndOfTrackFadePoller(Player player) {
+        stopEndOfTrackPoller();
+        abortCurrentFade = false;
+
+        endOfTrackPoller = new Runnable() {
+            boolean fadeStarted = false;
+
+            @Override
+            public void run() {
+                if (!isEndOfTrack()) return;
+                if (fadeStarted) return;
+
+                long duration = player.getDuration();
+                long position = player.getCurrentPosition();
+
+                if (duration > 0 && duration != C.TIME_UNSET) {
+                    long remaining = duration - position;
+                    if (remaining >= 1 && remaining <= FADE_DURATION_MS) {
+                        fadeStarted = true;
+                        startFadeOutThenPause(player);
+                        return;
+                    }
+                }
+                handler.postDelayed(this, 500);
+            }
+        };
+        handler.post(endOfTrackPoller);
+    }
+
+    /** Cancels any running end-of-track position poller. */
+    public void stopEndOfTrackPoller() {
+        if (endOfTrackPoller != null) {
+            handler.removeCallbacks(endOfTrackPoller);
+            endOfTrackPoller = null;
+        }
+    }
+
+    // -------------------------------------------------------------------------
     // Internal helpers
     // -------------------------------------------------------------------------
 
@@ -170,10 +270,12 @@ public class SleepTimerManager {
         active = false;
         endOfTrack = false;
         endTimeMs = 0;
+        abortCurrentFade = true;
         if (scheduledTick != null) {
             handler.removeCallbacks(scheduledTick);
             scheduledTick = null;
         }
+        stopEndOfTrackPoller();
         clearPersistedState();
         if (notifyListener && tickListener != null) {
             // expired=false: player keeps playing after a manual cancel.


### PR DESCRIPTION
The sleep timer's fade-out, end-of-track poller, and pause logic lived in PlayerControllerFragment, tying it to the Fragment lifecycle. If the Fragment was destroyed during background playback (eg. screen off), the timer would expire silently with no fade or pause.

### Changes

**SleepTimerManager** — Added ServiceActionListener interface with onTick(expired) and onEndOfTrackArmed() callbacks, decoupling playback actions from UI updates. startEndOfTrack() now notifies the service listener immediately on arm.
**BaseMediaService** — Implements ServiceActionListener to own the fade-out loop, end-of-track position poller, and pause. Logic survives Fragment destruction since the service runs as a foreground MediaSessionService. Also handles re-arming the poller on service restart when end-of-track state is restored from SharedPreferences.
**PlayerControllerFragment** — Removed startFadeOutThenPause, armEndOfTrackFadePoller, stopEndOfTrackPoller, and all associated fields. TickListener is now UI-only (label refresh and button tint).

### Result
The sleep timer fires correctly during background playback regardless of Fragment state. No behaviour changes from the user's perspective.

Fixes #708 