### PR TITLE
fix: prevent crashes on "Best Of"and "Radio Station" home music tab  …

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/repository/ArtistRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/ArtistRepository.java
@@ -341,7 +341,7 @@ public class ArtistRepository {
     }
 
     public MutableLiveData<List<Child>> getTopSongs(String artistName, int count) {
-        MutableLiveData<List<Child>> topSongs = new MutableLiveData<>(null);
+        MutableLiveData<List<Child>> topSongs = new MutableLiveData<>(new ArrayList<>());
 
         App.getSubsonicClientInstance(false)
                 .getBrowsingClient()
@@ -360,13 +360,13 @@ public class ArtistRepository {
                                     .getTopSongs()
                                     .getSongs();
                         }
-                        topSongs.setValue(fetched);
+                        topSongs.setValue(fetched != null ? fetched : new ArrayList<>());
                     }
 
                     @Override
                     public void onFailure(@NonNull Call<ApiResponse> call,
                                           @NonNull Throwable t) {
-                        topSongs.setValue(null);
+                        topSongs.setValue(new ArrayList<>());
                     }
                 });
 

--- a/app/src/main/java/com/cappielloantonio/tempo/repository/QueueRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/QueueRepository.java
@@ -145,7 +145,8 @@ public class QueueRepository {
             }
 
             final List<Queue> finalMedia = media;
-            List<Child> filteredToAdd = toAdd.stream()
+            List<Child> toAddCopy = new ArrayList<>(toAdd);
+            List<Child> filteredToAdd = toAddCopy.stream()
                     .filter(child -> !isMediaInQueue(finalMedia, child))
                     .collect(Collectors.toList());
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
@@ -101,6 +101,7 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
     private ShareHorizontalAdapter shareHorizontalAdapter;
 
     private ListenableFuture<MediaBrowser> mediaBrowserListenableFuture;
+    private Observer<List<Child>> bestOfObserver = null;
 
     @Nullable
     @Override
@@ -1313,18 +1314,19 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
                 homeViewModel.getArtistInstantMix(getViewLifecycleOwner(), bundle.getParcelable(Constants.ARTIST_OBJECT)).observe(getViewLifecycleOwner(), songs -> {
                     MusicUtil.ratingFilter(songs);
 
-                    if (!songs.isEmpty()) {
+                    if (songs != null && !songs.isEmpty()) {
                         MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
                         activity.setBottomSheetInPeek(true);
                     }
                 });
             }
         } else if (bundle.containsKey(Constants.MEDIA_BEST_OF) && bundle.getBoolean(Constants.MEDIA_BEST_OF)) {
+            ArtistID3 artist = bundle.getParcelable(Constants.ARTIST_OBJECT);
+            if (artist == null) return;
             if (mediaBrowserListenableFuture != null) {
-                homeViewModel.getArtistBestOf(getViewLifecycleOwner(), bundle.getParcelable(Constants.ARTIST_OBJECT)).observe(getViewLifecycleOwner(), songs -> {
+                homeViewModel.getArtistBestOf(artist).observe(getViewLifecycleOwner(), songs -> {
                     MusicUtil.ratingFilter(songs);
-
-                    if (!songs.isEmpty()) {
+                    if (songs != null && !songs.isEmpty()) {
                         MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
                         activity.setBottomSheetInPeek(true);
                     }

--- a/app/src/main/java/com/cappielloantonio/tempo/viewmodel/HomeViewModel.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/viewmodel/HomeViewModel.java
@@ -7,6 +7,7 @@ import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Observer;
 
 import com.cappielloantonio.tempo.interfaces.StarCallback;
 import com.cappielloantonio.tempo.model.Chronology;
@@ -67,7 +68,6 @@ public class HomeViewModel extends AndroidViewModel {
     private final MutableLiveData<List<Chronology>> thisGridTopSong = new MutableLiveData<>(null);
     private final MutableLiveData<List<Child>> mediaInstantMix = new MutableLiveData<>(null);
     private final MutableLiveData<List<Child>> artistInstantMix = new MutableLiveData<>(null);
-    private final MutableLiveData<List<Child>> artistBestOf = new MutableLiveData<>(null);
     private final MutableLiveData<List<Playlist>> pinnedPlaylists = new MutableLiveData<>(null);
     private final MutableLiveData<List<Share>> shares = new MutableLiveData<>(null);
 
@@ -237,12 +237,23 @@ public class HomeViewModel extends AndroidViewModel {
         return artistInstantMix;
     }
 
-    public LiveData<List<Child>> getArtistBestOf(LifecycleOwner owner, ArtistID3 artist) {
-        artistBestOf.setValue(Collections.emptyList());
+    public LiveData<List<Child>> getArtistBestOf(ArtistID3 artist) {
+        MutableLiveData<List<Child>> result = new MutableLiveData<>();
+        if (artist == null) {
+            result.setValue(new ArrayList<>());
+            return result;
+        }
 
-        artistRepository.getTopSongs(artist.getName(), 10).observe(owner, artistBestOf::postValue);
+        artistRepository.getTopSongs(artist.getName(), 10).observeForever(new Observer<List<Child>>() {
+            @Override
+            public void onChanged(List<Child> songs) {
+                List<Child> safeSongs = songs != null ? songs : new ArrayList<>();
+                result.setValue(safeSongs);
+                artistRepository.getTopSongs(artist.getName(), 10).removeObserver(this);
+            }
+        });
 
-        return artistBestOf;
+        return result;
     }
 
     public LiveData<List<Playlist>> getPinnedPlaylists(LifecycleOwner owner) {


### PR DESCRIPTION
Resolves #691

- Return empty list in ArtistRepository.getTopSongs() when no data
- Make HomeViewModel.getArtistBestOf()  return per-call LiveData
- Add null check for artist in HomeTabMusicFragment
- Defensive copy in QueueRepository.insertAll() to avoid ConcurrentModificationException

Fixes NPE on first click and ConcurrentModificationException on subsequent clicks.

video:
<details>

[Screen_recording_20260613_142041.webm](https://github.com/user-attachments/assets/3fb0307c-c6fc-45cd-b376-a1e97fc5f1fd)

<details>