### PR TITLE
fix: restore heart/repeat buttons in the media notification on Android 13 (#787)

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseSessionCallback.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseSessionCallback.kt
@@ -48,6 +48,7 @@ open class BaseSessionCallback(
         CommandButton.Builder(CommandButton.ICON_SHUFFLE_OFF)
             .setDisplayName(context.getString(R.string.exo_controls_shuffle_on_description))
             .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_ON, Bundle.EMPTY))
+            .setSlots(CommandButton.SLOT_OVERFLOW)
             .build()
 
     @SuppressLint("PrivateResource")
@@ -55,6 +56,7 @@ open class BaseSessionCallback(
         CommandButton.Builder(CommandButton.ICON_SHUFFLE_ON)
             .setDisplayName(context.getString(R.string.exo_controls_shuffle_off_description))
             .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_OFF, Bundle.EMPTY))
+            .setSlots(CommandButton.SLOT_OVERFLOW)
             .build()
 
     @SuppressLint("PrivateResource")
@@ -62,6 +64,7 @@ open class BaseSessionCallback(
         CommandButton.Builder(CommandButton.ICON_REPEAT_OFF)
             .setDisplayName(context.getString(R.string.exo_controls_repeat_off_description))
             .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_OFF, Bundle.EMPTY))
+            .setSlots(CommandButton.SLOT_OVERFLOW)
             .build()
 
     @SuppressLint("PrivateResource")
@@ -69,6 +72,7 @@ open class BaseSessionCallback(
         CommandButton.Builder(CommandButton.ICON_REPEAT_ONE)
             .setDisplayName(context.getString(R.string.exo_controls_repeat_one_description))
             .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ONE, Bundle.EMPTY))
+            .setSlots(CommandButton.SLOT_OVERFLOW)
             .build()
 
     @SuppressLint("PrivateResource")
@@ -76,6 +80,7 @@ open class BaseSessionCallback(
         CommandButton.Builder(CommandButton.ICON_REPEAT_ALL)
             .setDisplayName(context.getString(R.string.exo_controls_repeat_all_description))
             .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ALL, Bundle.EMPTY))
+            .setSlots(CommandButton.SLOT_OVERFLOW)
             .build()
 
     @Suppress("DEPRECATION")
@@ -84,6 +89,7 @@ open class BaseSessionCallback(
             .setDisplayName(context.getString(R.string.exo_controls_heart_on_description))
             .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_HEART_ON, Bundle.EMPTY))
             .setIconResId(R.drawable.ic_favorite)
+            .setSlots(CommandButton.SLOT_OVERFLOW)
             .build()
 
     @Suppress("DEPRECATION")
@@ -92,6 +98,7 @@ open class BaseSessionCallback(
             .setDisplayName(context.getString(R.string.exo_controls_heart_off_description))
             .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_HEART_OFF, Bundle.EMPTY))
             .setIconResId(R.drawable.ic_favorites_outlined)
+            .setSlots(CommandButton.SLOT_OVERFLOW)
             .build()
 
     @Suppress("DEPRECATION")
@@ -100,6 +107,7 @@ open class BaseSessionCallback(
             .setDisplayName(context.getString(R.string.cast_expanded_controller_loading))
             .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_TOGGLE_HEART_LOADING, Bundle.EMPTY))
             .setIconResId(R.drawable.ic_bookmark_sync)
+            .setSlots(CommandButton.SLOT_OVERFLOW)
             .build()
 
     @Suppress("DEPRECATION")
@@ -108,6 +116,7 @@ open class BaseSessionCallback(
             .setDisplayName("instantmix on")
             .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_INSTANT_MIX_ON, Bundle.EMPTY))
             .setIconResId(R.drawable.ic_instantmix_on)
+            .setSlots(CommandButton.SLOT_OVERFLOW)
             .build()
 
     @Suppress("DEPRECATION")
@@ -116,6 +125,27 @@ open class BaseSessionCallback(
             .setDisplayName("instantmix off")
             .setSessionCommand(SessionCommand(Constants.CUSTOM_COMMAND_INSTANT_MIX_OFF, Bundle.EMPTY))
             .setIconResId(R.drawable.media3_icon_minus_circle_unfilled)
+            .setSlots(CommandButton.SLOT_OVERFLOW)
+            .build()
+
+    // Standard transport controls. Kept pinned in setMediaButtonPreferences so the custom
+    // overflow buttons can't take their place on the last track (see #663).
+    private val previousButton =
+        CommandButton.Builder(CommandButton.ICON_PREVIOUS)
+            .setPlayerCommand(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
+            .setDisplayName("Previous")
+            .build()
+
+    private val playPauseButton =
+        CommandButton.Builder(CommandButton.ICON_PLAY)
+            .setPlayerCommand(Player.COMMAND_PLAY_PAUSE)
+            .setDisplayName("Play/Pause")
+            .build()
+
+    private val nextButton =
+        CommandButton.Builder(CommandButton.ICON_NEXT)
+            .setPlayerCommand(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
+            .setDisplayName("Next")
             .build()
 
     private val customLayoutCommandButtons = listOf(
@@ -184,38 +214,13 @@ open class BaseSessionCallback(
             session.player.addListener(playerListener)
         }
 
-        val previousButton =
-            CommandButton.Builder(CommandButton.ICON_PREVIOUS)
-                .setPlayerCommand(Player.COMMAND_SEEK_TO_PREVIOUS_MEDIA_ITEM)
-                .setDisplayName("Previous")
-                .build()
-
-        val playPauseButton =
-            CommandButton.Builder(CommandButton.ICON_PLAY)
-                .setPlayerCommand(Player.COMMAND_PLAY_PAUSE)
-                .setDisplayName("Play/Pause")
-                .build()
-
-        val nextButton =
-            CommandButton.Builder(CommandButton.ICON_NEXT)
-                .setPlayerCommand(Player.COMMAND_SEEK_TO_NEXT_MEDIA_ITEM)
-                .setDisplayName("Next")
-                .build()
-
         if (session.isMediaNotificationController(controller) ||
             session.isAutomotiveController(controller) ||
             session.isAutoCompanionController(controller)
         ) {
             return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
                 .setAvailableSessionCommands(mediaNotificationSessionCommands)
-                .setMediaButtonPreferences(
-                    ImmutableList.of(
-                        previousButton,
-                        playPauseButton,
-                        nextButton
-                    )
-                )
-                .setCustomLayout(buildCustomLayout(session.player))
+                .setMediaButtonPreferences(buildMediaButtonPreferences(session.player))
                 .build()
         }
 
@@ -232,10 +237,23 @@ open class BaseSessionCallback(
         isRatingPending: Boolean = false
     ) {
         val controller = session.mediaNotificationControllerInfo ?: return
-        session.setCustomLayout(
+        session.setMediaButtonPreferences(
             controller,
-            buildCustomLayout(session.player, isRatingPending)
+            buildMediaButtonPreferences(session.player, isRatingPending)
         )
+    }
+
+    // Pinned transport controls + the custom buttons (each in SLOT_OVERFLOW), built as one
+    // media-button-preferences list so the custom buttons actually render in the notification on
+    // Android 13 (#787); the deprecated setCustomLayout stopped applying them there once
+    // setMediaButtonPreferences was introduced for #663.
+    private fun buildMediaButtonPreferences(
+        player: Player,
+        isRatingPending: Boolean = false
+    ): ImmutableList<CommandButton> {
+        val buttons = mutableListOf(previousButton, playPauseButton, nextButton)
+        buttons.addAll(buildCustomLayout(player, isRatingPending))
+        return ImmutableList.copyOf(buttons)
     }
 
     protected fun buildCustomLayout(


### PR DESCRIPTION
Fixes #787.

### What was wrong
On some devices (reported on a Samsung A12 / Android 13, OneUI) the heart and
repeat buttons disappeared from the media notification, while the transport
controls stayed.

### Root cause
#663 added `setMediaButtonPreferences(previous, playPause, next)` to keep the
transport buttons pinned. On media3 1.8, once `setMediaButtonPreferences` is
set it drives the notification layout, and the deprecated `setCustomLayout(...)`
we still used for the custom buttons no longer places them in the notification.
So the transport controls stayed (that part of #663 kept working) but
heart/repeat dropped out.

### The fix
Move the custom buttons into `setMediaButtonPreferences` as well, each pinned to
`CommandButton.SLOT_OVERFLOW` so they render without displacing the transport
controls (keeping #663's reserved next-button behaviour), and drop the
deprecated `setCustomLayout`. The set of buttons the session exposes is
unchanged, only their notification placement moves. The transport buttons keep
the display-name labels added in #822.

### Testing
Confirmed on the reporter's real device: @Kurami32 verified the heart/repeat
buttons are back on the Samsung A12 (Android 13) from this fork's build.

I could not reproduce the original drop-out on emulators (an Android 13 and an
Android 15 AOSP image both render the notification the same, and the session
exposes all four custom buttons on both), so this looks like a OneUI rendering
difference with no matching emulator image.

### Note on Android Auto
`onConnect` handles the notification controller and the Android Auto /
Auto-companion controllers on the same branch, so this change also routes the
custom buttons through `setMediaButtonPreferences` for Auto. That path is not
device-verified here, only the notification is.
