### PR TITLE
feat: stable streaming cache keys + optional pre-cache of upcoming queue tracks

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -238,6 +238,7 @@ open class BaseMediaService : MediaLibraryService() {
                 }
 
                 updateWidget(player)
+                QueuePreloader.preload(this@BaseMediaService, player)
             }
 
             override fun onTimelineChanged(timeline: Timeline, reason: Int) {
@@ -247,6 +248,7 @@ open class BaseMediaService : MediaLibraryService() {
                 } catch (t: Throwable) {
                     Log.w(TAG, "prefetchQueueGains failed: $t")
                 }
+                QueuePreloader.preload(this@BaseMediaService, player)
                 if (timeline.isEmpty) return
                 val window = Timeline.Window()
                 for (i in 0 until timeline.windowCount) {
@@ -569,6 +571,7 @@ open class BaseMediaService : MediaLibraryService() {
     }
 
     override fun onDestroy() {
+        QueuePreloader.cancel()
         releaseNetworkCallback()
         equalizerManager.release(exoplayer.audioSessionId)
         ReplayGainUtil.release()

--- a/app/src/main/java/com/cappielloantonio/tempo/service/QueuePreloader.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/QueuePreloader.kt
@@ -52,8 +52,11 @@ object QueuePreloader {
 
         val uris = collectUpcomingStreamUris(appContext, player, count)
 
-        val myGeneration = generation.incrementAndGet()
-        activeWriter?.cancel()
+        val myGeneration: Int
+        synchronized(this) {
+            myGeneration = generation.incrementAndGet()
+            activeWriter?.cancel()
+        }
 
         if (uris.isEmpty()) return
 
@@ -66,8 +69,10 @@ object QueuePreloader {
     }
 
     fun cancel() {
-        generation.incrementAndGet()
-        activeWriter?.cancel()
+        synchronized(this) {
+            generation.incrementAndGet()
+            activeWriter?.cancel()
+        }
     }
 
     private fun collectUpcomingStreamUris(context: Context, player: Player, count: Int): List<Uri> {
@@ -109,7 +114,14 @@ object QueuePreloader {
         val dataSource = DownloadUtil.getStreamingCacheWriterFactory(context).createDataSource()
         val writer = CacheWriter(dataSource, dataSpec, null, null)
 
-        activeWriter = writer
+        // Re-check the generation while holding the same lock cancel() takes:
+        // otherwise a cancel() landing between the caller's generation check and
+        // this assignment would miss the writer and the stale write would run to
+        // completion.
+        synchronized(this) {
+            if (generation.get() != myGeneration) return
+            activeWriter = writer
+        }
 
         try {
             writer.cache()
@@ -118,7 +130,9 @@ object QueuePreloader {
             Log.d(TAG, "Pre-cache aborted for $uri: $exception")
             removePartialResource(context, dataSource.cacheKeyFactory.buildCacheKey(dataSpec))
         } finally {
-            if (activeWriter === writer) activeWriter = null
+            synchronized(this) {
+                if (activeWriter === writer) activeWriter = null
+            }
         }
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/service/QueuePreloader.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/QueuePreloader.kt
@@ -1,0 +1,146 @@
+package com.cappielloantonio.tempo.service
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Uri
+import android.util.Log
+import androidx.media3.common.C
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.cache.CacheWriter
+import androidx.media3.datasource.cache.ContentMetadata
+import com.cappielloantonio.tempo.util.Constants
+import com.cappielloantonio.tempo.util.DownloadUtil
+import com.cappielloantonio.tempo.util.Preferences
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Pre-caches the next tracks of the play queue into the streaming cache, so
+ * skips start instantly and playback survives short connectivity drops. The
+ * player reads through the same cache with the same keys, so anything written
+ * here is picked up transparently.
+ *
+ * Runs only when the user enabled it (settings > data), never for radio
+ * streams or already-downloaded tracks, and by default only on unmetered
+ * networks.
+ */
+@UnstableApi
+object QueuePreloader {
+    private const val TAG = "QueuePreloader"
+
+    private val executor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "queue-preloader").apply { priority = Thread.MIN_PRIORITY }
+    }
+    private val generation = AtomicInteger(0)
+
+    @Volatile
+    private var activeWriter: CacheWriter? = null
+
+    /** Must be called from the player's application thread. */
+    fun preload(context: Context, player: Player) {
+        val count = Preferences.getPrecacheTracksCount()
+        if (count <= 0) return
+
+        val appContext = context.applicationContext
+
+        if (Preferences.isPrecacheWifiOnly() && isMetered(appContext)) {
+            cancel()
+            return
+        }
+
+        val uris = collectUpcomingStreamUris(appContext, player, count)
+
+        val myGeneration = generation.incrementAndGet()
+        activeWriter?.cancel()
+
+        if (uris.isEmpty()) return
+
+        executor.execute {
+            for (uri in uris) {
+                if (generation.get() != myGeneration) return@execute
+                cacheTrack(appContext, uri, myGeneration)
+            }
+        }
+    }
+
+    fun cancel() {
+        generation.incrementAndGet()
+        activeWriter?.cancel()
+    }
+
+    private fun collectUpcomingStreamUris(context: Context, player: Player, count: Int): List<Uri> {
+        val timeline = player.currentTimeline
+        if (timeline.isEmpty) return emptyList()
+
+        val currentIndex = player.currentMediaItemIndex
+        if (currentIndex == C.INDEX_UNSET) return emptyList()
+
+        val uris = ArrayList<Uri>(count)
+        var index = currentIndex
+
+        while (uris.size < count) {
+            index = timeline.getNextWindowIndex(index, Player.REPEAT_MODE_OFF, player.shuffleModeEnabled)
+            if (index == C.INDEX_UNSET || index == currentIndex) break
+
+            val mediaItem = player.getMediaItemAt(index)
+
+            val type = mediaItem.mediaMetadata.extras?.getString("type")
+            if (type == Constants.MEDIA_TYPE_RADIO || mediaItem.mediaId.startsWith("ir-")) continue
+
+            if (DownloadUtil.getDownloadTracker(context).isDownloaded(mediaItem.mediaId)) continue
+
+            val uri = mediaItem.localConfiguration?.uri
+                ?: mediaItem.requestMetadata.mediaUri
+                ?: continue
+
+            val scheme = uri.scheme
+            if (scheme != "http" && scheme != "https") continue
+
+            uris.add(uri)
+        }
+
+        return uris
+    }
+
+    private fun cacheTrack(context: Context, uri: Uri, myGeneration: Int) {
+        val dataSpec = DataSpec.Builder().setUri(uri).build()
+        val dataSource = DownloadUtil.getStreamingCacheWriterFactory(context).createDataSource()
+        val writer = CacheWriter(dataSource, dataSpec, null, null)
+
+        activeWriter = writer
+
+        try {
+            writer.cache()
+            Log.d(TAG, "Pre-cached $uri")
+        } catch (exception: Exception) {
+            Log.d(TAG, "Pre-cache aborted for $uri: $exception")
+            removePartialResource(context, dataSource.cacheKeyFactory.buildCacheKey(dataSpec))
+        } finally {
+            if (activeWriter === writer) activeWriter = null
+        }
+    }
+
+    /**
+     * Same policy as StreamingCacheDataSource.close(): a resource whose total
+     * length never became known is an unfinished transcode fragment that can't
+     * be safely resumed with a range request, so drop it.
+     */
+    private fun removePartialResource(context: Context, cacheKey: String) {
+        try {
+            val cache = DownloadUtil.getStreamingCacheForPreload(context)
+            val contentLength = ContentMetadata.getContentLength(cache.getContentMetadata(cacheKey))
+            if (contentLength == C.LENGTH_UNSET.toLong()) {
+                cache.removeResource(cacheKey)
+            }
+        } catch (exception: Exception) {
+            Log.w(TAG, "Failed to clean up partial cache entry $cacheKey: $exception")
+        }
+    }
+
+    private fun isMetered(context: Context): Boolean {
+        val connectivityManager = context.getSystemService(ConnectivityManager::class.java) ?: return true
+        return connectivityManager.isActiveNetworkMetered
+    }
+}

--- a/app/src/main/java/com/cappielloantonio/tempo/util/DownloadUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/DownloadUtil.java
@@ -111,6 +111,7 @@ public final class DownloadUtil {
     public static synchronized DataSource.Factory getCacheDataSourceFactory(Context context) {
         CacheDataSource.Factory streamCacheFactory = new CacheDataSource.Factory()
                 .setCache(getStreamingCache(context))
+                .setCacheKeyFactory(new StreamingCacheKeyFactory())
                 .setUpstreamDataSourceFactory(getUpstreamDataSourceFactory(context));
 
         ResolvingDataSource.Factory resolvingFactory = new ResolvingDataSource.Factory(
@@ -123,6 +124,23 @@ public final class DownloadUtil {
         );
         dataSourceFactory = buildReadOnlyCacheDataSource(resolvingFactory, getDownloadCache(context));
         return dataSourceFactory;
+    }
+
+    /**
+     * Writes into the same streaming cache (and with the same keys) the player reads
+     * from, but bypasses the download-cache/resolving wrappers of
+     * {@link #getCacheDataSourceFactory(Context)}: CacheWriter needs a plain
+     * CacheDataSource.
+     */
+    public static synchronized CacheDataSource.Factory getStreamingCacheWriterFactory(Context context) {
+        return new CacheDataSource.Factory()
+                .setCache(getStreamingCache(context))
+                .setCacheKeyFactory(new StreamingCacheKeyFactory())
+                .setUpstreamDataSourceFactory(new DefaultDataSource.Factory(context, getHttpDataSourceFactory()));
+    }
+
+    public static synchronized Cache getStreamingCacheForPreload(Context context) {
+        return getStreamingCache(context);
     }
 
     public static synchronized DownloadNotificationHelper getDownloadNotificationHelper(Context context) {

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -71,6 +71,8 @@ object Preferences {
     private const val SHARE = "share"
     private const val SCROBBLING = "scrobbling"
     private const val SONG_PRELOAD_BUFFER = "song_preload_buffer"
+    private const val PRECACHE_TRACKS_COUNT = "precache_tracks_count"
+    private const val PRECACHE_WIFI_ONLY = "precache_wifi_only"
     private const val SKIP_MIN_STAR_RATING = "skip_min_star_rating"
     private const val MIN_STAR_RATING = "min_star_rating"
     private const val ALWAYS_ON_DISPLAY = "always_on_display"
@@ -669,6 +671,16 @@ object Preferences {
     @JvmStatic
     fun getSongPreloadBuffer(): Int {
         return App.getInstance().preferences.getString(SONG_PRELOAD_BUFFER, "60")!!.toInt()
+    }
+
+    @JvmStatic
+    fun getPrecacheTracksCount(): Int {
+        return App.getInstance().preferences.getString(PRECACHE_TRACKS_COUNT, "0")!!.toInt()
+    }
+
+    @JvmStatic
+    fun isPrecacheWifiOnly(): Boolean {
+        return App.getInstance().preferences.getBoolean(PRECACHE_WIFI_ONLY, true)
     }
 
     @JvmStatic

--- a/app/src/main/java/com/cappielloantonio/tempo/util/StreamingCacheKeyFactory.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/StreamingCacheKeyFactory.kt
@@ -1,0 +1,39 @@
+package com.cappielloantonio.tempo.util
+
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.cache.CacheKeyFactory
+
+/**
+ * Cache key for the streaming cache based on what identifies the audio bytes
+ * (server + song id + requested transcode quality) instead of the full URL.
+ *
+ * The full URL is a bad key: it carries the auth token/salt and whichever of the
+ * two server addresses (local vs public) is currently in use, so the same already
+ * cached track becomes a cache miss - and a duplicate cache entry - as soon as any
+ * of those change. maxBitRate/format stay part of the key because a different
+ * transcode really is different audio.
+ */
+@UnstableApi
+class StreamingCacheKeyFactory : CacheKeyFactory {
+    override fun buildCacheKey(dataSpec: DataSpec): String {
+        dataSpec.key?.let { return it }
+
+        val uri = dataSpec.uri
+        val scheme = uri.scheme
+        if (scheme != "http" && scheme != "https") return uri.toString()
+
+        val id = try {
+            uri.getQueryParameter("id")
+        } catch (exception: UnsupportedOperationException) {
+            null // opaque uri, cannot be parsed for query parameters
+        } ?: return uri.toString()
+
+        val bitrate = uri.getQueryParameter("maxBitRate").orEmpty()
+        val format = uri.getQueryParameter("format").orEmpty()
+        val timeOffset = uri.getQueryParameter("timeOffset").orEmpty()
+        val server = Preferences.getServerId().orEmpty()
+
+        return "$server|$id|$bitrate|$format|$timeOffset"
+    }
+}

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -251,6 +251,21 @@
         <item>600</item>
     </string-array>
 
+    <string-array name="precache_tracks_titles">
+        <item>Disabled</item>
+        <item>Next track</item>
+        <item>Next 2 tracks</item>
+        <item>Next 3 tracks</item>
+        <item>Next 5 tracks</item>
+    </string-array>
+    <string-array name="precache_tracks_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>5</item>
+    </string-array>
+
     <string-array name="playlist_sort_option_titles">
         <item>Name</item>
         <item>Random</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -413,6 +413,10 @@
     <string name="settings_set_download_folder">Set download folder</string>
     <string name="settings_song_preload_buffer">Song preload buffer</string>
     <string name="settings_song_preload_buffer_summary">Current value: %1$s\nFor the change to take effect you must manually restart the app.</string>
+    <string name="settings_precache_tracks">Pre-cache upcoming tracks</string>
+    <string name="settings_precache_tracks_summary">Fully cache the next tracks of the queue in the background, so skips start instantly and playback survives short signal drops</string>
+    <string name="settings_precache_wifi_only">Pre-cache on Wi-Fi only</string>
+    <string name="settings_precache_wifi_only_summary">Pause pre-caching while on a metered connection</string>
     <string name="settings_system_equalizer_summary">Adjust audio settings</string>
     <string name="settings_system_equalizer_title">System equalizer</string>
     <string name="settings_github_link">https://github.com/eddyizm/tempus</string>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -355,6 +355,21 @@
             app:title="@string/settings_song_preload_buffer"
             app:summary="@string/settings_song_preload_buffer_summary" />
 
+        <ListPreference
+            app:defaultValue="0"
+            app:dialogTitle="@string/settings_precache_tracks"
+            app:entries="@array/precache_tracks_titles"
+            app:entryValues="@array/precache_tracks_values"
+            app:key="precache_tracks_count"
+            app:title="@string/settings_precache_tracks"
+            app:summary="@string/settings_precache_tracks_summary" />
+
+        <SwitchPreference
+            android:title="@string/settings_precache_wifi_only"
+            android:defaultValue="true"
+            android:summary="@string/settings_precache_wifi_only_summary"
+            android:key="precache_wifi_only" />
+
         <Preference
             android:key="streaming_cache_storage"
             app:title="@string/settings_streaming_cache_storage_title" />


### PR DESCRIPTION
## What

Two improvements that make streaming feel instant and stop wasting data, using the cache infrastructure that is already in place:

**1. Stable, content-based streaming cache keys** (`StreamingCacheKeyFactory`)

The streaming cache currently keys entries by the full stream URL. That URL carries the auth token/salt and whichever server address (local vs public) is in use, and `MusicUtil.getStreamUri()`/`updateStreamUri()` splice in `&maxBitRate=`/`&format=` based on the currently active network. Any of those changing turns an already-cached track into a cache miss and a duplicate cache entry. Most notably: leaving home Wi-Fi (local address -> public address) invalidated the entire streaming cache.

The new `CacheKeyFactory` keys entries on `serverId | song id | maxBitRate | format | timeOffset` instead. Bitrate/format stay in the key on purpose - a different transcode really is different audio. Old URL-keyed entries simply become unreferenced and age out through the existing LRU evictor.

**2. Optional pre-caching of upcoming queue tracks** (`QueuePreloader`)

New setting (Settings > Data, default **off**): fully cache the next 1/2/3/5 queue tracks in the background via `CacheWriter`, into the same streaming cache the player reads through - so skips start instantly and playback survives short signal drops. Details:

- Runs on track transitions and queue changes; superseded preload runs are cancelled (generation counter + `CacheWriter.cancel()`).
- Follows shuffle order via `Timeline.getNextWindowIndex`.
- Skips radio streams (endless), already-downloaded tracks, and non-http URIs.
- "Pre-cache on Wi-Fi only" companion switch (default on) pauses it on metered networks.
- On abort it applies the same policy as `StreamingCacheDataSource.close()`: partial entries with unknown total length are removed, so no un-resumable transcode fragments are left behind.

## Why

This is the biggest "feels like a first-class streaming service" win available without server changes: instant skips, fewer rebuffers on network handoff, and less duplicate data use. Refs #859.

## Testing

- Built `assembleTempusDebug` locally.
- Pre-caching is opt-in (default 0 tracks), so behavior is unchanged unless the user enables it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to precache upcoming tracks for faster playback.
  * Lets you choose how many tracks to precache (next 1/2/3/5) or disable precaching.
  * Added a Wi‑Fi-only switch to limit preloading on metered connections.
* **Improvements**
  * Preloading now adapts to playback queue/timeline changes and cancels pending work when no longer needed.
  * Updated caching behavior to better reuse streaming cache entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->