### PR TITLE
Make some of the equalizer strings translatable

### DIFF
--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -636,6 +636,9 @@
     <string name="equalizer_managed_externally">Equalizer jest zarządzany przez system lub inną aplikację</string>
     <string name="settings_app_equalizer">Wbudowany equalizer</string>
     <string name="settings_app_equalizer_summary">Otwórz wbudowany korektor dźwięku</string>
+    <string name="settings_title_equalizer">Equalizer</string>
+    <string name="settings_equalizer_select">Wybierz equalizer do użycia</string>
+    <string name="settings_equalizer_dialog_title">Equalizery</string>
     <string name="settings_album_detail">Pokaż szczegóły albumu</string>
     <string name="settings_album_detail_summary">Jeżeli włączone, pokaż szczegóły albumu takie jak gatunek, ilość piosenek itp. na stronie albumu</string>
     <string name="settings_artist_sort_by_album_count">Sortuj wykonawców po ilości albumów</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -636,6 +636,9 @@
     <string name="equalizer_managed_externally">Equalizer managed by system or third party app</string>
     <string name="settings_app_equalizer">Built-in equalizer</string>
     <string name="settings_app_equalizer_summary">Open the built-in equalizer</string>
+    <string name="settings_title_equalizer">Equalizer</string>
+    <string name="settings_equalizer_select">Select an equalizer to use</string>
+    <string name="settings_equalizer_dialog_title">Equalizers</string>
 
     <string name="settings_album_detail">Show album detail</string>
     <string name="settings_album_detail_summary">If enabled, show the album details like genre, song count etc. on the album page</string>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -157,12 +157,12 @@
 
     <com.cappielloantonio.tempo.util.ClickablePreferenceCategory app:title="@string/settings_title_sound">
 
-        <PreferenceCategory app:title="Equalizer">
+        <PreferenceCategory app:title="@string/settings_title_equalizer">
             <ListPreference
                 android:key="selected_equalizer"
-                android:title="Select an equalizer to use"
+                android:title="@string/settings_equalizer_select"
                 android:summary="None"
-                android:dialogTitle="Equalizers"
+                android:dialogTitle="@string/settings_equalizer_dialog_title"
                 android:entries="@array/selected_equalizer_entries"
                 android:entryValues="@array/selected_equalizer_values"
                 android:defaultValue="0" />


### PR DESCRIPTION
Some of the strings were not translatable. I'm showing Polish in the screenshot below since English would look unchanged.
Before:
<img width="1080" height="2400" alt="Screenshot_20260609-123038_Tempus" src="https://github.com/user-attachments/assets/47d79bf3-6607-4754-a095-39d6ffcfad78" />

<img width="1080" height="2400" alt="Screenshot_20260609-123041_Tempus" src="https://github.com/user-attachments/assets/f13c9e2a-94b8-4fce-aa65-efb7f7a9574f" />

After:
<img width="1080" height="2400" alt="Screenshot_20260609-131557_Tempus" src="https://github.com/user-attachments/assets/b286bb0f-ac55-46c7-8dba-9774712bba1b" />
<img width="1080" height="2400" alt="Screenshot_20260609-131559_Tempus" src="https://github.com/user-attachments/assets/fdaba568-4c0e-46db-89b0-68a21e91aa52" />
