### PR TITLE
fix: unsanitized fqdn crashes login

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/glide/CustomGlideRequest.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/glide/CustomGlideRequest.java
@@ -87,7 +87,7 @@ public class CustomGlideRequest {
 
         StringBuilder uri = new StringBuilder();
 
-        uri.append(App.getSubsonicClientInstance(false).getUrl());
+        uri.append(App.getSubsonicClientInstance(false).getUrl(App.getContext()));
         uri.append("getCoverArt");
 
         if (params.containsKey("u") && params.get("u") != null)

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/RetrofitClient.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/RetrofitClient.kt
@@ -23,7 +23,7 @@ class RetrofitClient(subsonic: Subsonic) {
             .create()
 
         retrofit = Retrofit.Builder()
-            .baseUrl(subsonic.url)
+            .baseUrl(subsonic.getUrl(App.getContext()))
             .addConverterFactory(GsonConverterFactory.create(gson))
             .client(getOkHttpClient())
             .build()

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/Subsonic.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/Subsonic.java
@@ -1,5 +1,10 @@
 package com.cappielloantonio.tempo.subsonic;
 
+import android.content.Context;
+import android.os.Handler;
+import android.os.Looper;
+import android.widget.Toast;
+
 import com.cappielloantonio.tempo.subsonic.api.albumsonglist.AlbumSongListClient;
 import com.cappielloantonio.tempo.subsonic.api.bookmarks.BookmarksClient;
 import com.cappielloantonio.tempo.subsonic.api.browsing.BrowsingClient;
@@ -15,8 +20,12 @@ import com.cappielloantonio.tempo.subsonic.api.sharing.SharingClient;
 import com.cappielloantonio.tempo.subsonic.api.system.SystemClient;
 import com.cappielloantonio.tempo.subsonic.base.Version;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.HashMap;
 import java.util.Map;
+
+import okhttp3.HttpUrl;
 
 public class Subsonic {
     private static final Version API_MAX_VERSION = Version.of("1.15.0");
@@ -137,9 +146,26 @@ public class Subsonic {
         return openClient;
     }
 
-    public String getUrl() {
-        String url = preferences.getServerUrl() + "/rest/";
-        return url.replace("//rest", "/rest");
+    public String getUrl(Context context) {
+        String serverUrl = preferences.getServerUrl();
+        if (serverUrl == null || serverUrl.trim().isEmpty()) {
+            return "http://bad.fqdn";
+        }
+        HttpUrl baseUrl = HttpUrl.parse(serverUrl);
+        if (baseUrl == null || baseUrl.host().isEmpty()) {
+            new Handler(Looper.getMainLooper()).post(() -> {
+                Toast.makeText(
+                        context.getApplicationContext(),
+                        "Invalid Server URL.",
+                        Toast.LENGTH_LONG
+                ).show();
+            });
+            return "http://bad_fqdn";
+        }
+        return baseUrl.newBuilder()
+                .addPathSegment("rest")
+                .build()
+                .toString();
     }
 
     public Map<String, String> getParams() {

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/Subsonic.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/Subsonic.java
@@ -149,7 +149,14 @@ public class Subsonic {
     public String getUrl(Context context) {
         String serverUrl = preferences.getServerUrl();
         if (serverUrl == null || serverUrl.trim().isEmpty()) {
-            return "http://bad.fqdn";
+            new Handler(Looper.getMainLooper()).post(() -> {
+                Toast.makeText(
+                        context.getApplicationContext(),
+                        "Invalid Server URL.",
+                        Toast.LENGTH_LONG
+                ).show();
+            });
+            return "http://bad_fqdn";
         }
         HttpUrl baseUrl = HttpUrl.parse(serverUrl);
         if (baseUrl == null || baseUrl.host().isEmpty()) {

--- a/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
@@ -36,7 +36,7 @@ public class MusicUtil {
 
         StringBuilder uri = new StringBuilder();
 
-        uri.append(App.getSubsonicClientInstance(false).getUrl());
+        uri.append(App.getSubsonicClientInstance(false).getUrl(App.getContext()));
         uri.append("stream");
 
         if (params.containsKey("u") && params.get("u") != null)
@@ -107,7 +107,7 @@ public class MusicUtil {
         if (download == null || download.getDownloadUri().isEmpty()) {
             Map<String, String> params = App.getSubsonicClientInstance(false).getParams();
 
-            uri.append(App.getSubsonicClientInstance(false).getUrl());
+            uri.append(App.getSubsonicClientInstance(false).getUrl(App.getContext()));
             uri.append("download");
 
             if (params.containsKey("u") && params.get("u") != null)
@@ -138,7 +138,7 @@ public class MusicUtil {
 
         StringBuilder uri = new StringBuilder();
 
-        uri.append(App.getSubsonicClientInstance(false).getUrl());
+        uri.append(App.getSubsonicClientInstance(false).getUrl(App.getContext()));
         uri.append("stream");
 
         if (params.containsKey("u") && params.get("u") != null)


### PR DESCRIPTION
Solves #795.

Not elegant, not actually a solution. It prevents the crash loop and the user getting logged out permanently by:

* Running a sanitation of the URL that works as a try/catch.
* Showing a Toast to the user explaining what went wrong.

Now the non-fix thing. The flow of the program continues and everyone that asked for the URL will still get it, only that this time the error handling will push a non-crashing, FQDN-compilant string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved server URL validation with enhanced error detection and user notifications for invalid server configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->