### PR TITLE
Playlist menu changes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -135,6 +135,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation 'org.mockito:mockito-core:5.12.0'
     testImplementation 'org.mockito.kotlin:mockito-kotlin:5.4.0'
+    testImplementation 'androidx.arch.core:core-testing:2.2.0'
 
 }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/interfaces/ClickCallback.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/interfaces/ClickCallback.java
@@ -2,6 +2,7 @@ package com.cappielloantonio.tempo.interfaces;
 
 
 import android.os.Bundle;
+import android.view.View;
 
 import androidx.annotation.Keep;
 
@@ -16,6 +17,9 @@ public interface ClickCallback {
     default void onGenreClick(Bundle bundle) {}
     default void onPlaylistClick(Bundle bundle) {}
     default void onPlaylistLongClick(Bundle bundle) {}
+    default void onPlaylistLongClick(View view, Bundle bundle) {
+        onPlaylistLongClick(bundle);
+    }
     default void onYearClick(Bundle bundle) {}
     default void onServerClick(Bundle bundle) {}
     default void onServerLongClick(Bundle bundle) {}

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PlaylistHorizontalAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PlaylistHorizontalAdapter.java
@@ -2,6 +2,7 @@ package com.cappielloantonio.tempo.ui.adapter;
 
 import android.os.Bundle;
 import android.view.LayoutInflater;
+import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Filter;
 import android.widget.Filterable;
@@ -117,9 +118,9 @@ public class PlaylistHorizontalAdapter extends RecyclerView.Adapter<PlaylistHori
             item.playlistTitleTextView.setSelected(true);
 
             itemView.setOnClickListener(v -> onClick());
-            itemView.setOnLongClickListener(v -> onLongClick());
+            itemView.setOnLongClickListener(this::onLongClick);
 
-            item.playlistMoreButton.setOnClickListener(v -> onLongClick());
+            item.playlistMoreButton.setOnClickListener(this::onLongClick);
         }
 
         public void onClick() {
@@ -129,11 +130,11 @@ public class PlaylistHorizontalAdapter extends RecyclerView.Adapter<PlaylistHori
             click.onPlaylistClick(bundle);
         }
 
-        public boolean onLongClick() {
+        public boolean onLongClick(View v) {
             Bundle bundle = new Bundle();
             bundle.putParcelable(Constants.PLAYLIST_OBJECT, playlists.get(getBindingAdapterPosition()));
 
-            click.onPlaylistLongClick(bundle);
+            click.onPlaylistLongClick(v, bundle);
 
             return true;
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
@@ -1368,7 +1368,15 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
         
         popup.setOnMenuItemClickListener(menuItem -> {
             if (menuItem.getItemId() == R.id.action_go_to_playlist) {
-                onPlaylistClick(bundle);
+                Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
+                if (playlist != null) {
+                    new PlaylistRepository().getPlaylistSongs(playlist.getId()).observe(getViewLifecycleOwner(), songs -> {
+                        if (songs != null && !songs.isEmpty()) {
+                            MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
+                            activity.setBottomSheetInPeek(true);
+                        }
+                    });
+                }
                 return true;
             } else if (menuItem.getItemId() == R.id.action_add_to_queue) {
                 Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
@@ -37,12 +37,14 @@ import com.cappielloantonio.tempo.interfaces.ClickCallback;
 import com.cappielloantonio.tempo.interfaces.PlaylistCallback;
 import com.cappielloantonio.tempo.model.Download;
 import com.cappielloantonio.tempo.model.HomeSector;
+import com.cappielloantonio.tempo.repository.PlaylistRepository;
 import com.cappielloantonio.tempo.service.DownloaderManager;
 import com.cappielloantonio.tempo.service.MediaManager;
 import com.cappielloantonio.tempo.service.MediaService;
 import com.cappielloantonio.tempo.subsonic.models.AlbumID3;
 import com.cappielloantonio.tempo.subsonic.models.ArtistID3;
 import com.cappielloantonio.tempo.subsonic.models.Child;
+import com.cappielloantonio.tempo.subsonic.models.Playlist;
 import com.cappielloantonio.tempo.subsonic.models.Share;
 import com.cappielloantonio.tempo.ui.activity.MainActivity;
 import com.cappielloantonio.tempo.ui.adapter.AlbumAdapter;
@@ -1360,16 +1362,40 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
     }
 
     @Override
-    public void onPlaylistLongClick(Bundle bundle) {
-        PlaylistEditorDialog dialog = new PlaylistEditorDialog(new PlaylistCallback() {
-            @Override
-            public void onDismiss() {
-                refreshPlaylistView();
-            }
-        });
+    public void onPlaylistLongClick(View view, Bundle bundle) {
+        PopupMenu popup = new PopupMenu(requireContext(), view);
+        popup.getMenuInflater().inflate(R.menu.playlist_popup_menu, popup.getMenu());
+        
+        popup.setOnMenuItemClickListener(menuItem -> {
+            if (menuItem.getItemId() == R.id.action_go_to_playlist) {
+                onPlaylistClick(bundle);
+                return true;
+            } else if (menuItem.getItemId() == R.id.action_add_to_queue) {
+                Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
+                if (playlist != null) {
+                    new PlaylistRepository().getPlaylistSongs(playlist.getId()).observe(getViewLifecycleOwner(), songs -> {
+                        if (songs != null && !songs.isEmpty()) {
+                            MediaManager.enqueue(mediaBrowserListenableFuture, songs, false);
+                            Toast.makeText(requireContext(), R.string.playlist_added_to_queue, Toast.LENGTH_SHORT).show();
+                        }
+                    });
+                }
+                return true;
+            } else if (menuItem.getItemId() == R.id.action_edit_playlist) {
+                PlaylistEditorDialog dialog = new PlaylistEditorDialog(new PlaylistCallback() {
+                    @Override
+                    public void onDismiss() {
+                        refreshPlaylistView();
+                    }
+                });
 
-        dialog.setArguments(bundle);
-        dialog.show(activity.getSupportFragmentManager(), null);
+                dialog.setArguments(bundle);
+                dialog.show(activity.getSupportFragmentManager(), null);
+                return true;
+            }
+            return false;
+        });
+        popup.show();
     }
 
     @Override

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
@@ -1385,6 +1385,24 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
                     live.observe(getViewLifecycleOwner(), observer);
                 }
                 return true;
+            } else if (menuItem.getItemId() == R.id.action_play_shuffle) {
+                Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
+                if (playlist != null) {
+                    final LiveData<List<Child>> liveShuffle = new PlaylistRepository().getPlaylistSongs(playlist.getId());
+                    final Observer<List<Child>> observerShuffle = new Observer<List<Child>>() {
+                        @Override
+                        public void onChanged(List<Child> songs) {
+                            if (songs != null && !songs.isEmpty()) {
+                                java.util.Collections.shuffle(songs);
+                                MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
+                                activity.setBottomSheetInPeek(true);
+                                liveShuffle.removeObserver(this);
+                            }
+                        }
+                    };
+                    liveShuffle.observe(getViewLifecycleOwner(), observerShuffle);
+                }
+                return true;
             } else if (menuItem.getItemId() == R.id.action_add_to_queue) {
                 Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
                 if (playlist != null) {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
@@ -17,6 +17,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.core.view.ViewCompat;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.LiveData;
 import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.media3.common.util.UnstableApi;
@@ -1370,23 +1371,35 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
             if (menuItem.getItemId() == R.id.action_go_to_playlist) {
                 Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
                 if (playlist != null) {
-                    new PlaylistRepository().getPlaylistSongs(playlist.getId()).observe(getViewLifecycleOwner(), songs -> {
-                        if (songs != null && !songs.isEmpty()) {
-                            MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
-                            activity.setBottomSheetInPeek(true);
+                    final LiveData<List<Child>> live = new PlaylistRepository().getPlaylistSongs(playlist.getId());
+                    final Observer<List<Child>> observer = new Observer<List<Child>>() {
+                        @Override
+                        public void onChanged(List<Child> songs) {
+                            if (songs != null && !songs.isEmpty()) {
+                                MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
+                                activity.setBottomSheetInPeek(true);
+                                live.removeObserver(this);
+                            }
                         }
-                    });
+                    };
+                    live.observe(getViewLifecycleOwner(), observer);
                 }
                 return true;
             } else if (menuItem.getItemId() == R.id.action_add_to_queue) {
                 Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
                 if (playlist != null) {
-                    new PlaylistRepository().getPlaylistSongs(playlist.getId()).observe(getViewLifecycleOwner(), songs -> {
-                        if (songs != null && !songs.isEmpty()) {
-                            MediaManager.enqueue(mediaBrowserListenableFuture, songs, false);
-                            Toast.makeText(requireContext(), R.string.playlist_added_to_queue, Toast.LENGTH_SHORT).show();
+                    final LiveData<List<Child>> live = new PlaylistRepository().getPlaylistSongs(playlist.getId());
+                    final Observer<List<Child>> observer = new Observer<List<Child>>() {
+                        @Override
+                        public void onChanged(List<Child> songs) {
+                            if (songs != null && !songs.isEmpty()) {
+                                MediaManager.enqueue(mediaBrowserListenableFuture, songs, false);
+                                Toast.makeText(requireContext(), R.string.playlist_added_to_queue, Toast.LENGTH_SHORT).show();
+                                live.removeObserver(this);
+                            }
                         }
-                    });
+                    };
+                    live.observe(getViewLifecycleOwner(), observer);
                 }
                 return true;
             } else if (menuItem.getItemId() == R.id.action_edit_playlist) {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
@@ -64,6 +64,7 @@ import com.cappielloantonio.tempo.util.Constants;
 import com.cappielloantonio.tempo.util.DownloadUtil;
 import com.cappielloantonio.tempo.util.ExternalAudioReader;
 import com.cappielloantonio.tempo.util.ExternalAudioWriter;
+import com.cappielloantonio.tempo.util.LiveDataUtils;
 import com.cappielloantonio.tempo.util.MappingUtil;
 import com.cappielloantonio.tempo.util.MusicUtil;
 import com.cappielloantonio.tempo.util.Preferences;
@@ -75,6 +76,7 @@ import com.google.android.material.snackbar.Snackbar;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -1371,53 +1373,29 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
             if (menuItem.getItemId() == R.id.action_go_to_playlist) {
                 Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
                 if (playlist != null) {
-                    final LiveData<List<Child>> live = new PlaylistRepository().getPlaylistSongs(playlist.getId());
-                    final Observer<List<Child>> observer = new Observer<List<Child>>() {
-                        @Override
-                        public void onChanged(List<Child> songs) {
-                            if (songs != null && !songs.isEmpty()) {
-                                MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
-                                activity.setBottomSheetInPeek(true);
-                                live.removeObserver(this);
-                            }
-                        }
-                    };
-                    live.observe(getViewLifecycleOwner(), observer);
+                    LiveDataUtils.observePlaylistSongsOnce(getViewLifecycleOwner(), playlist.getId(), songs -> {
+                        MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
+                        activity.setBottomSheetInPeek(true);
+                    });
                 }
                 return true;
             } else if (menuItem.getItemId() == R.id.action_play_shuffle) {
                 Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
                 if (playlist != null) {
-                    final LiveData<List<Child>> liveShuffle = new PlaylistRepository().getPlaylistSongs(playlist.getId());
-                    final Observer<List<Child>> observerShuffle = new Observer<List<Child>>() {
-                        @Override
-                        public void onChanged(List<Child> songs) {
-                            if (songs != null && !songs.isEmpty()) {
-                                java.util.Collections.shuffle(songs);
-                                MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
-                                activity.setBottomSheetInPeek(true);
-                                liveShuffle.removeObserver(this);
-                            }
-                        }
-                    };
-                    liveShuffle.observe(getViewLifecycleOwner(), observerShuffle);
+                    LiveDataUtils.observePlaylistSongsOnce(getViewLifecycleOwner(), playlist.getId(), songs -> {
+                        Collections.shuffle(songs);
+                        MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
+                        activity.setBottomSheetInPeek(true);
+                    });
                 }
                 return true;
             } else if (menuItem.getItemId() == R.id.action_add_to_queue) {
                 Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
                 if (playlist != null) {
-                    final LiveData<List<Child>> live = new PlaylistRepository().getPlaylistSongs(playlist.getId());
-                    final Observer<List<Child>> observer = new Observer<List<Child>>() {
-                        @Override
-                        public void onChanged(List<Child> songs) {
-                            if (songs != null && !songs.isEmpty()) {
-                                MediaManager.enqueue(mediaBrowserListenableFuture, songs, false);
-                                Toast.makeText(requireContext(), R.string.playlist_added_to_queue, Toast.LENGTH_SHORT).show();
-                                live.removeObserver(this);
-                            }
-                        }
-                    };
-                    live.observe(getViewLifecycleOwner(), observer);
+                    LiveDataUtils.observePlaylistSongsOnce(getViewLifecycleOwner(), playlist.getId(), songs -> {
+                        MediaManager.enqueue(mediaBrowserListenableFuture, songs, false);
+                        Toast.makeText(requireContext(), R.string.playlist_added_to_queue, Toast.LENGTH_SHORT).show();
+                    });
                 }
                 return true;
             } else if (menuItem.getItemId() == R.id.action_edit_playlist) {
@@ -1436,6 +1414,7 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
         });
         popup.show();
     }
+
 
     @Override
     public void onShareLongClick(Bundle bundle) {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LibraryFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LibraryFragment.java
@@ -323,7 +323,15 @@ public class LibraryFragment extends Fragment implements ClickCallback {
         
         popup.setOnMenuItemClickListener(menuItem -> {
             if (menuItem.getItemId() == R.id.action_go_to_playlist) {
-                onPlaylistClick(bundle);
+                com.cappielloantonio.tempo.subsonic.models.Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
+                if (playlist != null) {
+                    new PlaylistRepository().getPlaylistSongs(playlist.getId()).observe(getViewLifecycleOwner(), songs -> {
+                        if (songs != null && !songs.isEmpty()) {
+                            MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
+                            activity.setBottomSheetInPeek(true);
+                        }
+                    });
+                }
                 return true;
             } else if (menuItem.getItemId() == R.id.action_add_to_queue) {
                 com.cappielloantonio.tempo.subsonic.models.Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LibraryFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LibraryFragment.java
@@ -343,6 +343,24 @@ public class LibraryFragment extends Fragment implements ClickCallback {
                     live.observe(getViewLifecycleOwner(), observer);
                 }
                 return true;
+            } else if (menuItem.getItemId() == R.id.action_play_shuffle) {
+                com.cappielloantonio.tempo.subsonic.models.Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
+                if (playlist != null) {
+                    final LiveData<List<Child>> liveShuffle = new PlaylistRepository().getPlaylistSongs(playlist.getId());
+                    final Observer<List<Child>> observerShuffle = new Observer<List<Child>>() {
+                        @Override
+                        public void onChanged(List<Child> songs) {
+                            if (songs != null && !songs.isEmpty()) {
+                                java.util.Collections.shuffle(songs);
+                                MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
+                                activity.setBottomSheetInPeek(true);
+                                liveShuffle.removeObserver(this);
+                            }
+                        }
+                    };
+                    liveShuffle.observe(getViewLifecycleOwner(), observerShuffle);
+                }
+                return true;
             } else if (menuItem.getItemId() == R.id.action_add_to_queue) {
                 com.cappielloantonio.tempo.subsonic.models.Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
                 if (playlist != null) {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LibraryFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LibraryFragment.java
@@ -36,6 +36,7 @@ import com.cappielloantonio.tempo.navigation.NavigationController;
 import com.cappielloantonio.tempo.repository.PlaylistRepository;
 import com.cappielloantonio.tempo.service.MediaManager;
 import com.cappielloantonio.tempo.subsonic.models.Child;
+import com.cappielloantonio.tempo.subsonic.models.Playlist;
 import com.cappielloantonio.tempo.ui.activity.MainActivity;
 import com.cappielloantonio.tempo.ui.adapter.AlbumAdapter;
 import com.cappielloantonio.tempo.ui.adapter.ArtistAdapter;
@@ -44,12 +45,14 @@ import com.cappielloantonio.tempo.ui.adapter.MusicFolderAdapter;
 import com.cappielloantonio.tempo.ui.adapter.PlaylistHorizontalAdapter;
 import com.cappielloantonio.tempo.ui.dialog.PlaylistEditorDialog;
 import com.cappielloantonio.tempo.util.Constants;
+import com.cappielloantonio.tempo.util.LiveDataUtils;
 import com.cappielloantonio.tempo.util.Preferences;
 import com.cappielloantonio.tempo.viewmodel.LibraryViewModel;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.cappielloantonio.tempo.service.MediaService;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 
@@ -327,55 +330,31 @@ public class LibraryFragment extends Fragment implements ClickCallback {
         
         popup.setOnMenuItemClickListener(menuItem -> {
             if (menuItem.getItemId() == R.id.action_go_to_playlist) {
-                com.cappielloantonio.tempo.subsonic.models.Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
+                Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
                 if (playlist != null) {
-                    final LiveData<List<Child>> live = new PlaylistRepository().getPlaylistSongs(playlist.getId());
-                    final Observer<List<Child>> observer = new Observer<List<Child>>() {
-                        @Override
-                        public void onChanged(List<Child> songs) {
-                            if (songs != null && !songs.isEmpty()) {
-                                MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
-                                activity.setBottomSheetInPeek(true);
-                                live.removeObserver(this);
-                            }
-                        }
-                    };
-                    live.observe(getViewLifecycleOwner(), observer);
+                    LiveDataUtils.observePlaylistSongsOnce(getViewLifecycleOwner(), playlist.getId(), songs -> {
+                        MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
+                        activity.setBottomSheetInPeek(true);
+                    });
                 }
                 return true;
             } else if (menuItem.getItemId() == R.id.action_play_shuffle) {
-                com.cappielloantonio.tempo.subsonic.models.Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
+                Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
                 if (playlist != null) {
-                    final LiveData<List<Child>> liveShuffle = new PlaylistRepository().getPlaylistSongs(playlist.getId());
-                    final Observer<List<Child>> observerShuffle = new Observer<List<Child>>() {
-                        @Override
-                        public void onChanged(List<Child> songs) {
-                            if (songs != null && !songs.isEmpty()) {
-                                java.util.Collections.shuffle(songs);
-                                MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
-                                activity.setBottomSheetInPeek(true);
-                                liveShuffle.removeObserver(this);
-                            }
-                        }
-                    };
-                    liveShuffle.observe(getViewLifecycleOwner(), observerShuffle);
+                    LiveDataUtils.observePlaylistSongsOnce(getViewLifecycleOwner(), playlist.getId(), songs -> {
+                        Collections.shuffle(songs);
+                        MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
+                        activity.setBottomSheetInPeek(true);
+                    });
                 }
                 return true;
             } else if (menuItem.getItemId() == R.id.action_add_to_queue) {
-                com.cappielloantonio.tempo.subsonic.models.Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
+                Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
                 if (playlist != null) {
-                    final LiveData<List<Child>> live = new PlaylistRepository().getPlaylistSongs(playlist.getId());
-                    final Observer<List<Child>> observer = new Observer<List<Child>>() {
-                        @Override
-                        public void onChanged(List<Child> songs) {
-                            if (songs != null && !songs.isEmpty()) {
-                                MediaManager.enqueue(mediaBrowserListenableFuture, songs, false);
-                                Toast.makeText(requireContext(), R.string.playlist_added_to_queue, Toast.LENGTH_SHORT).show();
-                                live.removeObserver(this);
-                            }
-                        }
-                    };
-                    live.observe(getViewLifecycleOwner(), observer);
+                    LiveDataUtils.observePlaylistSongsOnce(getViewLifecycleOwner(), playlist.getId(), songs -> {
+                        MediaManager.enqueue(mediaBrowserListenableFuture, songs, false);
+                        Toast.makeText(requireContext(), R.string.playlist_added_to_queue, Toast.LENGTH_SHORT).show();
+                    });
                 }
                 return true;
             } else if (menuItem.getItemId() == R.id.action_edit_playlist) {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LibraryFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LibraryFragment.java
@@ -11,6 +11,8 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.session.MediaBrowser;
@@ -33,6 +35,7 @@ import com.cappielloantonio.tempo.interfaces.PlaylistCallback;
 import com.cappielloantonio.tempo.navigation.NavigationController;
 import com.cappielloantonio.tempo.repository.PlaylistRepository;
 import com.cappielloantonio.tempo.service.MediaManager;
+import com.cappielloantonio.tempo.subsonic.models.Child;
 import com.cappielloantonio.tempo.ui.activity.MainActivity;
 import com.cappielloantonio.tempo.ui.adapter.AlbumAdapter;
 import com.cappielloantonio.tempo.ui.adapter.ArtistAdapter;
@@ -47,6 +50,7 @@ import com.google.android.material.appbar.MaterialToolbar;
 import com.cappielloantonio.tempo.service.MediaService;
 import com.google.common.util.concurrent.ListenableFuture;
 
+import java.util.List;
 import java.util.Objects;
 
 @UnstableApi
@@ -325,23 +329,35 @@ public class LibraryFragment extends Fragment implements ClickCallback {
             if (menuItem.getItemId() == R.id.action_go_to_playlist) {
                 com.cappielloantonio.tempo.subsonic.models.Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
                 if (playlist != null) {
-                    new PlaylistRepository().getPlaylistSongs(playlist.getId()).observe(getViewLifecycleOwner(), songs -> {
-                        if (songs != null && !songs.isEmpty()) {
-                            MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
-                            activity.setBottomSheetInPeek(true);
+                    final LiveData<List<Child>> live = new PlaylistRepository().getPlaylistSongs(playlist.getId());
+                    final Observer<List<Child>> observer = new Observer<List<Child>>() {
+                        @Override
+                        public void onChanged(List<Child> songs) {
+                            if (songs != null && !songs.isEmpty()) {
+                                MediaManager.startQueue(mediaBrowserListenableFuture, songs, 0);
+                                activity.setBottomSheetInPeek(true);
+                                live.removeObserver(this);
+                            }
                         }
-                    });
+                    };
+                    live.observe(getViewLifecycleOwner(), observer);
                 }
                 return true;
             } else if (menuItem.getItemId() == R.id.action_add_to_queue) {
                 com.cappielloantonio.tempo.subsonic.models.Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
                 if (playlist != null) {
-                    new PlaylistRepository().getPlaylistSongs(playlist.getId()).observe(getViewLifecycleOwner(), songs -> {
-                        if (songs != null && !songs.isEmpty()) {
-                            MediaManager.enqueue(mediaBrowserListenableFuture, songs, false);
-                            Toast.makeText(requireContext(), R.string.playlist_added_to_queue, Toast.LENGTH_SHORT).show();
+                    final LiveData<List<Child>> live = new PlaylistRepository().getPlaylistSongs(playlist.getId());
+                    final Observer<List<Child>> observer = new Observer<List<Child>>() {
+                        @Override
+                        public void onChanged(List<Child> songs) {
+                            if (songs != null && !songs.isEmpty()) {
+                                MediaManager.enqueue(mediaBrowserListenableFuture, songs, false);
+                                Toast.makeText(requireContext(), R.string.playlist_added_to_queue, Toast.LENGTH_SHORT).show();
+                                live.removeObserver(this);
+                            }
                         }
-                    });
+                    };
+                    live.observe(getViewLifecycleOwner(), observer);
                 }
                 return true;
             } else if (menuItem.getItemId() == R.id.action_edit_playlist) {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LibraryFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LibraryFragment.java
@@ -18,6 +18,7 @@ import androidx.media3.session.SessionToken;
 import androidx.navigation.Navigation;
 
 import android.content.ComponentName;
+import android.widget.PopupMenu;
 import android.widget.Toast;
 
 import androidx.recyclerview.widget.GridLayoutManager;
@@ -30,6 +31,8 @@ import com.cappielloantonio.tempo.helper.recyclerview.CustomLinearSnapHelper;
 import com.cappielloantonio.tempo.interfaces.ClickCallback;
 import com.cappielloantonio.tempo.interfaces.PlaylistCallback;
 import com.cappielloantonio.tempo.navigation.NavigationController;
+import com.cappielloantonio.tempo.repository.PlaylistRepository;
+import com.cappielloantonio.tempo.service.MediaManager;
 import com.cappielloantonio.tempo.ui.activity.MainActivity;
 import com.cappielloantonio.tempo.ui.adapter.AlbumAdapter;
 import com.cappielloantonio.tempo.ui.adapter.ArtistAdapter;
@@ -314,16 +317,40 @@ public class LibraryFragment extends Fragment implements ClickCallback {
     }
 
     @Override
-    public void onPlaylistLongClick(Bundle bundle) {
-        PlaylistEditorDialog dialog = new PlaylistEditorDialog(new PlaylistCallback() {
-            @Override
-            public void onDismiss() {
-                refreshPlaylistView();
-            }
-        });
+    public void onPlaylistLongClick(View view, Bundle bundle) {
+        PopupMenu popup = new PopupMenu(requireContext(), view);
+        popup.getMenuInflater().inflate(R.menu.playlist_popup_menu, popup.getMenu());
+        
+        popup.setOnMenuItemClickListener(menuItem -> {
+            if (menuItem.getItemId() == R.id.action_go_to_playlist) {
+                onPlaylistClick(bundle);
+                return true;
+            } else if (menuItem.getItemId() == R.id.action_add_to_queue) {
+                com.cappielloantonio.tempo.subsonic.models.Playlist playlist = bundle.getParcelable(Constants.PLAYLIST_OBJECT);
+                if (playlist != null) {
+                    new PlaylistRepository().getPlaylistSongs(playlist.getId()).observe(getViewLifecycleOwner(), songs -> {
+                        if (songs != null && !songs.isEmpty()) {
+                            MediaManager.enqueue(mediaBrowserListenableFuture, songs, false);
+                            Toast.makeText(requireContext(), R.string.playlist_added_to_queue, Toast.LENGTH_SHORT).show();
+                        }
+                    });
+                }
+                return true;
+            } else if (menuItem.getItemId() == R.id.action_edit_playlist) {
+                PlaylistEditorDialog dialog = new PlaylistEditorDialog(new PlaylistCallback() {
+                    @Override
+                    public void onDismiss() {
+                        refreshPlaylistView();
+                    }
+                });
 
-        dialog.setArguments(bundle);
-        dialog.show(activity.getSupportFragmentManager(), null);
+                dialog.setArguments(bundle);
+                dialog.show(activity.getSupportFragmentManager(), null);
+                return true;
+            }
+            return false;
+        });
+        popup.show();
     }
 
     @Override

--- a/app/src/main/java/com/cappielloantonio/tempo/util/LiveDataUtils.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/LiveDataUtils.java
@@ -1,0 +1,36 @@
+package com.cappielloantonio.tempo.util;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.Observer;
+
+import com.cappielloantonio.tempo.repository.PlaylistRepository;
+import com.cappielloantonio.tempo.subsonic.models.Child;
+
+import java.util.List;
+import java.util.function.Consumer;
+
+public final class LiveDataUtils {
+    private LiveDataUtils() {}
+
+    // Default convenience method that constructs a PlaylistRepository
+    public static void observePlaylistSongsOnce(@NonNull LifecycleOwner owner, @NonNull String playlistId, @NonNull Consumer<List<Child>> action) {
+        observePlaylistSongsOnce(new PlaylistRepository(), owner, playlistId, action);
+    }
+
+    // Testable overload that accepts a PlaylistRepository instance
+    public static void observePlaylistSongsOnce(@NonNull PlaylistRepository repo, @NonNull LifecycleOwner owner, @NonNull String playlistId, @NonNull Consumer<List<Child>> action) {
+        final LiveData<List<Child>> live = repo.getPlaylistSongs(playlistId);
+        final Observer<List<Child>> observer = new Observer<List<Child>>() {
+            @Override
+            public void onChanged(List<Child> songs) {
+                if (songs != null && !songs.isEmpty()) {
+                    action.accept(songs);
+                    live.removeObserver(this);
+                }
+            }
+        };
+        live.observe(owner, observer);
+    }
+}

--- a/app/src/main/res/menu/playlist_popup_menu.xml
+++ b/app/src/main/res/menu/playlist_popup_menu.xml
@@ -4,6 +4,9 @@
         android:id="@+id/action_go_to_playlist"
         android:title="@string/menu_go_to_playlist_button" />
     <item
+        android:id="@+id/action_play_shuffle"
+        android:title="@string/menu_play_shuffle_button" />
+    <item
         android:id="@+id/action_add_to_queue"
         android:title="@string/menu_add_to_queue_button" />
     <item

--- a/app/src/main/res/menu/playlist_popup_menu.xml
+++ b/app/src/main/res/menu/playlist_popup_menu.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android">
+    <item
+        android:id="@+id/action_go_to_playlist"
+        android:title="@string/menu_go_to_playlist_button" />
+    <item
+        android:id="@+id/action_add_to_queue"
+        android:title="@string/menu_add_to_queue_button" />
+    <item
+        android:id="@+id/action_edit_playlist"
+        android:title="@string/menu_edit_playlist_button" />
+</menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -224,6 +224,7 @@
     <string name="menu_add_to_playlist_button">Add to playlist</string>
     <string name="playlist_added_to_queue">Playlist added to queue</string>
     <string name="menu_go_to_playlist_button">Play</string>
+    <string name="menu_play_shuffle_button">Play shuffle</string>
     <string name="menu_add_to_queue_button">Add to queue</string>
     <string name="menu_edit_playlist_button">Edit playlist</string>
     <string name="menu_download_all_button">Download all</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -223,7 +223,7 @@
     <string name="menu_add_button">Add</string>
     <string name="menu_add_to_playlist_button">Add to playlist</string>
     <string name="playlist_added_to_queue">Playlist added to queue</string>
-    <string name="menu_go_to_playlist_button">Go to playlist</string>
+    <string name="menu_go_to_playlist_button">Play</string>
     <string name="menu_add_to_queue_button">Add to queue</string>
     <string name="menu_edit_playlist_button">Edit playlist</string>
     <string name="menu_download_all_button">Download all</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -222,6 +222,8 @@
     <string name="media_route_menu_title">Cast</string>
     <string name="menu_add_button">Add</string>
     <string name="menu_add_to_playlist_button">Add to playlist</string>
+    <string name="playlist_added_to_queue">Playlist added to queue</string>
+    <string name="menu_go_to_playlist_button">Go to playlist</string>
     <string name="menu_add_to_queue_button">Add to queue</string>
     <string name="menu_edit_playlist_button">Edit playlist</string>
     <string name="menu_download_all_button">Download all</string>

--- a/app/src/test/java/com/cappielloantonio/tempo/util/LiveDataUtilsTest.java
+++ b/app/src/test/java/com/cappielloantonio/tempo/util/LiveDataUtilsTest.java
@@ -1,0 +1,69 @@
+package com.cappielloantonio.tempo.util;
+
+import static org.junit.Assert.assertEquals;
+
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LifecycleRegistry;
+import androidx.lifecycle.MutableLiveData;
+
+import com.cappielloantonio.tempo.repository.PlaylistRepository;
+import com.cappielloantonio.tempo.subsonic.models.Child;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TestRule;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule;
+
+@RunWith(JUnit4.class)
+public class LiveDataUtilsTest {
+
+    @Rule
+    public TestRule rule = new InstantTaskExecutorRule();
+
+    private static class TestLifecycleOwner implements LifecycleOwner {
+        private final LifecycleRegistry registry = new LifecycleRegistry(this);
+
+        TestLifecycleOwner() {
+            registry.handleLifecycleEvent(Lifecycle.Event.ON_RESUME);
+        }
+
+        @Override
+        public Lifecycle getLifecycle() {
+            return registry;
+        }
+    }
+
+    @Test
+    public void observePlaylistSongsOnce_invokesActionExactlyOnce() {
+        MutableLiveData<List<Child>> live = new MutableLiveData<>();
+
+        PlaylistRepository fakeRepo = new PlaylistRepository() {
+            @Override
+            public MutableLiveData<List<Child>> getPlaylistSongs(String id) {
+                return live;
+            }
+        };
+
+        AtomicInteger called = new AtomicInteger(0);
+
+        TestLifecycleOwner owner = new TestLifecycleOwner();
+
+        LiveDataUtils.observePlaylistSongsOnce(fakeRepo, owner, "pl1", songs -> called.incrementAndGet());
+
+        // First publish: should invoke action once
+        live.setValue(Arrays.asList(new Child("1")));
+        assertEquals(1, called.get());
+
+        // Second publish: observer should have been removed, so count stays 1
+        live.setValue(Arrays.asList(new Child("2")));
+        assertEquals(1, called.get());
+    }
+}


### PR DESCRIPTION
added menu options to playlist in HomeTabMusic and Library Fragments
 * Play
 * Play shuffle
 * Add to queue
 * Edit playlist

On the main Playlist page new options added (play and shuffle excluded since they exist in the body already)
* Add to queue
* Edit playlist

Resolves most of #692
#734 
<details> 

home/library 
<img width="270" height="606" alt="image" src="https://github.com/user-attachments/assets/5c248036-4cf4-4dc4-8cf4-453306583c94" />

playlist page
<img width="270" height="606" alt="image" src="https://github.com/user-attachments/assets/a88f6de5-1246-49a9-b58d-177aa307f6b5" />

</details> 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added context menu when long-pressing a playlist, providing quick access to play, shuffle play, add tracks to queue, or edit the playlist.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->