### PR TITLE
fix: show cached cover art when Limit mobile data usage is enabled

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/glide/CustomGlideRequest.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/glide/CustomGlideRequest.java
@@ -115,11 +115,14 @@ public class CustomGlideRequest {
                                           int size,
                                           CustomTarget<Bitmap> target) {
         String url = createUrl(coverId, size);
-        Glide.with(context)
+        var builder = Glide.with(context)
                 .asBitmap()
                 .load(url)
-                .apply(createRequestOptions(context, coverId, ResourceType.Album))
-                .into(target);
+                .apply(createRequestOptions(context, coverId, ResourceType.Album));
+        if (Preferences.isDataSavingMode()) {
+            builder = builder.onlyRetrieveFromCache(true);
+        }
+        builder.into(target);
     }
 
     public static class Builder {
@@ -129,7 +132,7 @@ public class CustomGlideRequest {
         private Builder(Context context, String item, ResourceType type) {
             this.requestManager = Glide.with(context);
 
-            if (item != null && !Preferences.isDataSavingMode()) {
+            if (item != null) {
                 this.item = createUrl(item, Preferences.getImageSize());
             }
 
@@ -141,9 +144,13 @@ public class CustomGlideRequest {
         }
 
         public RequestBuilder<Drawable> build() {
-            return requestManager
+            RequestBuilder<Drawable> builder = requestManager
                     .load(item)
                     .transition(DrawableTransitionOptions.withCrossFade());
+            if (Preferences.isDataSavingMode()) {
+                builder = builder.onlyRetrieveFromCache(true);
+            }
+            return builder;
         }
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/provider/AlbumArtContentProvider.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/provider/AlbumArtContentProvider.java
@@ -85,14 +85,19 @@ public class AlbumArtContentProvider extends ContentProvider {
                 try (OutputStream out = new ParcelFileDescriptor.AutoCloseOutputStream(writeSide)) {
 
                     // local radio cover: read directly from disk; otherwise fetch via Glide
-                    File file = (localFileFinal != null)
-                            ? localFileFinal
-                            : Glide.with(context)
-                                    .asFile()
-                                    .load(artworkUriFinal)
-                                    .diskCacheStrategy(DiskCacheStrategy.DATA)
-                                    .submit()
-                                    .get();
+                    File file;
+                    if (localFileFinal != null) {
+                        file = localFileFinal;
+                    } else {
+                        var fileRequest = Glide.with(context)
+                                .asFile()
+                                .load(artworkUriFinal)
+                                .diskCacheStrategy(DiskCacheStrategy.DATA);
+                        if (Preferences.isDataSavingMode()) {
+                            fileRequest = fileRequest.onlyRetrieveFromCache(true);
+                        }
+                        file = fileRequest.submit().get();
+                    }
 
                     // copy artwork down pipe returned by ContentProvider
                     try (InputStream in = new FileInputStream(file)) {


### PR DESCRIPTION
When data saving mode is active, `CustomGlideRequest` nulls out the cover URL so Glide loads nothing and always shows the placeholder, even when the cover is already present in the disk cache. Instead, keep the URL as the cache key and constrain the load with `onlyRetrieveFromCache(true)`: already-cached covers render without any network usage, and cache misses fall back to the placeholder.

This also applies the same constraint to `AlbumArtContentProvider` so SystemUI media controls and Android Auto reuse cached art instead of fetching on mobile data.

### Changes
- `CustomGlideRequest.Builder`: always build the cover URL; add `onlyRetrieveFromCache(true)` when `isDataSavingMode()` is true
- `CustomGlideRequest.loadAlbumArtBitmap`: same cache-only constraint
- `AlbumArtContentProvider.openFile`: same cache-only constraint for the cross-process file pipe used by SystemUI/Android Auto

### Testing
- Build passes (`./gradlew :app:assembleDebug`)
- When data saving is enabled and a cover was previously cached, it still displays without a network request
- When data saving is enabled and a cover was never cached, the placeholder is shown (no crash, no network usage)
- When data saving is disabled, covers download normally over the network

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added stronger data-saving behavior for album art loading, limiting artwork fetches to cached content when data-saving mode is enabled.

* **Bug Fixes**
  * Improved consistency in how album art is retrieved across the app and provider path.
  * Reduced unnecessary network use for artwork in data-saving mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->