### PR TITLE
Keep the album list scroll position when returning from an album

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumListPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumListPageFragment.java
@@ -23,6 +23,7 @@ import androidx.lifecycle.ViewModelProvider;
 import androidx.media3.common.util.UnstableApi;
 import androidx.navigation.Navigation;
 import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
 
 import com.cappielloantonio.tempo.R;
 import com.cappielloantonio.tempo.databinding.FragmentAlbumListPageBinding;
@@ -137,6 +138,10 @@ public class AlbumListPageFragment extends Fragment implements ClickCallback {
                 this,
                 (albumListPageViewModel.title.equals(Constants.ALBUM_DOWNLOADED) || albumListPageViewModel.title.equals(Constants.ALBUM_FROM_ARTIST))
         );
+        // Defer scroll position restoration until the async album list has loaded; otherwise
+        // RecyclerView restores against the empty adapter and drops the position (scrolls to top
+        // on back). Matches ArtistCatalogueFragment, which is why Artists already behaves.
+        albumHorizontalAdapter.setStateRestorationPolicy(RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY);
 
         bind.albumListRecyclerView.setAdapter(albumHorizontalAdapter);
         albumListPageViewModel.getAlbumList(getViewLifecycleOwner()).observe(getViewLifecycleOwner(), albums -> {


### PR DESCRIPTION
## What

A small quality of life change: the album lists now keep your scroll position when you open an album and press back, instead of jumping to the top. This helps most on large libraries, where you can be dozens of albums deep, previously, losing your place meant scrolling all the way back down every time you looked at an album.

## The problem

In the album lists (Recently Added, Most Played, Recently Played, Starred, New Releases, Downloaded, and an artist's albums), scrolling down, tapping an album, then pressing back sent the list back to the top. The Artists list did not do this, it kept your place.

## Why it happens

All of those lists are served by `AlbumListPageFragment`, which sets its adapter with RecyclerView's default state restoration policy (`ALLOW`). On back, the fragment view is recreated with an empty adapter and the album list arrives asynchronously through LiveData. With `ALLOW`, RecyclerView tries to restore the saved scroll position on the next layout, sees zero items, and discards it, so when the data lands it lays out from the top.

`ArtistCatalogueFragment` never had the problem because it already sets `PREVENT_WHEN_EMPTY`, which is why Artists behaved correctly.

## The fix

One line (plus the import) in `AlbumListPageFragment.initAlbumListView()`:

```java
albumHorizontalAdapter.setStateRestorationPolicy(
        RecyclerView.Adapter.StateRestorationPolicy.PREVENT_WHEN_EMPTY);
```

This tells RecyclerView to wait until the adapter has items before restoring, so the saved position survives the async load. It mirrors the existing `ArtistCatalogueFragment` approach. Because this single fragment backs every album list variant, they all get the fix from the one change.

## Testing

Built, installed on a device, and logged into a Navidrome server. Opened Recently Added, scrolled well down, tapped an album, pressed back, and the list returned to the same spot. Repeated for Most Played. Artists still behaves as before.
