### PR TITLE
fix: pass through click on lyric view

### DIFF
--- a/app/src/main/res/layout-sw600dp/inner_fragment_player_controller_layout.xml
+++ b/app/src/main/res/layout-sw600dp/inner_fragment_player_controller_layout.xml
@@ -2,8 +2,10 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/now_playing_media_controller_layout"
+    android:clickable="true"
+    android:focusable="true"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent" >
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/player_media_quality_sector"

--- a/app/src/main/res/layout/inner_fragment_player_controller_layout.xml
+++ b/app/src/main/res/layout/inner_fragment_player_controller_layout.xml
@@ -2,6 +2,7 @@
 <androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     android:id="@+id/now_playing_media_controller_layout"
+    android:clickable="true"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 


### PR DESCRIPTION
Solves #714.

This is a bug on Google's library, if not setting explicitly the focus it becomes a pass-through (more details on the issue link).