### PR TITLE
Keep the player sheet opaque and its queue clear of the navigation bar

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerQueueFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerQueueFragment.java
@@ -10,6 +10,8 @@ import android.view.ViewGroup;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.lifecycle.Observer;
@@ -157,6 +159,23 @@ public class PlayerQueueFragment extends Fragment implements ClickCallback {
     private void initQueueRecyclerView() {
         bind.playerQueueRecyclerView.setLayoutManager(new LinearLayoutManager(requireContext()));
         bind.playerQueueRecyclerView.setHasFixedSize(true);
+
+        // #883: the queue list draws to the bottom of the screen under the navigation bar (the
+        // player sheet never gets a bottom inset). Pad the list by the bottom system bar inset,
+        // read from the decor view, and let items scroll past it so the last row clears the bar.
+        bind.playerQueueRecyclerView.setClipToPadding(false);
+        bind.playerQueueRecyclerView.post(() -> {
+            if (bind == null) return;
+            WindowInsetsCompat rootInsets = ViewCompat.getRootWindowInsets(
+                    requireActivity().getWindow().getDecorView());
+            int navBottom = rootInsets == null ? 0
+                    : rootInsets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
+            bind.playerQueueRecyclerView.setPadding(
+                    bind.playerQueueRecyclerView.getPaddingLeft(),
+                    bind.playerQueueRecyclerView.getPaddingTop(),
+                    bind.playerQueueRecyclerView.getPaddingRight(),
+                    navBottom);
+        });
 
         playerSongQueueAdapter = new PlayerSongQueueAdapter(this);
         bind.playerQueueRecyclerView.setAdapter(playerSongQueueAdapter);

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -23,6 +23,7 @@
             android:id="@+id/player_bottom_sheet"
             android:layout_width="match_parent"
             android:layout_height="match_parent"
+            android:background="?attr/colorSurface"
             app:enableEdgeToEdge="true"
             app:paddingBottomSystemWindowInsets="true"
             app:behavior_hideable="true"


### PR DESCRIPTION
Fixes #883. Opening this as discussed in the issue thread. It is a follow up to the edge to edge work in #878: the player sheet is the one surface that never got a bottom inset.

## Symptom

Under edge to edge the expanded player sheet leaves the bottom system bar strip uncovered, so whatever screen is behind the sheet shows through it, and the queue list draws its last row under the navigation bar glyphs. This covers both reports in the thread: the queue under the glassy navbar on the Pixel 8a, and the view underneath the bottom sheet showing through on the S21 FE and my S25.

## Root cause

Two separate problems living in the same strip:

1. The sheet container `@id/player_bottom_sheet` is a plain `FrameLayout` with no background, so the screen behind the sheet paints the bottom strip. Its `app:paddingBottomSystemWindowInsets="true"` has no effect there: that attribute is only honored by Material components, which is why #878 could fix the `BottomNavigationView` overlap while the sheet stayed uncovered.
2. The queue `RecyclerView` has no bottom padding, and the `CoordinatorLayout` never dispatches window insets into the sheet, so an `OnApplyWindowInsetsListener` on the sheet or its children never fires (verified on device). The inset has to be read from somewhere it provably exists.

## Fix

1. `activity_main.xml`: give the sheet `android:background="?attr/colorSurface"`. It only changes pixels where nothing painted before, since every page inside the sheet already draws its own surface on top.
2. `PlayerQueueFragment.initQueueRecyclerView()`: pad the queue list by `systemBars().bottom`, read from the decor view in a `post()` after layout, with `clipToPadding` disabled so rows scroll past the padding and the last row settles above the bar. The padding is zero on devices with no bottom inset, so nothing changes for them.

## Why the inset comes from the decor view

I tried the conventional routes first, all on device: a `setOnApplyWindowInsetsListener` on the sheet fragment root never fires (the `CoordinatorLayout` consumes the pass), reading `getRootWindowInsets` from the fragment view returned nothing usable, and padding the sheet container from the listener that does fire still left the queue rows underneath, because the inner pager page ignores the container padding. Reading the decor view insets after layout is the one path that provably works. If the insets are somehow unavailable the code falls back to zero padding, which is exactly the behavior before this change.

## Verified

Before and after on the same builds. Galaxy S25 (One UI 8.5): unpatched shows the strip behind the sheet and the last queue row under the nav glyphs; patched, the strip is gone and the last row scrolls fully clear of the bar. Corroborated on an Android emulator in both gesture and three button navigation. Not yet confirmed on a Pixel, so a check there would still be welcome.

## Scope notes

- I left `app:paddingBottomSystemWindowInsets` on the `FrameLayout` untouched even though it has no effect on a plain `FrameLayout`.
- The inset is read once per view creation. Navigation mode changes recreate the activity, so the value is read again on every path a user can actually hit.
