### PR TITLE
fix: setting signing for degoogled (fdroid) version to 34 (#904)

### DIFF
--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -61,7 +61,7 @@ jobs:
           keyStorePassword: ${{ secrets.KEYSTORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD_GITHUB }}
         env:
-          BUILD_TOOLS_VERSION: "36.0.0"
+          BUILD_TOOLS_VERSION: "34.0.0"
 
       - name: Rename Signed APKs to match local pattern
         run: |


### PR DESCRIPTION
resolves #904 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Android build tools used when signing degoogled release APKs.
  * Release signing now uses build tools version 34.0.0 for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->