### PR TITLE
Migrate to OnBackPressedDispatcher from deprecated onBackPressed

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/activity/MainActivity.java
@@ -17,6 +17,7 @@ import android.view.View;
 import android.widget.FrameLayout;
 
 import androidx.activity.EdgeToEdge;
+import androidx.activity.OnBackPressedCallback;
 import androidx.activity.SystemBarStyle;
 import androidx.annotation.NonNull;
 import androidx.core.content.ContextCompat;
@@ -152,18 +153,11 @@ public class MainActivity extends BaseActivity {
         consumePendingPlaybackIntent();
     }
 
-    @Override
-    public void onBackPressed() {
-        if (bottomSheetBehavior.getState() == BottomSheetBehavior.STATE_EXPANDED)
-            collapseBottomSheetDelayed();
-        else
-            super.onBackPressed();
-    }
-
     public void init() {
 
         initBottomSheet();
         initNavigation();
+        initBackPressedDispatcher();
 
         if (Preferences.getPassword() != null || (Preferences.getToken() != null && Preferences.getSalt() != null)) {
             goFromLogin();
@@ -228,6 +222,18 @@ public class MainActivity extends BaseActivity {
         bottomSheetController.addCallback(bottomSheetCallback);
         bottomSheetController.replaceFragment(R.id.player_bottom_sheet);
         bottomSheetController.checkAfterStateChanged(mainViewModel);
+    }
+
+    public void initBackPressedDispatcher() {
+        getOnBackPressedDispatcher().addCallback(this, new OnBackPressedCallback(true) {
+            @Override
+            public void handleOnBackPressed() {
+                if (bottomSheetBehavior.getState() == BottomSheetBehavior.STATE_EXPANDED)
+                    collapseBottomSheetDelayed();
+                else
+                    finishAffinity();
+            }
+        });
     }
 
     public BottomSheetController getBottomSheetController() {


### PR DESCRIPTION
- Fix: #886 
## Problem
After bumping the target SDK to 36, `onBackPressed` is no longer called, and the player bottom sheet does not collapse when back button is pressed.

## Fix
We had two options: opt-out the predictive back or migrate to OnBackPressedDispatcher.
Since only MainActivity uses onBackPressed. So I chose migrate to OnBackPressedDispatcher rather than opt-opt the predictive back.