### PR TITLE
fix: recover playback after a network switch instead of freezing (#682)

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -145,8 +145,35 @@ open class BaseMediaService : MediaLibraryService() {
     private var lastRadioArtist: String? = null
     private var lastRadioTitle: String? = null
 
+    // Throttle for onPlayerError re-prepare recovery (see #682).
+    private var lastPlayerErrorRecoveryMs = 0L
+    private val playerErrorRecoveryThrottleMs = 5_000L
+
     fun initializePlayerListener(player: Player) {
         player.addListener(object : Player.Listener {
+            override fun onPlayerError(error: PlaybackException) {
+                // A network switch (WiFi <-> mobile) surfaces here as a source/network
+                // error. Without recovery the player goes idle and stays silent until the
+                // app is restarted (issue #682). Re-prepare to resume from the current
+                // position, but only for recoverable IO errors and throttled so a permanent
+                // failure (bad URL, auth) can't spin in an endless prepare loop.
+                Log.w(TAG, "onPlayerError: ${error.errorCodeName}", error)
+
+                val recoverable = when (error.errorCode) {
+                    PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_FAILED,
+                    PlaybackException.ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT,
+                    PlaybackException.ERROR_CODE_IO_UNSPECIFIED -> true
+                    else -> false
+                }
+                if (!recoverable) return
+
+                val now = android.os.SystemClock.elapsedRealtime()
+                if (now - lastPlayerErrorRecoveryMs >= playerErrorRecoveryThrottleMs) {
+                    lastPlayerErrorRecoveryMs = now
+                    player.prepare()
+                }
+            }
+
             override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
                 Log.d(TAG, "onMediaItemTransition" + player.currentMediaItemIndex)
                 if (mediaItem == null) return


### PR DESCRIPTION
Fixes #682.

### Problem
Switching network (WiFi ⇄ mobile) while a track is playing freezes playback — the player goes silent and stays that way until the app is restarted.

### Root cause
`BaseMediaService`'s `Player.Listener` has no `onPlayerError` override. A mid-stream network change surfaces as a source/network `PlaybackException`, ExoPlayer transitions to the idle/error state, and nothing re-prepares it, so playback never resumes.

### Fix
Add `onPlayerError` to the listener. For recoverable IO errors only — `ERROR_CODE_IO_NETWORK_CONNECTION_FAILED`, `ERROR_CODE_IO_NETWORK_CONNECTION_TIMEOUT`, `ERROR_CODE_IO_UNSPECIFIED` — it calls `player.prepare()` to resume from the current position. It's throttled to once per 5s so a permanent failure (bad URL, auth) can't spin in an endless prepare loop; other error codes are left to surface normally.

### Testing
Build green; emulator no-regression smoke (listener registers, service inits, normal playback unaffected). The live network-switch recovery was not reproduced on the emulator (needs a real server + a mid-stream interface change) — it follows the standard Media3 re-prepare-on-recoverable-error pattern, and the missing handler is the direct cause of the freeze.

Builds successfully on the development toolchain (Gradle 9.4.1 / AGP 9.2.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved playback error handling with smarter differentiation between recoverable network/I/O errors and permanent failures
  * Added intelligent throttling to control the frequency of automatic recovery procedures during connectivity problems
  * Enhanced overall playback stability during transient network interruptions with optimized recovery intervals

<!-- end of auto-generated comment: release notes by coderabbit.ai -->