### PR TITLE
feat: optional pre-cache of upcoming queue tracks

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -970,6 +970,10 @@ open class BaseMediaService : MediaLibraryService() {
                 wasWifi = isWifi
                 widgetUpdateHandler.post {
                     updateMediaItems(mediaLibrarySession.player)
+                    // preload() re-evaluates the network itself: it cancels any
+                    // in-flight precache when the new network is not allowed and
+                    // restarts it when it is.
+                    QueuePreloader.preload(this@BaseMediaService, mediaLibrarySession.player)
                 }
             }
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -278,6 +278,7 @@ open class BaseMediaService : MediaLibraryService() {
                 }
 
                 updateWidget(player)
+                QueuePreloader.preload(this@BaseMediaService, player)
             }
 
             override fun onTimelineChanged(timeline: Timeline, reason: Int) {
@@ -287,6 +288,7 @@ open class BaseMediaService : MediaLibraryService() {
                 } catch (t: Throwable) {
                     Log.w(TAG, "prefetchQueueGains failed: $t")
                 }
+                QueuePreloader.preload(this@BaseMediaService, player)
                 if (timeline.isEmpty) return
                 val window = Timeline.Window()
                 for (i in 0 until timeline.windowCount) {
@@ -609,6 +611,7 @@ open class BaseMediaService : MediaLibraryService() {
     }
 
     override fun onDestroy() {
+        QueuePreloader.cancel()
         releaseNetworkCallback()
         equalizerManager.release(exoplayer.audioSessionId)
         ReplayGainUtil.release()

--- a/app/src/main/java/com/cappielloantonio/tempo/service/QueuePreloader.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/QueuePreloader.kt
@@ -86,7 +86,7 @@ object QueuePreloader {
         var index = currentIndex
 
         while (uris.size < count) {
-            index = timeline.getNextWindowIndex(index, Player.REPEAT_MODE_OFF, player.shuffleModeEnabled)
+            index = timeline.getNextWindowIndex(index, player.repeatMode, player.shuffleModeEnabled)
             if (index == C.INDEX_UNSET || index == currentIndex) break
 
             val mediaItem = player.getMediaItemAt(index)

--- a/app/src/main/java/com/cappielloantonio/tempo/service/QueuePreloader.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/QueuePreloader.kt
@@ -1,0 +1,160 @@
+package com.cappielloantonio.tempo.service
+
+import android.content.Context
+import android.net.ConnectivityManager
+import android.net.Uri
+import android.util.Log
+import androidx.media3.common.C
+import androidx.media3.common.Player
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.datasource.DataSpec
+import androidx.media3.datasource.cache.CacheWriter
+import androidx.media3.datasource.cache.ContentMetadata
+import com.cappielloantonio.tempo.util.Constants
+import com.cappielloantonio.tempo.util.DownloadUtil
+import com.cappielloantonio.tempo.util.Preferences
+import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
+
+/**
+ * Pre-caches the next tracks of the play queue into the streaming cache, so
+ * skips start instantly and playback survives short connectivity drops. The
+ * player reads through the same cache with the same keys, so anything written
+ * here is picked up transparently.
+ *
+ * Runs only when the user enabled it (settings > data), never for radio
+ * streams or already-downloaded tracks, and by default only on unmetered
+ * networks.
+ */
+@UnstableApi
+object QueuePreloader {
+    private const val TAG = "QueuePreloader"
+
+    private val executor = Executors.newSingleThreadExecutor { runnable ->
+        Thread(runnable, "queue-preloader").apply { priority = Thread.MIN_PRIORITY }
+    }
+    private val generation = AtomicInteger(0)
+
+    @Volatile
+    private var activeWriter: CacheWriter? = null
+
+    /** Must be called from the player's application thread. */
+    fun preload(context: Context, player: Player) {
+        val count = Preferences.getPrecacheTracksCount()
+        if (count <= 0) return
+
+        val appContext = context.applicationContext
+
+        if (Preferences.isPrecacheWifiOnly() && isMetered(appContext)) {
+            cancel()
+            return
+        }
+
+        val uris = collectUpcomingStreamUris(appContext, player, count)
+
+        val myGeneration: Int
+        synchronized(this) {
+            myGeneration = generation.incrementAndGet()
+            activeWriter?.cancel()
+        }
+
+        if (uris.isEmpty()) return
+
+        executor.execute {
+            for (uri in uris) {
+                if (generation.get() != myGeneration) return@execute
+                cacheTrack(appContext, uri, myGeneration)
+            }
+        }
+    }
+
+    fun cancel() {
+        synchronized(this) {
+            generation.incrementAndGet()
+            activeWriter?.cancel()
+        }
+    }
+
+    private fun collectUpcomingStreamUris(context: Context, player: Player, count: Int): List<Uri> {
+        val timeline = player.currentTimeline
+        if (timeline.isEmpty) return emptyList()
+
+        val currentIndex = player.currentMediaItemIndex
+        if (currentIndex == C.INDEX_UNSET) return emptyList()
+
+        val uris = ArrayList<Uri>(count)
+        var index = currentIndex
+
+        while (uris.size < count) {
+            index = timeline.getNextWindowIndex(index, Player.REPEAT_MODE_OFF, player.shuffleModeEnabled)
+            if (index == C.INDEX_UNSET || index == currentIndex) break
+
+            val mediaItem = player.getMediaItemAt(index)
+
+            val type = mediaItem.mediaMetadata.extras?.getString("type")
+            if (type == Constants.MEDIA_TYPE_RADIO || mediaItem.mediaId.startsWith("ir-")) continue
+
+            if (DownloadUtil.getDownloadTracker(context).isDownloaded(mediaItem.mediaId)) continue
+
+            val uri = mediaItem.localConfiguration?.uri
+                ?: mediaItem.requestMetadata.mediaUri
+                ?: continue
+
+            val scheme = uri.scheme
+            if (scheme != "http" && scheme != "https") continue
+
+            uris.add(uri)
+        }
+
+        return uris
+    }
+
+    private fun cacheTrack(context: Context, uri: Uri, myGeneration: Int) {
+        val dataSpec = DataSpec.Builder().setUri(uri).build()
+        val dataSource = DownloadUtil.getStreamingCacheWriterFactory(context).createDataSource()
+        val writer = CacheWriter(dataSource, dataSpec, null, null)
+
+        // Re-check the generation while holding the same lock cancel() takes:
+        // otherwise a cancel() landing between the caller's generation check and
+        // this assignment would miss the writer and the stale write would run to
+        // completion.
+        synchronized(this) {
+            if (generation.get() != myGeneration) return
+            activeWriter = writer
+        }
+
+        try {
+            writer.cache()
+            Log.d(TAG, "Pre-cached $uri")
+        } catch (exception: Exception) {
+            Log.d(TAG, "Pre-cache aborted for $uri: $exception")
+            removePartialResource(context, dataSource.cacheKeyFactory.buildCacheKey(dataSpec))
+        } finally {
+            synchronized(this) {
+                if (activeWriter === writer) activeWriter = null
+            }
+        }
+    }
+
+    /**
+     * Same policy as StreamingCacheDataSource.close(): a resource whose total
+     * length never became known is an unfinished transcode fragment that can't
+     * be safely resumed with a range request, so drop it.
+     */
+    private fun removePartialResource(context: Context, cacheKey: String) {
+        try {
+            val cache = DownloadUtil.getStreamingCacheForPreload(context)
+            val contentLength = ContentMetadata.getContentLength(cache.getContentMetadata(cacheKey))
+            if (contentLength == C.LENGTH_UNSET.toLong()) {
+                cache.removeResource(cacheKey)
+            }
+        } catch (exception: Exception) {
+            Log.w(TAG, "Failed to clean up partial cache entry $cacheKey: $exception")
+        }
+    }
+
+    private fun isMetered(context: Context): Boolean {
+        val connectivityManager = context.getSystemService(ConnectivityManager::class.java) ?: return true
+        return connectivityManager.isActiveNetworkMetered
+    }
+}

--- a/app/src/main/java/com/cappielloantonio/tempo/service/QueuePreloader.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/QueuePreloader.kt
@@ -13,6 +13,7 @@ import androidx.media3.datasource.cache.ContentMetadata
 import com.cappielloantonio.tempo.util.Constants
 import com.cappielloantonio.tempo.util.DownloadUtil
 import com.cappielloantonio.tempo.util.Preferences
+import com.cappielloantonio.tempo.util.StreamingCacheKeyFactory
 import java.util.concurrent.Executors
 import java.util.concurrent.atomic.AtomicInteger
 
@@ -38,10 +39,15 @@ object QueuePreloader {
     @Volatile
     private var activeWriter: CacheWriter? = null
 
+    /** Target of the task currently queued/executing; empty when idle. */
+    @Volatile
+    private var runningUris: List<Uri> = emptyList()
+
     /** Must be called from the player's application thread. */
     fun preload(context: Context, player: Player) {
         val count = Preferences.getPrecacheTracksCount()
         if (count <= 0) return
+        if (Preferences.getStreamingCacheSize() <= 0L) return
 
         val appContext = context.applicationContext
 
@@ -54,7 +60,14 @@ object QueuePreloader {
 
         val myGeneration: Int
         synchronized(this) {
+            // The in-flight task is already working towards exactly this target:
+            // leave it alone. preload() fires on every timeline/metadata/network
+            // event, and restarting the writer each time discards all progress on
+            // unknown-length (transcoded) content, so the precache never finishes.
+            if (uris == runningUris) return
+
             myGeneration = generation.incrementAndGet()
+            runningUris = uris
             activeWriter?.cancel()
         }
 
@@ -63,7 +76,13 @@ object QueuePreloader {
         executor.execute {
             for (uri in uris) {
                 if (generation.get() != myGeneration) return@execute
+                if (isFullyCached(appContext, uri)) continue
                 cacheTrack(appContext, uri, myGeneration)
+            }
+            // Clear the target so the next preload() retries tracks that failed
+            // (fully cached ones are skipped by the check above anyway).
+            synchronized(this) {
+                if (generation.get() == myGeneration) runningUris = emptyList()
             }
         }
     }
@@ -71,6 +90,7 @@ object QueuePreloader {
     fun cancel() {
         synchronized(this) {
             generation.incrementAndGet()
+            runningUris = emptyList()
             activeWriter?.cancel()
         }
     }
@@ -112,6 +132,12 @@ object QueuePreloader {
     private fun cacheTrack(context: Context, uri: Uri, myGeneration: Int) {
         val dataSpec = DataSpec.Builder().setUri(uri).build()
         val dataSource = DownloadUtil.getStreamingCacheWriterFactory(context).createDataSource()
+        val cacheKey = dataSource.cacheKeyFactory.buildCacheKey(dataSpec)
+
+        // A leftover unknown-length partial from an interrupted earlier run can't
+        // be resumed with a range request; drop it so this run starts clean.
+        removePartialResource(context, cacheKey)
+
         val writer = CacheWriter(dataSource, dataSpec, null, null)
 
         // Re-check the generation while holding the same lock cancel() takes:
@@ -128,11 +154,30 @@ object QueuePreloader {
             Log.d(TAG, "Pre-cached $uri")
         } catch (exception: Exception) {
             Log.d(TAG, "Pre-cache aborted for $uri: $exception")
-            removePartialResource(context, dataSource.cacheKeyFactory.buildCacheKey(dataSpec))
+            // When connectivity was just lost, keep whatever got cached: it is a
+            // valid prefix written in one continuous run, and it is exactly what
+            // an imminent offline skip needs to keep playing. The player's own
+            // close() policy (and the start-clean removal above) cleans it up
+            // later. While still online, apply the usual unknown-length cleanup
+            // so playback never resumes into a mismatched fresh transcode.
+            if (hasActiveNetwork(context)) {
+                removePartialResource(context, cacheKey)
+            }
         } finally {
             synchronized(this) {
                 if (activeWriter === writer) activeWriter = null
             }
+        }
+    }
+
+    private fun isFullyCached(context: Context, uri: Uri): Boolean {
+        return try {
+            val cache = DownloadUtil.getStreamingCacheForPreload(context)
+            val cacheKey = StreamingCacheKeyFactory().buildCacheKey(DataSpec.Builder().setUri(uri).build())
+            val contentLength = ContentMetadata.getContentLength(cache.getContentMetadata(cacheKey))
+            contentLength != C.LENGTH_UNSET.toLong() && cache.isCached(cacheKey, 0, contentLength)
+        } catch (exception: Exception) {
+            false
         }
     }
 
@@ -156,5 +201,10 @@ object QueuePreloader {
     private fun isMetered(context: Context): Boolean {
         val connectivityManager = context.getSystemService(ConnectivityManager::class.java) ?: return true
         return connectivityManager.isActiveNetworkMetered
+    }
+
+    private fun hasActiveNetwork(context: Context): Boolean {
+        val connectivityManager = context.getSystemService(ConnectivityManager::class.java) ?: return false
+        return connectivityManager.activeNetwork != null
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/util/DownloadUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/DownloadUtil.java
@@ -126,6 +126,23 @@ public final class DownloadUtil {
         return dataSourceFactory;
     }
 
+    /**
+     * Writes into the same streaming cache (and with the same keys) the player reads
+     * from, but bypasses the download-cache/resolving wrappers of
+     * {@link #getCacheDataSourceFactory(Context)}: CacheWriter needs a plain
+     * CacheDataSource.
+     */
+    public static synchronized CacheDataSource.Factory getStreamingCacheWriterFactory(Context context) {
+        return new CacheDataSource.Factory()
+                .setCache(getStreamingCache(context))
+                .setCacheKeyFactory(new StreamingCacheKeyFactory())
+                .setUpstreamDataSourceFactory(new DefaultDataSource.Factory(context, getHttpDataSourceFactory()));
+    }
+
+    public static synchronized Cache getStreamingCacheForPreload(Context context) {
+        return getStreamingCache(context);
+    }
+
     public static synchronized DownloadNotificationHelper getDownloadNotificationHelper(Context context) {
         if (downloadNotificationHelper == null) {
             downloadNotificationHelper = new DownloadNotificationHelper(context, DOWNLOAD_NOTIFICATION_CHANNEL_ID);

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -75,6 +75,8 @@ object Preferences {
     private const val SHARE = "share"
     private const val SCROBBLING = "scrobbling"
     private const val SONG_PRELOAD_BUFFER = "song_preload_buffer"
+    private const val PRECACHE_TRACKS_COUNT = "precache_tracks_count"
+    private const val PRECACHE_WIFI_ONLY = "precache_wifi_only"
     private const val SKIP_MIN_STAR_RATING = "skip_min_star_rating"
     private const val MIN_STAR_RATING = "min_star_rating"
     private const val ALWAYS_ON_DISPLAY = "always_on_display"
@@ -715,6 +717,16 @@ object Preferences {
     @JvmStatic
     fun getSongPreloadBuffer(): Int {
         return App.getInstance().preferences.getString(SONG_PRELOAD_BUFFER, "60")!!.toInt()
+    }
+
+    @JvmStatic
+    fun getPrecacheTracksCount(): Int {
+        return App.getInstance().preferences.getString(PRECACHE_TRACKS_COUNT, "0")!!.toInt()
+    }
+
+    @JvmStatic
+    fun isPrecacheWifiOnly(): Boolean {
+        return App.getInstance().preferences.getBoolean(PRECACHE_WIFI_ONLY, true)
     }
 
     @JvmStatic

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -251,6 +251,21 @@
         <item>600</item>
     </string-array>
 
+    <string-array name="precache_tracks_titles">
+        <item>Disabled</item>
+        <item>Next track</item>
+        <item>Next 2 tracks</item>
+        <item>Next 3 tracks</item>
+        <item>Next 5 tracks</item>
+    </string-array>
+    <string-array name="precache_tracks_values">
+        <item>0</item>
+        <item>1</item>
+        <item>2</item>
+        <item>3</item>
+        <item>5</item>
+    </string-array>
+
     <string-array name="playlist_sort_option_titles">
         <item>Name</item>
         <item>Random</item>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -423,6 +423,10 @@
     <string name="settings_set_download_folder">Set download folder</string>
     <string name="settings_song_preload_buffer">Song preload buffer</string>
     <string name="settings_song_preload_buffer_summary">Current value: %1$s\nFor the change to take effect you must manually restart the app.</string>
+    <string name="settings_precache_tracks">Pre-cache upcoming tracks</string>
+    <string name="settings_precache_tracks_summary">Fully cache the next tracks of the queue in the background, so skips start instantly and playback survives short signal drops</string>
+    <string name="settings_precache_wifi_only">Pre-cache on Wi-Fi only</string>
+    <string name="settings_precache_wifi_only_summary">Pause pre-caching while on a metered connection</string>
     <string name="settings_system_equalizer_summary">Adjust audio settings</string>
     <string name="settings_system_equalizer_title">System equalizer</string>
     <string name="settings_github_link">https://github.com/eddyizm/tempus</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -423,7 +423,7 @@
     <string name="settings_set_download_folder">Set download folder</string>
     <string name="settings_song_preload_buffer">Song preload buffer</string>
     <string name="settings_song_preload_buffer_summary">Current value: %1$s\nFor the change to take effect you must manually restart the app.</string>
-    <string name="settings_precache_tracks">Pre-cache upcoming tracks</string>
+    <string name="settings_precache_tracks">Pre-cache upcoming tracks [Experimental]</string>
     <string name="settings_precache_tracks_summary">Fully cache the next tracks of the queue in the background, so skips start instantly and playback survives short signal drops</string>
     <string name="settings_precache_wifi_only">Pre-cache on Wi-Fi only</string>
     <string name="settings_precache_wifi_only_summary">Pause pre-caching while on a metered connection</string>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -367,6 +367,21 @@
             app:title="@string/settings_song_preload_buffer"
             app:summary="@string/settings_song_preload_buffer_summary" />
 
+        <ListPreference
+            app:defaultValue="0"
+            app:dialogTitle="@string/settings_precache_tracks"
+            app:entries="@array/precache_tracks_titles"
+            app:entryValues="@array/precache_tracks_values"
+            app:key="precache_tracks_count"
+            app:title="@string/settings_precache_tracks"
+            app:summary="@string/settings_precache_tracks_summary" />
+
+        <SwitchPreference
+            android:title="@string/settings_precache_wifi_only"
+            android:defaultValue="true"
+            android:summary="@string/settings_precache_wifi_only_summary"
+            android:key="precache_wifi_only" />
+
         <Preference
             android:key="streaming_cache_storage"
             app:title="@string/settings_streaming_cache_storage_title" />


### PR DESCRIPTION
## What

Split out of #861 as requested by @tvillega. This is the pre-cache feature half.

Adds an opt-in setting to fully cache the next N tracks of the play queue in the background, so skips start instantly and playback survives short signal drops (tunnels, elevators, spotty commutes).

This is the track-count-based prefetch users asked for in the #472 discussion (DSub2000 comparison), with the storage concern raised there addressed: pre-cached audio goes into the existing **size-limited LRU streaming cache**, not into downloads, so it can never grow storage unbounded — old entries are evicted automatically.

## UI

Two new options in **Settings**, directly below the existing "Song preload buffer" option they complement:

- **Pre-cache upcoming tracks** — list preference, default **Off**, choices 1–5 tracks.
- **Pre-cache on Wi-Fi only** — switch, default **On**, pauses pre-caching on metered connections.

(The time-based preload buffer answers "how much of the *current* song to buffer"; this answers "how many of the *next* songs to have ready".)

## How

- `QueuePreloader` watches queue/timeline changes from `BaseMediaService` and writes upcoming tracks into the streaming cache via Media3's `CacheWriter`.
- Uses the same cache keys the player reads with, so pre-cached bytes are found at playback time.
- In-flight work is generation-tracked: queue changes or service teardown cancel superseded writes safely (no orphaned downloads).
- Skips tracks already fully cached and does nothing while the setting is Off.

## Notes

- **Stacked on #865** — the first commit here is that PR's cache-key change (the preloader needs stable keys so the player finds what it wrote). Once #865 merges, this diff reduces to the feature commit only.
- Implements the pre-cache part of #859.

## Testing

- `assembleDebug` builds clean.
- Ran on-device: with 3 tracks enabled, skipping to the next track starts instantly with no network; toggling airplane mode mid-queue keeps playing through the pre-cached tracks.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic pre-caching of upcoming (non-radio) HTTP/HTTPS tracks to improve playback smoothness.
  * Added settings to control how many tracks to pre-cache.
  * Added an option to enable pre-caching only on Wi‑Fi.
  * Pre-caching skips radio/“ir-” content and tracks already marked as downloaded.
* **Bug Fixes**
  * Improved streaming cache consistency by aligning cache keying between playback and pre-caching.
  * Pre-caching now safely cancels and refreshes when playback state or network conditions change.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->