### PR TITLE
fix: avoid playback gap on WiFi/cellular switch by not rebuilding the active item

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -107,12 +107,24 @@ open class BaseMediaService : MediaLibraryService() {
 
     fun updateMediaItems(player: Player) {
         Log.d(TAG, "update items")
-        val n = player.mediaItemCount
-        val k = player.currentMediaItemIndex
-        val current = player.currentPosition
-        val items = (0..n - 1).map { MappingUtil.mapMediaItem(player.getMediaItemAt(it)) }
-        player.clearMediaItems()
-        player.setMediaItems(items, k, current)
+        // Re-resolve per-network stream URLs (maxBitRate/format) for the queue WITHOUT
+        // interrupting the currently-playing track. The previous implementation called
+        // clearMediaItems() + setMediaItems() over the live player, which discards the
+        // active item's forward buffer and forces a re-prepare on every WiFi<->cellular
+        // switch — an audible ~0.5s gap (and, on some devices, the failed re-prepare that
+        // #682 recovers from). Instead, replace only the non-current items, and only when
+        // the resolved URI actually changed, so the active item is never touched while
+        // upcoming tracks still pick up the new network's transcoding settings.
+        val current = player.currentMediaItemIndex
+        if (current == C.INDEX_UNSET) return
+        for (i in 0 until player.mediaItemCount) {
+            if (i == current) continue
+            val old = player.getMediaItemAt(i)
+            val mapped = MappingUtil.mapMediaItem(old)
+            if (mapped.requestMetadata.mediaUri != old.requestMetadata.mediaUri) {
+                player.replaceMediaItem(i, mapped)
+            }
+        }
     }
 
     fun restorePlayerFromQueue(player: Player) {


### PR DESCRIPTION
## Problem

Switching between WiFi and mobile data mid-playback causes a brief but audible ~0.5s gap (#583), and on some devices playback stops entirely until the app is restarted (#682).

In #583 the thread describes it directly ("the music stops for about half a second and then plays on… it stutters when I leave WiFi range"), and notably it reproduces even with the app's network access fully blocked — which points at the transport-change callback rather than any actual network I/O.

## Root cause

`CustomNetworkCallback.onCapabilitiesChanged` calls `updateMediaItems()` on every WiFi↔cellular flip, and `updateMediaItems()` did this over the **live** player, including the currently-playing item:

```kotlin
player.clearMediaItems()
player.setMediaItems(items, k, current)
```

`clearMediaItems()` releases the active `MediaPeriod` and discards its forward buffer; `setMediaItems(..., current)` then re-creates the source and re-prepares from the current position — re-opening the HTTP stream and re-buffering before audio resumes. That re-prepare is the gap, and when it fails it's the freeze that #682 (#790) recovers from.

This logic was originally added in #222 (to fix #198 — applying per-network transcoding after a switch), where it was already noted that interrupting the current song "may be annoying."

## Fix

Re-resolve URLs only for the items that aren't currently playing, and only when the resolved URL actually changed:

```kotlin
val current = player.currentMediaItemIndex
if (current == C.INDEX_UNSET) return
for (i in 0 until player.mediaItemCount) {
    if (i == current) continue
    val old = player.getMediaItemAt(i)
    val mapped = MappingUtil.mapMediaItem(old)
    if (mapped.requestMetadata.mediaUri != old.requestMetadata.mediaUri) {
        player.replaceMediaItem(i, mapped)
    }
}
```

- The active track is never touched → no buffer discard, no re-prepare, **no gap** (#583), and the network-switch re-prepare that froze playback on some devices is no longer triggered (complementary to #790, which recovers from that error path).
- Upcoming tracks are still re-resolved, so **#198's per-network transcoding is preserved**.
- `replaceMediaItem` on non-current indices doesn't interrupt the active `MediaPeriod`. The URI guard skips no-op replacements (WiFi/mobile settings identical, downloaded/local items whose URI is unchanged).

## Testing

- `./gradlew assembleTempusRelease` builds cleanly.
- The change is confined to `updateMediaItems()`; because the active item is never replaced, the player no longer enters `STATE_BUFFERING` on a transport change while later tracks still pick up the new bitrate.
- Tested with real use case -- when I arrive home and phone switches to Wi-Fi, the gap is no longer there.

Fixes #583. Removes the network-switch trigger behind #682.
