### PR TITLE
fix: Fix genre search not working

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/GenreCatalogueAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/GenreCatalogueAdapter.java
@@ -47,8 +47,7 @@ public class GenreCatalogueAdapter extends RecyclerView.Adapter<GenreCatalogueAd
 
         @Override
         protected void publishResults(CharSequence constraint, FilterResults results) {
-            genres.clear();
-            if (results.count > 0) genres.addAll((List) results.values);
+            genres = ((ArrayList<Genre>) results.values);
             notifyDataSetChanged();
         }
     };

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/GenreCatalogueFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/GenreCatalogueFragment.java
@@ -61,6 +61,7 @@ public class GenreCatalogueFragment extends Fragment implements ClickCallback {
         bind = FragmentGenreCatalogueBinding.inflate(inflater, container, false);
         View view = bind.getRoot();
         genreCatalogueViewModel = new ViewModelProvider(requireActivity()).get(GenreCatalogueViewModel.class);
+        genreCatalogueViewModel.loadGenreList();
 
         TileSizeManager.getInstance().calculateGenreSize( requireContext() );
         spanCount = TileSizeManager.getInstance().getGenreSpanCount( requireContext() );
@@ -136,14 +137,15 @@ public class GenreCatalogueFragment extends Fragment implements ClickCallback {
         searchView.setOnQueryTextListener(new SearchView.OnQueryTextListener() {
             @Override
             public boolean onQueryTextSubmit(String query) {
+                genreCatalogueAdapter.getFilter().filter(query);
                 searchView.clearFocus();
-                return false;
+                return true;
             }
 
             @Override
             public boolean onQueryTextChange(String newText) {
                 genreCatalogueAdapter.getFilter().filter(newText);
-                return false;
+                return true;
             }
         });
 

--- a/app/src/main/java/com/cappielloantonio/tempo/viewmodel/GenreCatalogueViewModel.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/viewmodel/GenreCatalogueViewModel.java
@@ -13,6 +13,7 @@ import java.util.List;
 
 public class GenreCatalogueViewModel extends AndroidViewModel {
     private final GenreRepository genreRepository;
+    private LiveData<List<Genre>> genres;
 
     public GenreCatalogueViewModel(@NonNull Application application) {
         super(application);
@@ -20,7 +21,13 @@ public class GenreCatalogueViewModel extends AndroidViewModel {
         genreRepository = new GenreRepository();
     }
 
+    public void loadGenreList() {
+        if (genres == null) {
+            genres = genreRepository.getGenres(false, -1);
+        }
+    }
+
     public LiveData<List<Genre>> getGenreList() {
-        return genreRepository.getGenres(false, -1);
+        return genres;
     }
 }


### PR DESCRIPTION
- Fixes: #816, #815 

I also fix `GenreCatalogueViewModel` always fetch genre list from repository when `getGenreList()` called

After Fix:

https://github.com/user-attachments/assets/0ae5b40b-4bdb-4c90-a19b-7fa30513c776


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved genre browsing so the list loads reliably when the screen opens.
  * Search filtering now works consistently for both typed text changes and search submissions.
  * Search results update more smoothly, helping the displayed genre list stay in sync with your query.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->