### PR TITLE
Fix playlist-browsing OOM from a leaked LiveData observer (#696)

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
@@ -290,7 +290,14 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
     }
 
     private void initBackCover() {
-        playlistPageViewModel.getPlaylistSongLiveList().observe(requireActivity(), songs -> {
+        // Observe with the view lifecycle, not the activity. The view model is
+        // activity-scoped, so observing its shared LiveData with requireActivity()
+        // left one observer per opened playlist registered for the whole session,
+        // each retaining this fragment's view tree (the cover ImageViews) — the
+        // heap climbed with every playlist opened until OOM. getViewLifecycleOwner()
+        // removes the observer at onDestroyView so the view tree can be collected.
+        // See issue #696.
+        playlistPageViewModel.getPlaylistSongLiveList().observe(getViewLifecycleOwner(), songs -> {
             if (bind != null && songs != null && !songs.isEmpty()) {
                 java.util.List<com.cappielloantonio.tempo.subsonic.models.Child> randomSongs = new java.util.ArrayList<>(songs);
                 java.util.Collections.shuffle(randomSongs);


### PR DESCRIPTION
Follow-up to the conversation on #696 — this is the leaked-observer fix I mentioned, with the before/after you asked for. It's separate from the large-playlist work in #769/#785 and still reproduces on current `development` (tested at `ef10f351` / v4.19.2-dev).

## Root cause

`PlaylistPageFragment.initBackCover()` observes the activity-scoped `PlaylistPageViewModel`'s shared song LiveData with `requireActivity()` as the LifecycleOwner:

```java
playlistPageViewModel.getPlaylistSongLiveList().observe(requireActivity(), songs -> { ... });
```

That view model is scoped to the Activity, so it outlives every playlist fragment. Observing with `requireActivity()` keeps the observer registered for the whole Activity lifetime, and its lambda captures this fragment's views (the cover ImageViews). `onDestroyView` never removes it, so each playlist you open leaves its entire view tree pinned in memory.

The retained reference chain is:

```
Activity ViewModelStore
  └─ PlaylistPageViewModel  (lives as long as the Activity)
       └─ getPlaylistSongLiveList() LiveData → its observer list
            └─ observer bound to requireActivity()  (never removed at onDestroyView)
                 └─ the  songs -> { ... }  lambda
                      └─ captured PlaylistPageFragment + its bind/views
                           └─ the whole cover/list view tree
```

Open enough playlists and the heap climbs until it OOMs during list layout — which lines up with the report that it tracks the number of playlists opened, not the track count. Every other observer in this fragment already uses `getViewLifecycleOwner()`; `initBackCover()` is the only one that doesn't.

## Fix

One line — observe with the view lifecycle so the observer is removed at `onDestroyView`:

```java
playlistPageViewModel.getPlaylistSongLiveList().observe(getViewLifecycleOwner(), songs -> { ... });
```

## Reproducing the "open playlists one by one" flow + validation

Repro = open a playlist, go back, repeat. I opened the same 34-track playlist N times and measured the live `View` object count (`adb shell dumpsys meminfo`, forcing a GC first). It all stays in one Activity (`Activities = 1` the whole time), so this is purely the fragment's view trees being retained.

**Before** (`requireActivity`) — live View count climbs ~linearly and never comes back down:

| playlists opened | live Views |
|---|---|
| 0 | 677 |
| 10 | 4,843 |
| 20 | 8,423 |

~390 views leaked per open — unbounded, so it eventually OOMs. (With LeakCanary added locally it also flags `PlaylistPageFragment` retained on every back-navigation, and on the emulator's smaller heap the process actually died under the pressure.)

**After** (`getViewLifecycleOwner`) — it plateaus and stops growing:

| playlists opened | live Views |
|---|---|
| 0 | 739 |
| 20 | 1,035 |
| 40 | 1,035 |

Identical at 20 and 40 opens — the retained view trees are collected again, so opening more playlists no longer accumulates.

## Reproduce it yourself

If you'd like to see it directly, add LeakCanary to the debug build:

```gradle
debugImplementation 'com.squareup.leakcanary:leakcanary-android:2.14'
```

Then open a playlist, press back, and repeat ~10 times. On the current code LeakCanary reports `PlaylistPageFragment` retained after each back-press (and `adb shell dumpsys meminfo <package>` shows the `Views:` count climbing); with the fix it stays quiet and the count holds flat.

## Test environment

- Base: `development` @ `ef10f351` (v4.19.2-dev).
- Android 15 (API 35), arm64 emulator (Pixel 6 AVD), against the Navidrome public demo.
- Each measurement forced a GC (`adb shell am dumpheap`) before reading `dumpsys meminfo`, and every open was confirmed via fragment-lifecycle logs.
- Built green on the dev toolchain (Gradle 9.4.1 / AGP 9.2.1, JDK 21).
- The `requireActivity()` here is only the LiveData lifecycle owner; the view-model scoping (`new ViewModelProvider(requireActivity())`) is intentionally unchanged.
