### PR TITLE
fix: directory fragment tries to read 0 arguments

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/DirectoryFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/DirectoryFragment.java
@@ -86,6 +86,12 @@ public class DirectoryFragment extends Fragment implements ClickCallback {
         directoryViewModel = new ViewModelProvider(requireActivity()).get(DirectoryViewModel.class);
         directoryRepository = new DirectoryRepository();
 
+        Bundle args = getArguments();
+        if (args == null) {
+            if (activity != null && activity.navController != null) activity.navController.navigateUp();
+            return view;
+        }
+
         initAppBar();
         initDirectoryListView();
 


### PR DESCRIPTION
Fixes #854.

I tried to implement https://github.com/eddyizm/tempus/issues/854#issuecomment-4972847597 but there are no default views, they all get generated dynamically.

What this will do is to prevent the fragment to read 0 arguments (which on the report was triggered by switching to another app and back) and, when detected, going back 1 level on the navigation stack. Since this was two levels deep (`artist -> album`) it should kick the user back to the library page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory screen stability when required navigation information is unavailable.
  * Automatically returns to the previous screen instead of attempting to initialize an incomplete directory view.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->