### PR TITLE
fix: wrong fetching animations condition of artist top songs

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistPageFragment.java
@@ -284,6 +284,7 @@ public class ArtistPageFragment extends Fragment implements ClickCallback {
     private final Handler emptyTopSongsTimerHandler = new Handler(Looper.getMainLooper());
     private final Runnable emptyTopSongsTimerRunnable = () -> {
         bind.artistPageTopSongsSector.setVisibility(View.VISIBLE);
+        bind.mostStreamedSongRecyclerContainer.setVisibility(View.GONE);
         bind.mostStreamedSongRecyclerView.setVisibility(View.GONE);
         bind.mostStreamedSongRecyclerPlaceholder.setVisibility(View.GONE);
         bind.mostStreamedSongRecyclerEmpty.setVisibility(View.VISIBLE);
@@ -303,7 +304,7 @@ public class ArtistPageFragment extends Fragment implements ClickCallback {
                     /* Top Songs Timer unset whenever we enter the observer */
                     emptyTopSongsTimerHandler.removeCallbacks(emptyTopSongsTimerRunnable);
 
-                    if (songs == null) {
+                    if (songs.isEmpty()) {
                         // FETCHING -> Placeholder View
                         bind.artistPageTopSongsSector.setVisibility(View.VISIBLE);
                         bind.mostStreamedSongRecyclerContainer.setVisibility(View.GONE);
@@ -312,17 +313,6 @@ public class ArtistPageFragment extends Fragment implements ClickCallback {
                         bind.mostStreamedSongRecyclerEmpty.setVisibility(View.GONE);
                         // Start timeout to get out of placeholder
                         emptyTopSongsTimerHandler.postDelayed(emptyTopSongsTimerRunnable, TOP_SONGS_TIMEOUT);
-                        return;
-                    }
-
-                    if (songs.isEmpty()) {
-                        // EMPTY -> Empty View
-                        bind.artistPageTopSongsSector.setVisibility(View.VISIBLE);
-                        bind.mostStreamedSongRecyclerContainer.setVisibility(View.GONE);
-                        bind.mostStreamedSongRecyclerView.setVisibility(View.GONE);
-                        bind.mostStreamedSongRecyclerPlaceholder.setVisibility(View.GONE);
-                        bind.mostStreamedSongRecyclerEmpty.setVisibility(View.VISIBLE);
-                        bind.mostStreamedSongTextViewClickable.setVisibility(View.GONE);
                         return;
                     }
 


### PR DESCRIPTION
Solves #783. Makes #693 compatible with #761.

The fix is pretty simple, there are two states:
* Empty List
* Non-empty List

We start with Empty List.
* If the server returns data -> Non-Empty List -> Stop placeholder and show data
* If the server returns no data -> Empty List -> Show placeholder

The observer that checks data changes will only notice when Non-empty List happens, so it will show the placeholder indefinitely since no-server-data is the same as fetching-data.

The `emptyTopSongsTimerHandler` solves this by just cutting the placeholder after 3 seconds. We now entirely rely on this handler to stop the shimmering effect, this removed one conditional check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UI state handling for the Artist Page Top Songs display, ensuring proper cleanup when navigating between sections and better management of empty song lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->