### PR TITLE
chore: compress mapping.txt

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -82,6 +82,11 @@ jobs:
           mv -v app/build/outputs/mapping/tempusRelease/mapping.txt app/build/outputs/mapping/tempusRelease/mapping_Tempus.txt
           mv -v app/build/outputs/mapping/degoogledRelease/mapping.txt app/build/outputs/mapping/degoogledRelease/mapping_Degoogled.txt
 
+      - name: Compress Mapping Files
+        run: |
+          gzip -v app/build/outputs/mapping/tempusRelease/mapping_Tempus.txt
+          gzip -v app/build/outputs/mapping/degoogledRelease/mapping_Degoogled.txt
+
       - name: Create Release
         id: create_release
         uses: softprops/action-gh-release@v1
@@ -94,5 +99,5 @@ jobs:
           files: |
             app/build/outputs/apk/tempus/release/*-release.apk
             app/build/outputs/apk/degoogled/release/*-release.apk
-            app/build/outputs/mapping/tempusRelease/mapping_Tempus.txt
-            app/build/outputs/mapping/degoogledRelease/mapping_Degoogled.txt
+            app/build/outputs/mapping/tempusRelease/mapping_Tempus.txt.gz
+            app/build/outputs/mapping/degoogledRelease/mapping_Degoogled.txt.gz


### PR DESCRIPTION
Solves #871

XZ reduced to 3.0MiB, but GZIP reduced to 3.6MiB with no extra library needed. That's still a 91% reduction.