### PR TITLE
fix: skip un-mappable songs when restoring the play queue (#705)

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/util/MappingUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/MappingUtil.java
@@ -36,7 +36,18 @@ public class MappingUtil {
         ArrayList<MediaItem> mediaItems = new ArrayList<>();
 
         for (int i = 0; i < items.size(); i++) {
-            mediaItems.add(mapMediaItem(items.get(i)));
+            Child item = items.get(i);
+            try {
+                mediaItems.add(mapMediaItem(item));
+            } catch (Exception e) {
+                // A single un-mappable saved song (e.g. a cached queue entry whose
+                // Subsonic data lost fields after a server/library change) must not
+                // abort the whole batch. This runs during play-queue restore in
+                // MediaService.onCreate, so a thrown exception crashed the app on
+                // launch. Skip the bad item and keep the rest. See issue #705.
+                Log.e(TAG, "Skipping un-mappable song in queue restore: "
+                        + (item != null ? item.getId() : "null"), e);
+            }
         }
 
         return mediaItems;


### PR DESCRIPTION
Fixes #705.

### Problem
A single bad cached queue entry crashes the app on launch, recoverable only by clearing app data. The original report couldn't pin down the trigger.

### Root cause
`MappingUtil.mapMediaItems` maps every saved song and lets any per-item failure propagate. Play-queue restore runs in `MediaService.onCreate`, so one un-mappable entry — e.g. a cached song whose Subsonic data lost fields after a server/library change ("Mapping failed for song ID …") — throws and takes down the whole launch.

### Fix
Wrap each item's `mapMediaItem` in try/catch: log and skip the offending song, keep the rest of the queue. A single corrupt entry can no longer abort restore.

### Testing
Build green; emulator no-regression smoke (MediaService.onCreate restores the queue, 0 crashes). Not reproduced live because the trigger is data-dependent (an un-mappable cached entry) — verified by the code path (the rethrow during `onCreate` restore is the crash) plus a clean-launch smoke.

Builds successfully on the development toolchain (Gradle 9.4.1 / AGP 9.2.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved media item loading so a single problematic item no longer stops the entire list from being processed.
  * When an item can’t be mapped, the app now skips that item and continues with the rest of the results.
  * Added clearer error logging to help identify which item failed when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->