### PR TITLE
fix: Make "Play Next" actually play next under shuffle (#329)

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -167,59 +167,60 @@ open class BaseMediaService : MediaLibraryService() {
         }, MoreExecutors.directExecutor())
     }
 
-    // #329: "Play next" puts a track right after the current one on the TIMELINE, but under
-    // shuffle the play order is the ExoPlayer shuffle order, which the controller can't set
-    // and which ExoPlayer randomizes on insert. The UI sends this request (insert position,
-    // item count, and expected post-insert item count) and separately inserts the items; the
-    // two arrive in any order, and addMediaItems is applied asynchronously by the session, so
-    // we stash the request and apply it from onTimelineChanged once the insert is actually
-    // visible on the service player. Applying rebuilds the shuffle order so the inserted items
-    // play immediately after the current track. No-op when shuffle is off (timeline == play
-    // order) or when the item count doesn't match (resolution changed it — fail safe).
-    private var playNextInsertPos = -1
-    private var playNextCount = 0
-    private var playNextTarget = -1
+    // "Play next" under shuffle: the UI inserts items at current+1 on the timeline and asks
+    // the service to splice them into shuffle position current+1. Inserts land asynchronously,
+    // so requests are queued and applied from onTimelineChanged once each target count is visible.
+    private data class PlayNextRequest(val insertPos: Int, val count: Int, val target: Int)
+    private val playNextQueue = ArrayDeque<PlayNextRequest>()
 
     fun requestPlayNextFixup(insertPos: Int, count: Int, target: Int) {
         if (insertPos < 0 || count <= 0 || target < 0) return
-        playNextInsertPos = insertPos
-        playNextCount = count
-        playNextTarget = target
+        playNextQueue.addLast(PlayNextRequest(insertPos, count, target))
         tryApplyPlayNextFixup()
     }
 
     private fun tryApplyPlayNextFixup() {
-        if (playNextTarget < 0) return
         val player = exoplayer
-        if (player.mediaItemCount < playNextTarget) return   // insert not visible yet — wait for onTimelineChanged
-        val insertPos = playNextInsertPos
-        val count = playNextCount
-        val target = playNextTarget
-        playNextTarget = -1                                  // consume the request
-        if (!player.shuffleModeEnabled) return               // timeline == play order; nothing to fix
-        if (player.mediaItemCount != target) return          // item count changed unexpectedly — bail safely
-        val current = player.currentMediaItemIndex
-        if (current == C.INDEX_UNSET || insertPos + count > target) return
+        while (playNextQueue.isNotEmpty()) {
+            val req = playNextQueue.first()
+            if (player.mediaItemCount < req.target) return  // insert not visible yet — wait for onTimelineChanged
+            if (player.mediaItemCount != req.target) {       // count drifted — drop the stale request
+                playNextQueue.removeFirst()
+                continue
+            }
+            if (!player.shuffleModeEnabled) {                // timeline == play order; nothing to fix
+                playNextQueue.removeFirst()
+                continue
+            }
+            val current = player.currentMediaItemIndex
+            if (current == C.INDEX_UNSET || req.insertPos + req.count > req.target) {
+                playNextQueue.removeFirst()
+                continue
+            }
 
-        // Current play order (timeline indices in shuffle sequence), minus the new items.
-        val timeline = player.currentTimeline
-        val base = ArrayList<Int>(target)
-        var w = timeline.getFirstWindowIndex(true)
-        while (w != C.INDEX_UNSET) {
-            if (w < insertPos || w >= insertPos + count) base.add(w)
-            w = timeline.getNextWindowIndex(w, Player.REPEAT_MODE_OFF, true)
-        }
-        val curPos = base.indexOf(current)
-        if (curPos < 0) return
+            // Build the current shuffle order minus the new items, then splice them in after current.
+            val timeline = player.currentTimeline
+            val base = ArrayList<Int>(req.target)
+            var w = timeline.getFirstWindowIndex(true)
+            while (w != C.INDEX_UNSET) {
+                if (w < req.insertPos || w >= req.insertPos + req.count) base.add(w)
+                w = timeline.getNextWindowIndex(w, Player.REPEAT_MODE_OFF, true)
+            }
+            val curPos = base.indexOf(current)
+            if (curPos < 0) {
+                playNextQueue.removeFirst()
+                continue
+            }
 
-        // Splice the new timeline indices back in, immediately after the current track.
-        val newOrder = ArrayList<Int>(target)
-        newOrder.addAll(base)
-        for (j in 0 until count) {
-            newOrder.add(curPos + 1 + j, insertPos + j)
+            val newOrder = ArrayList<Int>(req.target)
+            newOrder.addAll(base)
+            for (j in 0 until req.count) {
+                newOrder.add(curPos + 1 + j, req.insertPos + j)
+            }
+            player.shuffleOrder = DefaultShuffleOrder(newOrder.toIntArray(), Random.nextLong())
+            Log.d(TAG, "playNextFixup: ${req.count} item(s) moved to shuffle position ${curPos + 1}")
+            playNextQueue.removeFirst()
         }
-        player.shuffleOrder = DefaultShuffleOrder(newOrder.toIntArray(), Random.nextLong())
-        Log.d(TAG, "playNextFixup: $count item(s) moved to shuffle position ${curPos + 1}")
     }
 
     fun restorePlayerFromQueue(player: Player) {

--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -167,6 +167,61 @@ open class BaseMediaService : MediaLibraryService() {
         }, MoreExecutors.directExecutor())
     }
 
+    // #329: "Play next" puts a track right after the current one on the TIMELINE, but under
+    // shuffle the play order is the ExoPlayer shuffle order, which the controller can't set
+    // and which ExoPlayer randomizes on insert. The UI sends this request (insert position,
+    // item count, and expected post-insert item count) and separately inserts the items; the
+    // two arrive in any order, and addMediaItems is applied asynchronously by the session, so
+    // we stash the request and apply it from onTimelineChanged once the insert is actually
+    // visible on the service player. Applying rebuilds the shuffle order so the inserted items
+    // play immediately after the current track. No-op when shuffle is off (timeline == play
+    // order) or when the item count doesn't match (resolution changed it — fail safe).
+    private var playNextInsertPos = -1
+    private var playNextCount = 0
+    private var playNextTarget = -1
+
+    fun requestPlayNextFixup(insertPos: Int, count: Int, target: Int) {
+        if (insertPos < 0 || count <= 0 || target < 0) return
+        playNextInsertPos = insertPos
+        playNextCount = count
+        playNextTarget = target
+        tryApplyPlayNextFixup()
+    }
+
+    private fun tryApplyPlayNextFixup() {
+        if (playNextTarget < 0) return
+        val player = exoplayer
+        if (player.mediaItemCount < playNextTarget) return   // insert not visible yet — wait for onTimelineChanged
+        val insertPos = playNextInsertPos
+        val count = playNextCount
+        val target = playNextTarget
+        playNextTarget = -1                                  // consume the request
+        if (!player.shuffleModeEnabled) return               // timeline == play order; nothing to fix
+        if (player.mediaItemCount != target) return          // item count changed unexpectedly — bail safely
+        val current = player.currentMediaItemIndex
+        if (current == C.INDEX_UNSET || insertPos + count > target) return
+
+        // Current play order (timeline indices in shuffle sequence), minus the new items.
+        val timeline = player.currentTimeline
+        val base = ArrayList<Int>(target)
+        var w = timeline.getFirstWindowIndex(true)
+        while (w != C.INDEX_UNSET) {
+            if (w < insertPos || w >= insertPos + count) base.add(w)
+            w = timeline.getNextWindowIndex(w, Player.REPEAT_MODE_OFF, true)
+        }
+        val curPos = base.indexOf(current)
+        if (curPos < 0) return
+
+        // Splice the new timeline indices back in, immediately after the current track.
+        val newOrder = ArrayList<Int>(target)
+        newOrder.addAll(base)
+        for (j in 0 until count) {
+            newOrder.add(curPos + 1 + j, insertPos + j)
+        }
+        player.shuffleOrder = DefaultShuffleOrder(newOrder.toIntArray(), Random.nextLong())
+        Log.d(TAG, "playNextFixup: $count item(s) moved to shuffle position ${curPos + 1}")
+    }
+
     fun restorePlayerFromQueue(player: Player) {
         if (player.mediaItemCount > 0) return
 
@@ -283,6 +338,7 @@ open class BaseMediaService : MediaLibraryService() {
 
             override fun onTimelineChanged(timeline: Timeline, reason: Int) {
                 Log.d(TAG, "onTimelineChanged reason=$reason")
+                tryApplyPlayNextFixup()
                 try {
                     ReplayGainUtil.prefetchQueueGains(player)
                 } catch (t: Throwable) {

--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseSessionCallback.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseSessionCallback.kt
@@ -224,13 +224,20 @@ open class BaseSessionCallback(
             session.isAutomotiveController(controller) ||
             session.isAutoCompanionController(controller)
         ) {
-            return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
-                .setAvailableSessionCommands(mediaNotificationSessionCommands)
-                .setMediaButtonPreferences(buildMediaButtonPreferences(session.player))
-                .build()
+        return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
+            .setAvailableSessionCommands(mediaNotificationSessionCommands)
+            .setMediaButtonPreferences(buildMediaButtonPreferences(session.player))
+            .build()
         }
 
-        return MediaSession.ConnectionResult.AcceptedResultBuilder(session).build()
+        val sessionCommands =
+            MediaSession.ConnectionResult.DEFAULT_SESSION_AND_LIBRARY_COMMANDS.buildUpon()
+                .add(SessionCommand(Constants.CUSTOM_COMMAND_PLAY_NEXT, Bundle.EMPTY))
+                .build()
+
+        return MediaSession.ConnectionResult.AcceptedResultBuilder(session)
+            .setAvailableSessionCommands(sessionCommands)
+            .build()
     }
 
     // ─────────────────────────────────────────────────────────────
@@ -406,6 +413,14 @@ open class BaseSessionCallback(
                     Log.d(TAG, "onCustomCommand: onInstantMix not usable")
 
                 updateMediaNotificationCustomLayout(session)
+                Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
+            }
+            Constants.CUSTOM_COMMAND_PLAY_NEXT -> {
+                service.requestPlayNextFixup(
+                    args.getInt(Constants.PLAY_NEXT_INSERT_POS, -1),
+                    args.getInt(Constants.PLAY_NEXT_COUNT, 0),
+                    args.getInt(Constants.PLAY_NEXT_TARGET_COUNT, -1)
+                )
                 Futures.immediateFuture(SessionResult(SessionResult.RESULT_SUCCESS))
             }
             Constants.CUSTOM_COMMAND_TOGGLE_SHUFFLE_MODE_ON -> {

--- a/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
@@ -17,6 +17,7 @@ import androidx.media3.common.Timeline;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.session.MediaBrowser;
 import androidx.media3.session.SessionCommand;
+import androidx.media3.session.SessionResult;
 
 import com.cappielloantonio.tempo.database.dao.QueueDao;
 import com.cappielloantonio.tempo.interfaces.MediaIndexCallback;
@@ -374,8 +375,22 @@ public class MediaManager {
         args.putInt(Constants.PLAY_NEXT_INSERT_POS, insertPos);
         args.putInt(Constants.PLAY_NEXT_COUNT, items.size());
         args.putInt(Constants.PLAY_NEXT_TARGET_COUNT, targetCount);
-        browser.sendCustomCommand(
-                new SessionCommand(Constants.CUSTOM_COMMAND_PLAY_NEXT, Bundle.EMPTY), args);
+        ListenableFuture<SessionResult> fixup =
+                browser.sendCustomCommand(
+                        new SessionCommand(Constants.CUSTOM_COMMAND_PLAY_NEXT, Bundle.EMPTY), args);
+        Futures.addCallback(fixup, new FutureCallback<SessionResult>() {
+            @Override
+            public void onSuccess(SessionResult result) {
+                if (result.resultCode != SessionResult.RESULT_SUCCESS) {
+                    Log.e(TAG, "insertPlayNext: play-next fixup rejected with code " + result.resultCode);
+                }
+            }
+
+            @Override
+            public void onFailure(Throwable t) {
+                Log.e(TAG, "insertPlayNext: play-next fixup command failed", t);
+            }
+        }, MoreExecutors.directExecutor());
         browser.addMediaItems(insertPos, items);
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
@@ -1,5 +1,6 @@
 package com.cappielloantonio.tempo.service;
 
+import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
@@ -9,11 +10,13 @@ import androidx.annotation.Nullable;
 import androidx.annotation.OptIn;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.Observer;
+import androidx.media3.common.C;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.Player;
 import androidx.media3.common.Timeline;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.session.MediaBrowser;
+import androidx.media3.session.SessionCommand;
 
 import com.cappielloantonio.tempo.database.dao.QueueDao;
 import com.cappielloantonio.tempo.interfaces.MediaIndexCallback;
@@ -35,6 +38,7 @@ import com.google.common.util.concurrent.MoreExecutors;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -311,9 +315,10 @@ public class MediaManager {
                     if (mediaBrowserListenableFuture.isDone()) {
                         Log.d(TAG, "enqueue");
                         MediaBrowser browser = mediaBrowserListenableFuture.get();
-                        if (playImmediatelyAfter && browser.getNextMediaItemIndex() != -1) {
-                            enqueueDatabase(media, false, browser.getNextMediaItemIndex());
-                            browser.addMediaItems(browser.getNextMediaItemIndex(), MappingUtil.mapMediaItems(media));
+                        int current = browser.getCurrentMediaItemIndex();
+                        if (playImmediatelyAfter && current != C.INDEX_UNSET) {
+                            enqueueDatabase(media, false, current + 1);
+                            insertPlayNext(browser, MappingUtil.mapMediaItems(media));
                         } else {
                             enqueueDatabase(media, false, mediaBrowserListenableFuture.get().getMediaItemCount());
                             mediaBrowserListenableFuture.get().addMediaItems(MappingUtil.mapMediaItems(media));
@@ -333,9 +338,10 @@ public class MediaManager {
                     if (mediaBrowserListenableFuture.isDone()) {
                         Log.e(TAG, "enqueue");
                         MediaBrowser browser = mediaBrowserListenableFuture.get();
-                        if (playImmediatelyAfter && browser.getNextMediaItemIndex() != -1) {
-                            enqueueDatabase(media, false, browser.getNextMediaItemIndex());
-                            browser.addMediaItem(browser.getNextMediaItemIndex(), MappingUtil.mapMediaItem(media));
+                        int current = browser.getCurrentMediaItemIndex();
+                        if (playImmediatelyAfter && current != C.INDEX_UNSET) {
+                            enqueueDatabase(media, false, current + 1);
+                            insertPlayNext(browser, Collections.singletonList(MappingUtil.mapMediaItem(media)));
                         } else {
                             enqueueDatabase(media, false, mediaBrowserListenableFuture.get().getMediaItemCount());
                             mediaBrowserListenableFuture.get().addMediaItem(MappingUtil.mapMediaItem(media));
@@ -346,6 +352,31 @@ public class MediaManager {
                 }
             }, MoreExecutors.directExecutor());
         }
+    }
+
+    // "Play next": insert the items right after the current item on the timeline, then —
+    // once the insert has actually applied — ask the service to move them next in the
+    // ExoPlayer shuffle order too. The timeline insert keeps URI/large-list handling on the
+    // normal onAddMediaItems path; the shuffle-order fixup must run on the service (only it
+    // can setShuffleOrder). addMediaItems and a custom command are NOT ordered relative to
+    // each other, so we send the fixup from a one-shot timeline listener once the insert is
+    // visible (same pattern startQueue uses), otherwise the fixup would be clobbered by
+    // addMediaItems' own internal shuffle insert. The fixup is a no-op when shuffle is off.
+    private static void insertPlayNext(MediaBrowser browser, List<MediaItem> items) {
+        if (items.isEmpty()) return;
+        int insertPos = browser.getCurrentMediaItemIndex() + 1;
+        int targetCount = browser.getMediaItemCount() + items.size();
+        // Send the fixup request and do the timeline insert. These two are NOT ordered
+        // relative to each other (and addMediaItems updates the controller optimistically
+        // before the session's async onAddMediaItems even runs), so the service stashes the
+        // request and applies it from its own onTimelineChanged once the insert is visible.
+        Bundle args = new Bundle();
+        args.putInt(Constants.PLAY_NEXT_INSERT_POS, insertPos);
+        args.putInt(Constants.PLAY_NEXT_COUNT, items.size());
+        args.putInt(Constants.PLAY_NEXT_TARGET_COUNT, targetCount);
+        browser.sendCustomCommand(
+                new SessionCommand(Constants.CUSTOM_COMMAND_PLAY_NEXT, Bundle.EMPTY), args);
+        browser.addMediaItems(insertPos, items);
     }
 
     public static void shuffle(ListenableFuture<MediaBrowser> mediaBrowserListenableFuture, List<Child> media, int startIndex, int endIndex) {

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Constants.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Constants.kt
@@ -135,6 +135,14 @@ object Constants {
     const val CUSTOM_COMMAND_TOGGLE_REPEAT_MODE_ALL = "android.media3.session.demo.REPEAT_ALL"
     const val CUSTOM_COMMAND_INSTANT_MIX_ON = "android.media3.session.demo.INSTANT_MIX_ON"
     const val CUSTOM_COMMAND_INSTANT_MIX_OFF = "android.media3.session.demo.INSTANT_MIX_OFF"
+
+    // "Play next" shuffle-order fixup: the UI inserts the items on the timeline, then
+    // asks the service (which owns the ExoPlayer) to move them next in the shuffle order.
+    const val CUSTOM_COMMAND_PLAY_NEXT = "com.cappielloantonio.tempo.PLAY_NEXT_FIXUP"
+    const val PLAY_NEXT_INSERT_POS = "play_next_insert_pos"
+    const val PLAY_NEXT_COUNT = "play_next_count"
+    const val PLAY_NEXT_TARGET_COUNT = "play_next_target_count"
+
     enum class SeedType {
         ARTIST, ALBUM, TRACK
     }


### PR DESCRIPTION
## Summary
Applied the "Play Next under shuffle" fix (from @herrerad85 commit #c55440e3d9d55988995cdce759470d45962ac6e7 ) across 4 files, adapted to the current repo (which was in the patch's exact "before" state) resolves #329 :
- Constants.kt — added CUSTOM_COMMAND_PLAY_NEXT + PLAY_NEXT_INSERT_POS / PLAY_NEXT_COUNT / PLAY_NEXT_TARGET_COUNT.
- BaseSessionCallback.kt — registered the custom command in onConnect and handled it in onCustomCommand (calls service.requestPlayNextFixup(...)).
- MediaManager.java — added 4 imports; both enqueue overloads now insert at current + 1 on the timeline and call the new insertPlayNext() helper, which sends the fixup command to the service and does the timeline addMediaItems.
- BaseMediaService.kt — added requestPlayNextFixup/tryApplyPlayNextFixup (rebuilds DefaultShuffleOrder so the inserted items play immediately after the current track; safe no-op when shuffle off or counts mismatch) and a tryApplyPlayNextFixup() call in onTimelineChanged.
Root cause it fixes: under shuffle, getNextMediaItemIndex() is shuffle-order-dependent and ExoPlayer randomizes a newly-inserted item's shuffle position — so "play next" landed at a random spot. Now the item is deterministically inserted at current+1 on the timeline and re-spliced into shuffle position current+1.