### PR TITLE
fix: deep-linked playlist loads no songs and crashes from null id (#729)

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/database/dao/PlaylistDao.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/database/dao/PlaylistDao.java
@@ -23,6 +23,13 @@ public interface PlaylistDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void insert(Playlist playlist);
 
+    // Insert only if the row is absent. REPLACE would delete-then-reinsert an existing
+    // playlist, which fails the playlist_song foreign key when its songs already exist
+    // (and can race when several callers cache the same playlist at once). Used to make
+    // sure a deep-linked playlist's row exists before caching its songs. See issue #729.
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    void insertIfAbsent(Playlist playlist);
+
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void insertAll(List<Playlist> playlists);
 

--- a/app/src/main/java/com/cappielloantonio/tempo/repository/PlaylistRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/PlaylistRepository.java
@@ -177,7 +177,7 @@ public class PlaylistRepository {
                                     songs = new ArrayList<>();
                                 }
                                 listLivePlaylistSongs.setValue(songs);
-                                cachePlaylistSongs(id, songs);
+                                cachePlaylistSongs(sr.getPlaylist(), songs);
                             } else if (sr.getError() != null && sr.getError().getCode() != null && sr.getError().getCode() == 70) {
                                 // Subsonic Standard Error Code 70: The requested data was not found.
                                 handleMissingPlaylist(id, null);
@@ -199,8 +199,16 @@ public class PlaylistRepository {
         return listLivePlaylistSongs;
     }
 
-    private void cachePlaylistSongs(String playlistId, List<Child> songs) {
+    private void cachePlaylistSongs(Playlist playlist, List<Child> songs) {
         new Thread(() -> {
+            String playlistId = playlist.getId();
+            // playlist_song has a foreign key to playlist.id, so the playlist row must
+            // exist before its songs are inserted. The full-list path caches playlists via
+            // cacheAllPlaylists, but the single-playlist endpoint (used by deep links) does
+            // not — without this the songs insert crashes with a FOREIGN KEY constraint.
+            // Insert before the early-return dedup checks so the row is ensured even when
+            // the songs are already cached. See issue #729.
+            playlistDao.insertIfAbsent(playlist);
             List<PlaylistSong> cached = playlistSongDao.getSongsForPlaylistSync(playlistId);
             if (songs == null || songs.isEmpty()) {
                 if (cached != null && !cached.isEmpty()) {

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/models/PlaylistWithSongs.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/models/PlaylistWithSongs.kt
@@ -8,8 +8,24 @@ import kotlinx.parcelize.Parcelize
 @Keep
 @Parcelize
 class PlaylistWithSongs(
-    @SerializedName("_id")
-    override var id: String,
     @SerializedName("entry")
     var entries: List<Child>? = null,
-) : Playlist(id), Parcelable
+) : Playlist(""), Parcelable {
+
+    // Do NOT redeclare `id` here. Overriding the base property creates a second `id`
+    // backing field, and Gson then sees two JSON fields named "id" (this class's and
+    // Playlist's) and throws "declares multiple JSON fields named 'id'" at startup.
+    // The previous workaround mapped this field to "_id", which dodged the clash but
+    // left the id null for the Subsonic getPlaylist response (it sends "id"): opening a
+    // playlist by id — e.g. a tempo://asset/playlist/<id> deep link — then re-fetched
+    // its songs with a null id, the server replied "missing parameter: 'id'", the page
+    // showed a perpetual spinner plus a misleading "Playlist not found" dialog, and the
+    // null id later crashed with a String.equals NPE. Inheriting Playlist.id (which maps
+    // "id" correctly) fixes all of that; the value still survives Parcelize because the
+    // base class is @Parcelize too. See issue #729.
+
+    // The synthetic "all songs" search result is built locally with a fixed id.
+    constructor(id: String, entries: List<Child>?) : this(entries) {
+        this.id = id
+    }
+}


### PR DESCRIPTION
Fixes #729.

### Problem
Opening a playlist by id — e.g. a `tempo://asset/playlist/<id>` deep link from
Tasker — shows the playlist's metadata but never its songs (endless spinner),
then crashes after a minute or two.

### Root cause
`PlaylistWithSongs` (the type the Subsonic `getPlaylist` response deserializes
into) annotated its `id` with `@SerializedName("_id")`, but the API sends `id`.
The `_id` was a workaround for Gson's "declares multiple JSON fields named 'id'"
error (the property shadows `Playlist.id`), but it left the id null. The page
then re-fetched the songs with a null id; Retrofit drops the null `@Query("id")`,
the server replies `error 10: missing parameter: 'id'`, and the song list spins
forever behind a misleading "Playlist not found" dialog. The null id is also what
produces the reported `String.equals` NPE. Opening a playlist from the in-app
list works because the list endpoint deserializes the base `Playlist`, which maps
`id` correctly.

### Fix
- `PlaylistWithSongs` no longer redeclares `id`; it inherits `Playlist.id`, which
  maps `id` correctly. The value still survives `@Parcelize` (the base class is
  `@Parcelize` too), and a secondary constructor keeps the local "all songs" use.
- Caching a deep-linked playlist's songs then hit a `FOREIGN KEY` constraint,
  because the single-playlist endpoint never inserts the playlist row (only the
  full-list path does, via `cacheAllPlaylists`). `cachePlaylistSongs` now inserts
  the parent first, via a new `insertIfAbsent` (`IGNORE`) so it can't
  delete-replace a row that already has child songs.

### Testing
Verified on an android-35 emulator against the Navidrome public demo:
- Before: deep link → metadata shown, songs spinner forever, "Playlist not found"
  dialog, then crash.
- After: deep link loads metadata, cover art and the full song list; no crash,
  no FK violation, no false "not found"; back-to-back deep links to two different
  playlists both succeed.

Builds successfully on the development toolchain (Gradle 9.4.1 / AGP 9.2.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
