### PR TITLE
fix: IndexOutOfBoundsException in Instant Mix for single-album artists

### DIFF
--- a/app/src/tempus/java/com/cappielloantonio/tempo/repository/InstantMixBuilder.java
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/repository/InstantMixBuilder.java
@@ -73,13 +73,19 @@ public class InstantMixBuilder {
                                     response.body().getSubsonicResponse().getArtist().getAlbums()
                             );
 
+                            if (albums.isEmpty()) {
+                                Log.e(TAG, "Artist " + artistId + " has no albums, nothing to build");
+                                isRunning.set(false);
+                                return;
+                            }
+
                             List<Child> mixTracks = new ArrayList<>();
                             Set<String> usedTrackIds = new HashSet<>();
                             usedTrackIds.add(usedTrackId);
 
                             Random random = new Random();
 
-                            fetchNextTrack(albums, 0, mixTracks, usedTrackIds, random, count, browserFuture);
+                            fetchNextTrack(albums, 0, mixTracks, usedTrackIds, random, count, count * 4, browserFuture);
 
                             isRunning.set(false);
                         } else {
@@ -101,17 +107,19 @@ public class InstantMixBuilder {
      * Each cycle shuffles the album list and fetches one track from albums[0], then one from albums[1],
      * alternating between the two until maxTracks is reached. The shuffle at the start of each cycle
      * ensures variety — consecutive cycles may pick from completely different albums.
+     * Artists with a single album keep drawing from that album.
      * -
-     * Recursion depth is bounded by maxTracks (capped at INSTANT_MIX_MAX_TRACKS),
-     * which matches the minimum total track count required to enable this feature,
-     * preventing both infinite loops and stack overflow.
+     * Each step consumes one attempt whether or not it yields a new track, so the recursion
+     * (and the number of network calls) is hard-bounded by attemptsLeft even when the artist
+     * has fewer unique tracks than maxTracks. Whatever was collected by then gets enqueued.
      *
-     * @param albums        Full list of artist albums
+     * @param albums        Full list of artist albums (never empty)
      * @param albumIndex    0 or 1 — which of the two albums to fetch in this step
      * @param mixTracks     Accumulated list of selected tracks
      * @param usedTrackIds  Set of already used track IDs to avoid duplicates
      * @param random        Shared Random instance for shuffling and track picking
      * @param maxTracks     Target number of tracks
+     * @param attemptsLeft  Remaining fetch attempts before giving up on reaching maxTracks
      * @param browserFuture Future to enqueue into when the mix is complete
      */
     private void fetchNextTrack(
@@ -121,10 +129,15 @@ public class InstantMixBuilder {
             Set<String> usedTrackIds,
             Random random,
             int maxTracks,
+            int attemptsLeft,
             ListenableFuture<MediaBrowser> browserFuture) {
 
-        if (mixTracks.size() >= maxTracks) {
-            Log.d(TAG, "Mix complete with " + mixTracks.size() + " tracks, enqueuing");
+        if (mixTracks.size() >= maxTracks || attemptsLeft <= 0) {
+            if (mixTracks.isEmpty()) {
+                Log.w(TAG, "No tracks collected, nothing to enqueue");
+                return;
+            }
+            Log.d(TAG, "Mix complete with " + mixTracks.size() + "/" + maxTracks + " tracks, enqueuing");
             repository.setChildrenMetadata(mixTracks);
             enqueue(browserFuture, mixTracks, true);
             return;
@@ -135,7 +148,7 @@ public class InstantMixBuilder {
             Log.d(TAG, "New cycle, albums shuffled");
         }
 
-        AlbumID3 album = albums.get(albumIndex);
+        AlbumID3 album = albums.get(albumIndex < albums.size() ? albumIndex : 0);
         Log.d(TAG, "Fetching album[" + albumIndex + "] " + album.getName()
                 + " (" + mixTracks.size() + "/" + maxTracks + " tracks so far)");
 
@@ -166,14 +179,14 @@ public class InstantMixBuilder {
                         }
 
                         int nextIndex = (albumIndex == 0) ? 1 : 0;
-                        fetchNextTrack(albums, nextIndex, mixTracks, usedTrackIds, random, maxTracks, browserFuture);
+                        fetchNextTrack(albums, nextIndex, mixTracks, usedTrackIds, random, maxTracks, attemptsLeft - 1, browserFuture);
                     }
 
                     @Override
                     public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
                         Log.e(TAG, "Failed to load album " + album.getName() + ": " + t.getMessage());
                         int nextIndex = (albumIndex == 0) ? 1 : 0;
-                        fetchNextTrack(albums, nextIndex, mixTracks, usedTrackIds, random, maxTracks, browserFuture);
+                        fetchNextTrack(albums, nextIndex, mixTracks, usedTrackIds, random, maxTracks, attemptsLeft - 1, browserFuture);
                     }
                 });
     }

--- a/app/src/tempus/java/com/cappielloantonio/tempo/repository/InstantMixBuilder.java
+++ b/app/src/tempus/java/com/cappielloantonio/tempo/repository/InstantMixBuilder.java
@@ -86,8 +86,6 @@ public class InstantMixBuilder {
                             Random random = new Random();
 
                             fetchNextTrack(albums, 0, mixTracks, usedTrackIds, random, count, count * 4, browserFuture);
-
-                            isRunning.set(false);
                         } else {
                             Log.e(TAG, "Failed to retrieve albums for artistId=" + artistId);
                             isRunning.set(false);
@@ -135,11 +133,13 @@ public class InstantMixBuilder {
         if (mixTracks.size() >= maxTracks || attemptsLeft <= 0) {
             if (mixTracks.isEmpty()) {
                 Log.w(TAG, "No tracks collected, nothing to enqueue");
+                isRunning.set(false);
                 return;
             }
             Log.d(TAG, "Mix complete with " + mixTracks.size() + "/" + maxTracks + " tracks, enqueuing");
             repository.setChildrenMetadata(mixTracks);
             enqueue(browserFuture, mixTracks, true);
+            isRunning.set(false);
             return;
         }
 


### PR DESCRIPTION
## Problem

Extending an Instant Mix for an artist that has only **one album** crashes the app:

```
java.lang.IndexOutOfBoundsException: Index 1 out of bounds for length 1
    at java.util.ArrayList.get(ArrayList.java:435)
    at com.cappielloantonio.tempo.repository.InstantMixBuilder.fetchNextTrack(InstantMixBuilder.java:138)
```

`fetchNextTrack` alternates between `albums.get(0)` and `albums.get(1)`; with a single-album artist the second step indexes past the end of the list. Hit in real use on a library where the mixed artist has exactly one album.

## Fix

- The album index falls back to `0` when it exceeds the album list size, so single-album artists keep drawing tracks from their only album.
- Bounded the recursion with an attempt budget (4× the requested track count). Previously, when an artist had fewer unique tracks than requested, every candidate eventually was a duplicate and the builder kept issuing `getAlbum` network calls forever. Now it enqueues whatever it collected once the budget is spent.
- An artist with no albums or no collected tracks no longer enqueues an empty list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved instant-mix generation when an artist has no albums by aborting early with safe state handling.
  * Added a hard cap on repeated fetch attempts to prevent excessive work beyond the track limit.
  * Prevented crashes from invalid album selection during recursive track loading.
  * Enhanced termination behavior for failed/empty album loads to avoid enqueuing missing results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->