### PR TITLE
Scrobble a track you skip once it passes the play threshold

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -496,8 +496,8 @@ open class BaseMediaService : MediaLibraryService() {
                     if (newPosition.mediaItem?.mediaMetadata?.extras?.getString("type") == Constants.MEDIA_TYPE_MUSIC) {
                         MediaManager.setLastPlayedTimestamp(newPosition.mediaItem)
                     }
-                } else if (oldPosition.mediaItemIndex != newPosition.mediaItemIndex) {
-                    // Manual skip to another track: scrobble the track being left if it passed the Last.fm threshold.
+                } else if (reason == Player.DISCONTINUITY_REASON_SEEK && oldPosition.mediaItemIndex != newPosition.mediaItemIndex) {
+                    // SEEK only: scrobble a genuine user skip, not other index changes such as removing the currently playing track (REMOVE).
                     if (oldPosition.mediaItem?.mediaMetadata?.extras?.getString("type") == Constants.MEDIA_TYPE_MUSIC) {
                         val durationMs = ((oldPosition.mediaItem?.mediaMetadata?.extras?.getInt("duration") ?: 0).toLong()) * 1000L
                         if (MediaManager.meetsScrobbleThreshold(oldPosition.positionMs, durationMs)) {

--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -496,6 +496,15 @@ open class BaseMediaService : MediaLibraryService() {
                     if (newPosition.mediaItem?.mediaMetadata?.extras?.getString("type") == Constants.MEDIA_TYPE_MUSIC) {
                         MediaManager.setLastPlayedTimestamp(newPosition.mediaItem)
                     }
+                } else if (oldPosition.mediaItemIndex != newPosition.mediaItemIndex) {
+                    // Manual skip to another track: scrobble the track being left if it passed the Last.fm threshold.
+                    if (oldPosition.mediaItem?.mediaMetadata?.extras?.getString("type") == Constants.MEDIA_TYPE_MUSIC) {
+                        val durationMs = ((oldPosition.mediaItem?.mediaMetadata?.extras?.getInt("duration") ?: 0).toLong()) * 1000L
+                        if (MediaManager.meetsScrobbleThreshold(oldPosition.positionMs, durationMs)) {
+                            MediaManager.scrobble(oldPosition.mediaItem, true)
+                            MediaManager.saveChronology(oldPosition.mediaItem)
+                        }
+                    }
                 }
             }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
@@ -462,6 +462,12 @@ public class MediaManager {
         }
     }
 
+    // Last.fm rule: a play counts once it has passed half the track or 4 minutes, whichever comes first; never under 30 seconds.
+    public static boolean meetsScrobbleThreshold(long positionMs, long durationMs) {
+        if (durationMs <= 30_000L) return false;
+        return positionMs >= Math.min(durationMs / 2, 240_000L);
+    }
+
     @OptIn(markerClass = UnstableApi.class)
     public static void continuousPlay(MediaItem mediaItem,
                                       ListenableFuture<MediaBrowser> existingBrowserFuture) {


### PR DESCRIPTION
### What

Tempus only submits a scrobble when a track finishes on its own or auto advances to the next one. If you skip away from a track before it ends, it is never scrobbled, even when you heard almost all of it. That is stricter than the scrobbling rule (a play counts once it passes half the track or four minutes, for tracks over thirty seconds), so real plays get dropped.

### The fix

The scrobble submissions live in onPositionDiscontinuity in BaseMediaService, which only handled the DISCONTINUITY_REASON_AUTO_TRANSITION case. This adds the missing case: when the track index changes for any other reason (a manual skip to another track), scrobble the track being left if it passed the threshold, through the same standard scrobble endpoint used everywhere else.

A small MediaManager.meetsScrobbleThreshold(positionMs, durationMs) helper holds the rule (half the length or four minutes, never under thirty seconds). Duration comes from the item metadata Tempus already carries. Skipping a barely played track still does nothing, so short skips are not scrobbled.

### Local history

A skipped track that passes the threshold is also written to Tempus's local play history (chronology), the same as when a track finishes on its own. That keeps the local history and the scrobble consistent: if a skip counts as a play, it shows up in both places, and a short skip shows up in neither.

### Why the standard endpoint

This rides the plain scrobble endpoint, so it works on every Subsonic backend today and forwards to whatever the server scrobbles to (Last.fm, ListenBrainz, and so on). The OpenSubsonic playbackReport extension is the nicer long term path but it is backend dependent, so it is a separate follow up.

### Testing

Verified against a live server. Skipping a track played past the threshold now fires a scrobble submission, the server records it, and it forwards to the external scrobbler within a second. Skipping a track played only a few seconds does not scrobble.

Fixes #906


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tracks manually skipped after meeting Last.fm’s scrobbling threshold are now automatically scrobbled.
  * Qualifying skipped tracks are also saved to listening history.
  * Scrobbling now follows improved duration and playback-progress rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->