### PR TITLE
fix: applying main layout to current buggy changes

### DIFF
--- a/app/src/main/res/layout/item_horizontal_track.xml
+++ b/app/src/main/res/layout/item_horizontal_track.xml
@@ -5,6 +5,7 @@
     android:layout_height="wrap_content"
     android:background="?attr/selectableItemBackground"
     android:clipChildren="false"
+    android:orientation="horizontal"
     android:paddingTop="2dp"
     android:paddingBottom="2dp">
 
@@ -12,7 +13,7 @@
         android:id="@+id/different_disk_divider_sector"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:paddingTop="12dp"
+        android:layout_marginTop="12dp"
         android:layout_marginHorizontal="16dp"
         android:visibility="gone"
         app:layout_constraintEnd_toEndOf="parent"
@@ -38,7 +39,6 @@
             android:id="@+id/different_disk_divider"
             style="@style/Divider"
             android:layout_width="0dp"
-            android:layout_height="1dp"
             app:layout_constraintBottom_toBottomOf="@+id/disc_title_text_view"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toEndOf="@+id/disc_title_text_view"
@@ -49,6 +49,7 @@
         android:id="@+id/song_cover_image_view"
         android:layout_width="52dp"
         android:layout_height="52dp"
+        android:layout_gravity="center"
         android:layout_marginStart="16dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
@@ -69,8 +70,8 @@
         android:id="@+id/play_pause_icon"
         android:layout_width="28dp"
         android:layout_height="28dp"
+        android:layout_gravity="center"
         android:layout_marginStart="28dp"
-        android:visibility="invisible"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/different_disk_divider_sector" />
@@ -92,6 +93,7 @@
         android:layout_width="12dp"
         android:layout_height="52dp"
         app:layout_constraintBottom_toBottomOf="@+id/song_cover_image_view"
+        app:layout_constraintEnd_toStartOf="@+id/search_result_song_title_text_view"
         app:layout_constraintStart_toEndOf="@+id/song_cover_image_view"
         app:layout_constraintTop_toTopOf="@+id/song_cover_image_view" />
 
@@ -131,14 +133,14 @@
         android:paddingVertical="8dp"
         app:layout_constraintBottom_toBottomOf="@+id/song_cover_image_view"
         app:layout_constraintEnd_toStartOf="@+id/search_result_download_indicator_image_view"
+        app:layout_constraintStart_toEndOf="@+id/search_result_song_title_text_view"
         app:layout_constraintTop_toTopOf="@+id/song_cover_image_view">
 
         <ImageView
             android:id="@+id/preferred_icon"
             android:layout_width="18dp"
             android:layout_height="18dp"
-            android:src="@drawable/ic_favorite"
-            android:contentDescription="@string/favorite_icon_description"
+            android:background="@drawable/ic_favorite"
             android:visibility="gone"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -150,18 +152,40 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="horizontal"
-            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toBottomOf="@id/preferred_icon"
-            tools:visibility="visible">
+            app:layout_constraintTop_toBottomOf="@id/preferred_icon">
 
-            <ImageView android:id="@+id/one_star_icon" android:layout_width="8dp" android:layout_height="8dp" tools:src="@drawable/ic_star" />
-            <ImageView android:id="@+id/two_star_icon" android:layout_width="8dp" android:layout_height="8dp" tools:src="@drawable/ic_star" />
-            <ImageView android:id="@+id/three_star_icon" android:layout_width="8dp" android:layout_height="8dp" tools:src="@drawable/ic_star" />
-            <ImageView android:id="@+id/four_star_icon" android:layout_width="8dp" android:layout_height="8dp" tools:src="@drawable/ic_star" />
-            <ImageView android:id="@+id/five_star_icon" android:layout_width="8dp" android:layout_height="8dp" tools:src="@drawable/ic_star" />
+            <ImageView
+                android:id="@+id/one_star_icon"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                tools:src="@drawable/ic_star" />
+
+            <ImageView
+                android:id="@+id/two_star_icon"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                tools:src="@drawable/ic_star" />
+
+            <ImageView
+                android:id="@+id/three_star_icon"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                tools:src="@drawable/ic_star" />
+
+            <ImageView
+                android:id="@+id/four_star_icon"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                tools:src="@drawable/ic_star" />
+
+            <ImageView
+                android:id="@+id/five_star_icon"
+                android:layout_width="8dp"
+                android:layout_height="8dp"
+                tools:src="@drawable/ic_star" />
 
         </LinearLayout>
     </androidx.constraintlayout.widget.ConstraintLayout>
@@ -174,13 +198,15 @@
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="@+id/song_cover_image_view"
         app:layout_constraintEnd_toStartOf="@+id/search_result_song_more_button"
+        app:layout_constraintStart_toEndOf="@+id/rating_indicator_image_view"
         app:layout_constraintTop_toTopOf="@+id/song_cover_image_view"
         tools:visibility="visible">
 
         <ImageView
             android:layout_width="18dp"
             android:layout_height="18dp"
-            android:background="@drawable/ic_download" />
+            android:background="@drawable/ic_download"
+            android:foreground="?android:attr/selectableItemBackgroundBorderless" />
     </FrameLayout>
 
     <FrameLayout
@@ -190,6 +216,7 @@
         android:padding="12dp"
         app:layout_constraintBottom_toBottomOf="@+id/song_cover_image_view"
         app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toEndOf="@+id/search_result_download_indicator_image_view"
         app:layout_constraintTop_toTopOf="@+id/song_cover_image_view">
 
         <ImageView
@@ -198,5 +225,4 @@
             android:background="@drawable/ic_more_vert"
             android:foreground="?android:attr/selectableItemBackgroundBorderless" />
     </FrameLayout>
-
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/layout/item_horizontal_track.xml
+++ b/app/src/main/res/layout/item_horizontal_track.xml
@@ -194,11 +194,13 @@
         android:id="@+id/search_result_download_indicator_image_view"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="12dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        android:paddingStart="2dp"
+        android:paddingEnd="0dp"
         android:visibility="gone"
         app:layout_constraintBottom_toBottomOf="@+id/song_cover_image_view"
         app:layout_constraintEnd_toStartOf="@+id/search_result_song_more_button"
-        app:layout_constraintStart_toEndOf="@+id/rating_indicator_image_view"
         app:layout_constraintTop_toTopOf="@+id/song_cover_image_view"
         tools:visibility="visible">
 
@@ -213,10 +215,12 @@
         android:id="@+id/search_result_song_more_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:padding="12dp"
+        android:paddingTop="12dp"
+        android:paddingBottom="12dp"
+        android:paddingStart="2dp"
+        android:paddingEnd="12dp"
         app:layout_constraintBottom_toBottomOf="@+id/song_cover_image_view"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/search_result_download_indicator_image_view"
         app:layout_constraintTop_toTopOf="@+id/song_cover_image_view">
 
         <ImageView

--- a/app/src/main/res/layout/item_player_queue_song.xml
+++ b/app/src/main/res/layout/item_player_queue_song.xml
@@ -81,7 +81,7 @@
         android:paddingVertical="8dp"
         android:layout_marginHorizontal="12dp"
         app:layout_constraintBottom_toBottomOf="@+id/queue_song_cover_image_view"
-        app:layout_constraintEnd_toStartOf="@+id/queue_song_holder_image"
+        app:layout_constraintEnd_toStartOf="@+id/download_indicator_icon"
         app:layout_constraintStart_toEndOf="@+id/queue_song_title_text_view"
         app:layout_constraintTop_toTopOf="@+id/queue_song_cover_image_view">
 
@@ -145,7 +145,8 @@
         android:layout_height="20dp"
         android:layout_marginEnd="8dp"
         android:visibility="gone"
-        android:src="@drawable/ic_download"  app:layout_constraintBottom_toBottomOf="@+id/queue_song_cover_image_view"
+        android:src="@drawable/ic_download"
+        app:layout_constraintBottom_toBottomOf="@+id/queue_song_cover_image_view"
         app:layout_constraintEnd_toStartOf="@+id/queue_song_holder_image"
         app:layout_constraintTop_toTopOf="@+id/queue_song_cover_image_view"
         tools:visibility="visible" />
@@ -158,6 +159,5 @@
         android:src="@drawable/ic_drag_handle"
         app:layout_constraintBottom_toBottomOf="@+id/queue_song_cover_image_view"
         app:layout_constraintEnd_toEndOf="parent"
-        app:layout_constraintStart_toEndOf="@+id/rating_indicator_image_view"
         app:layout_constraintTop_toTopOf="@+id/queue_song_cover_image_view" />
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
attempting to revert as much of the `item_horizontal_track` to the stable version in `main`
#786 

@tvillega This is trying to keep the changes I made with the working version. I appreciate a quick look!

## screenshots:

### playlists

<details> 

<img width="270" height="606" alt="image" src="https://github.com/user-attachments/assets/96f05135-fef2-4e90-922c-f5bec1e294d7" />

<img width="606" height="270" alt="image" src="https://github.com/user-attachments/assets/90545d1d-1393-45ba-8b27-c9fb79fa9bff" />
</details> 

### playqueue

<details> 

<img width="270" height="606" alt="image" src="https://github.com/user-attachments/assets/2e89d790-21d6-4d4a-b08e-7990d393eeec" />

<img width="606" height="270" alt="image" src="https://github.com/user-attachments/assets/8b0b410d-007a-4da4-a060-c71985ed32ba" />

</details>