### PR TITLE
fix: stop server-ping loop when local and remote addresses match (#242)

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/activity/MainActivity.java
@@ -474,11 +474,21 @@ public class MainActivity extends BaseActivity {
         if (Preferences.isInUseServerAddressLocal()) {
             mainViewModel.ping().observe(this, subsonicResponse -> {
                 if (subsonicResponse == null) {
-                    Preferences.setServerSwitchableTimer();
-                    Preferences.switchInUseServerAddress();
-                    App.refreshSubsonicClient();
-                    pingServer();
-                    resetView();
+                    // Switching only helps when remote and local are different addresses. When
+                    // they're equal (issue #242) switchInUseServerAddress() is a no-op, so we'd
+                    // re-enter this branch forever (ping/refresh/resetView loop). Treat that case
+                    // like an unreachable server instead of looping.
+                    String server = Preferences.getServer();
+                    if (server != null && !server.equals(Preferences.getLocalAddress())) {
+                        Preferences.setServerSwitchableTimer();
+                        Preferences.switchInUseServerAddress();
+                        App.refreshSubsonicClient();
+                        pingServer();
+                        resetView();
+                    } else if (Preferences.showServerUnreachableDialog()) {
+                        ServerUnreachableDialog dialog = new ServerUnreachableDialog();
+                        dialog.show(getSupportFragmentManager(), null);
+                    }
                 } else {
                     Preferences.setOpenSubsonic(subsonicResponse.getOpenSubsonic() != null && subsonicResponse.getOpenSubsonic());
                 }


### PR DESCRIPTION
closes #242 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a server connection loop that could repeatedly refresh the app when the local server address was unavailable.
  * Improved server fallback behavior so the app now avoids unnecessary switching when the configured server matches the local address.
  * When the server can’t be reached, the app now shows the unreachable server dialog instead of getting stuck in repeated retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->