### PR TITLE
fix: cancel leaked player/home callbacks that retain MainActivity (#777)

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/DiscoverSongAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/DiscoverSongAdapter.java
@@ -70,6 +70,16 @@ public class DiscoverSongAdapter extends RecyclerView.Adapter<DiscoverSongAdapte
     }
 
     @Override
+    public void onViewDetachedFromWindow(@NonNull ViewHolder holder) {
+        super.onViewDetachedFromWindow(holder);
+        // #777: cancel the long (20s) scale animation when the row leaves the window.
+        // A running ViewPropertyAnimator is referenced by the global AnimationHandler,
+        // which would otherwise retain this ImageView — and, via View.mContext, the
+        // whole destroyed MainActivity and its cover-art bitmaps — until the app OOMs.
+        holder.item.discoverSongCoverImageView.animate().cancel();
+    }
+
+    @Override
     public int getItemCount() {
         return songs.size();
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerBottomSheetFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerBottomSheetFragment.java
@@ -86,6 +86,13 @@ public class PlayerBottomSheetFragment extends Fragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+        // #777: cancel the self-reposting progress updater. Otherwise its pending
+        // Handler message keeps this destroyed fragment alive — and, via the
+        // MediaBrowser the runnable captures, the whole MainActivity and its
+        // cover-art bitmaps — leaking ~3MB per Activity recreation until OOM.
+        if (progressBarHandler != null) {
+            progressBarHandler.removeCallbacks(progressBarRunnable);
+        }
         bind = null;
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerCoverFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerCoverFragment.java
@@ -79,6 +79,9 @@ public class PlayerCoverFragment extends Fragment {
     @Override
     public void onDestroyView() {
         super.onDestroyView();
+        // #777: drop the pending tap-button-hide runnable (postDelayed 10s) so its
+        // queued main-thread message can't retain this destroyed fragment.
+        handler.removeCallbacksAndMessages(null);
         bind = null;
     }
 


### PR DESCRIPTION
Fixes #777.

### Problem
Memory climbs across Activity recreations (rotating while playing, switching apps, …) until the app hits an `OutOfMemoryError`. Each recreation leaks the previous `MainActivity` and its tens of MB of cover-art bitmaps.

### Root cause
Three independent async callbacks outlive their view and each retains the destroyed `MainActivity` as a separate GC root:
1. **`PlayerBottomSheetFragment.progressBarRunnable`** — a self-reposting (1s) seekbar updater, only cancelled on pause, never on view destroy. Its pending Handler message keeps the fragment alive and, via the `MediaBrowser` it captures, MainActivity.
2. **`DiscoverSongAdapter`** — a 20s scale animation started in `onViewAttachedToWindow`, never cancelled. The running `ViewPropertyAnimator` is held by the global `AnimationHandler` → cover ImageView → (via `View.mContext`) MainActivity.
3. **`PlayerCoverFragment`** — a 10s tap-hide `postDelayed` not cleared on destroy.

### Fix
Cancel each in the matching lifecycle callback:
- `PlayerBottomSheetFragment.onDestroyView` → `removeCallbacks(progressBarRunnable)`
- `DiscoverSongAdapter.onViewDetachedFromWindow` → `animate().cancel()`
- `PlayerCoverFragment.onDestroyView` → `removeCallbacksAndMessages(null)`

### Testing
Verified with LeakCanary in my fork's debug build using a 12×-rotate-while-playing stress test: before, consistent `APPLICATION LEAKS` with MainActivity retained ~14× via these GC roots; after, **0 application leaks** across two heap dumps. (LeakCanary itself is not part of this PR.) Build green; normal playback unaffected.

Builds successfully on the development toolchain (Gradle 9.4.1 / AGP 9.2.1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by stopping pending UI animations and delayed actions when screens are closed.
  * Reduced the risk of app freezes or memory leaks by clearing background updates and view callbacks after fragments are destroyed.
  * Prevented image and playback controls from continuing to update after their screen is no longer visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->