### PR TITLE
fix: Replace lateinit var with an initialized default that sets statu…

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/repository/SystemRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/SystemRepository.java
@@ -29,7 +29,8 @@ public class SystemRepository {
                     public void onResponse(@NonNull Call<ApiResponse> call, @NonNull retrofit2.Response<ApiResponse> response) {
                         if (response.body() != null) {
                             if (response.body().getSubsonicResponse().getStatus().equals(ResponseStatus.FAILED)) {
-                                callback.onError(new Exception(response.body().getSubsonicResponse().getError().getCode() + " - " + response.body().getSubsonicResponse().getError().getMessage()));
+                                com.cappielloantonio.tempo.subsonic.models.Error apiError = response.body().getSubsonicResponse().getError();
+                                callback.onError(new Exception(apiError != null ? apiError.getCode() + " - " + apiError.getMessage() : "Unknown server error"));
                             } else if (response.body().getSubsonicResponse().getStatus().equals(ResponseStatus.OK)) {
                                 String password = response.raw().request().url().queryParameter("p");
                                 String token = response.raw().request().url().queryParameter("t");

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/base/ApiResponse.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/base/ApiResponse.kt
@@ -1,11 +1,14 @@
 package com.cappielloantonio.tempo.subsonic.base
 
 import androidx.annotation.Keep
+import com.cappielloantonio.tempo.subsonic.models.ResponseStatus
 import com.cappielloantonio.tempo.subsonic.models.SubsonicResponse
 import com.google.gson.annotations.SerializedName
 
 @Keep
 class ApiResponse {
     @SerializedName("subsonic-response")
-    lateinit var subsonicResponse: SubsonicResponse
+    var subsonicResponse: SubsonicResponse = SubsonicResponse().apply {
+        status = ResponseStatus.FAILED
+    }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/viewmodel/PodcastChannelBottomSheetViewModel.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/viewmodel/PodcastChannelBottomSheetViewModel.java
@@ -53,7 +53,7 @@ public class PodcastChannelBottomSheetViewModel extends AndroidViewModel {
                             if (response.isSuccessful() && response.body() != null) {
                                 ApiResponse apiResponse = response.body();
 
-                                String status = apiResponse.subsonicResponse.getStatus();
+                                String status = apiResponse.getSubsonicResponse().getStatus();
 
                                 if ("ok".equals(status)) {
                                     Toast.makeText(getApplication(),

--- a/app/src/main/java/com/cappielloantonio/tempo/viewmodel/PodcastChannelEditorViewModel.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/viewmodel/PodcastChannelEditorViewModel.java
@@ -60,7 +60,7 @@ public class PodcastChannelEditorViewModel extends AndroidViewModel {
                         if (response.isSuccessful() && response.body() != null) {
                             ApiResponse apiResponse = response.body();
 
-                            String status = apiResponse.subsonicResponse.getStatus();
+                            String status = apiResponse.getSubsonicResponse().getStatus();
                             if ("ok".equals(status)) {
                                 isSuccess.setValue(true);
                             }

--- a/app/src/main/java/com/cappielloantonio/tempo/viewmodel/RadioEditorViewModel.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/viewmodel/RadioEditorViewModel.java
@@ -85,7 +85,7 @@ public class RadioEditorViewModel extends AndroidViewModel {
                         }
                         if (response.isSuccessful() && response.body() != null) {
                             ApiResponse apiResponse = response.body();
-                            String status = apiResponse.subsonicResponse.getStatus();
+                            String status = apiResponse.getSubsonicResponse().getStatus();
                             if ("ok".equals(status)) {
                                 isSuccess.setValue(true);
                             } else if ("failed".equals(status)) {
@@ -127,8 +127,8 @@ public class RadioEditorViewModel extends AndroidViewModel {
                     public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
                         if (response.isSuccessful() && response.body() != null) {
                             ApiResponse apiResponse = response.body();
-                            if (apiResponse.subsonicResponse != null) {
-                                String status = apiResponse.subsonicResponse.getStatus();
+                            if (apiResponse.getSubsonicResponse() != null) {
+                                String status = apiResponse.getSubsonicResponse().getStatus();
                                 if ("ok".equals(status)) {
                                     isSuccess.setValue(true);
                                 } else if ("failed".equals(status)) {
@@ -171,7 +171,7 @@ public class RadioEditorViewModel extends AndroidViewModel {
                     public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
                         if (response.isSuccessful() && response.body() != null) {
                             ApiResponse apiResponse = response.body();
-                            String status = apiResponse.subsonicResponse.getStatus();
+                            String status = apiResponse.getSubsonicResponse().getStatus();
                             if ("ok".equals(status)) {
                                 isSuccess.setValue(true);
                             } else if ("failed".equals(status)) {
@@ -196,8 +196,8 @@ public class RadioEditorViewModel extends AndroidViewModel {
     private void handleFailedResponse(ApiResponse apiResponse) {
         String errorMsg = "Unknown server error";
 
-        if (apiResponse.subsonicResponse.getError() != null) {
-            errorMsg = apiResponse.subsonicResponse.getError().getMessage();
+        if (apiResponse.getSubsonicResponse().getError() != null) {
+            errorMsg = apiResponse.getSubsonicResponse().getError().getMessage();
             if ("Not implemented".equals(errorMsg)) {
                 errorMsg = getApplication().getString(R.string.radio_dialog_not_supported_snackbar);
             }


### PR DESCRIPTION
## Root Cause

ApiResponse.subsonicResponse was declared as lateinit var. When a server returns HTTP 200 but the JSON lacks the "subsonic-response" key (e.g., non-Subsonic server, HTML error page), Gson never initialized the field. Any access to getSubsonicResponse() threw UninitializedPropertyAccessException, crashing the app and causing a boot loop via CustomActivityOnCrash. Resolves #892 

## Fix
ApiResponse.kt — Replace lateinit var with an initialized default that sets status = "failed":
- Gson overwrites the field if "subsonic-response" is in the JSON (normal operation unchanged)
- If absent, the default SubsonicResponse(status="failed") is used, with all data fields null
- This causes graceful degradation: callers see status == "failed" or get null data fields instead of crashing
SystemRepository.java — Guard against null Error object in checkUserCredential() since the default response has status="failed" but error = null
3 ViewModel files — Converted direct field access (apiResponse.subsonicResponse) to getter (apiResponse.getSubsonicResponse()) to match the rest of the codebase after removing lateinit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of incomplete or missing server error responses, preventing unexpected failures during credential checks.
  * Added a safe default failure status for malformed or unavailable API responses.
  * Improved reliability of podcast channel and radio create, update, and delete operations when server responses are incomplete or unsuccessful.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->