### PR TITLE
fix: bottom padding for song_recycler_view under edge-to-edge

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumPageFragment.java
@@ -16,6 +16,8 @@ import android.widget.ToggleButton;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.media3.common.util.UnstableApi;
@@ -349,6 +351,22 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
     private void initSongsView() {
         bind.songRecyclerView.setLayoutManager(new LinearLayoutManager(requireContext()));
         bind.songRecyclerView.setHasFixedSize(true);
+
+        /* Edge-to-edge dynamic inset for bottom padding */
+        bind.songRecyclerView.setClipToPadding(false);
+        bind.songRecyclerView.post(() -> {
+            if (bind == null) return;
+            int peekHeight = (int) getResources().getDimension(R.dimen.bottom_sheet_behavior_peek_height);
+            WindowInsetsCompat rootInsets = ViewCompat.getRootWindowInsets(
+                    requireActivity().getWindow().getDecorView());
+            int navBottom = rootInsets == null ? 0
+                    : rootInsets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
+            bind.songRecyclerView.setPadding(
+                    bind.songRecyclerView.getPaddingLeft(),
+                    bind.songRecyclerView.getPaddingTop(),
+                    bind.songRecyclerView.getPaddingRight(),
+                    navBottom+peekHeight);
+        });
 
         // Synchronize scrolling if info scroll view exists (landscape)
         if (bind.getRoot().findViewById(R.id.album_info_scroll_view) != null) {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
@@ -18,6 +18,8 @@ import android.widget.Toast;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.media3.common.util.UnstableApi;
@@ -336,6 +338,22 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
     private void initSongsView() {
         bind.songRecyclerView.setLayoutManager(new LinearLayoutManager(requireContext()));
         bind.songRecyclerView.setHasFixedSize(true);
+
+        /* Edge-to-edge dynamic inset for bottom padding */
+        bind.songRecyclerView.setClipToPadding(false);
+        bind.songRecyclerView.post(() -> {
+            if (bind == null) return;
+            int peekHeight = (int) getResources().getDimension(R.dimen.bottom_sheet_behavior_peek_height);
+            WindowInsetsCompat rootInsets = ViewCompat.getRootWindowInsets(
+                    requireActivity().getWindow().getDecorView());
+            int navBottom = rootInsets == null ? 0
+                    : rootInsets.getInsets(WindowInsetsCompat.Type.systemBars()).bottom;
+            bind.songRecyclerView.setPadding(
+                    bind.songRecyclerView.getPaddingLeft(),
+                    bind.songRecyclerView.getPaddingTop(),
+                    bind.songRecyclerView.getPaddingRight(),
+                    navBottom+peekHeight);
+        });
 
         // Synchronize scrolling between the list and the header in landscape mode
         if (bind.playlistInfoScrollView != null) {


### PR DESCRIPTION
Solves #889.

Re-implements #847 in code (which was broken by #878) by injecting it next to the system inset the same way as #890.

All due credits to the authors of those PR's, I only put the pieces together.