### PR TITLE
feat: surface network errors via a Result wrapper and shared callback

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/interfaces/SystemCallback.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/interfaces/SystemCallback.java
@@ -1,9 +1,0 @@
-package com.cappielloantonio.tempo.interfaces;
-
-import androidx.annotation.Keep;
-
-@Keep
-public interface SystemCallback {
-    default void onError(Exception exception) {}
-    default void onSuccess(String password, String token, String salt) {}
-}

--- a/app/src/main/java/com/cappielloantonio/tempo/repository/SystemRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/SystemRepository.java
@@ -7,10 +7,11 @@ import androidx.lifecycle.MutableLiveData;
 
 import com.cappielloantonio.tempo.App;
 import com.cappielloantonio.tempo.github.models.LatestRelease;
-import com.cappielloantonio.tempo.interfaces.SystemCallback;
 import com.cappielloantonio.tempo.subsonic.base.ApiResponse;
+import com.cappielloantonio.tempo.subsonic.base.Resource;
+import com.cappielloantonio.tempo.subsonic.base.ResourceCallback;
+import com.cappielloantonio.tempo.subsonic.base.SubsonicCallback;
 import com.cappielloantonio.tempo.subsonic.models.OpenSubsonicExtension;
-import com.cappielloantonio.tempo.subsonic.models.ResponseStatus;
 import com.cappielloantonio.tempo.subsonic.models.SubsonicResponse;
 
 import java.util.List;
@@ -20,33 +21,16 @@ import retrofit2.Callback;
 import retrofit2.Response;
 
 public class SystemRepository {
-    public void checkUserCredential(SystemCallback callback) {
+    public void checkUserCredential(ResourceCallback<Void> callback) {
+        callback.onResult(Resource.loading());
+
         App.getSubsonicClientInstance(false)
                 .getSystemClient()
                 .ping()
-                .enqueue(new Callback<ApiResponse>() {
+                .enqueue(new SubsonicCallback<Void>(callback) {
                     @Override
-                    public void onResponse(@NonNull Call<ApiResponse> call, @NonNull retrofit2.Response<ApiResponse> response) {
-                        if (response.body() != null) {
-                            if (response.body().getSubsonicResponse().getStatus().equals(ResponseStatus.FAILED)) {
-                                com.cappielloantonio.tempo.subsonic.models.Error apiError = response.body().getSubsonicResponse().getError();
-                                callback.onError(new Exception(apiError != null ? apiError.getCode() + " - " + apiError.getMessage() : "Unknown server error"));
-                            } else if (response.body().getSubsonicResponse().getStatus().equals(ResponseStatus.OK)) {
-                                String password = response.raw().request().url().queryParameter("p");
-                                String token = response.raw().request().url().queryParameter("t");
-                                String salt = response.raw().request().url().queryParameter("s");
-                                callback.onSuccess(password, token, salt);
-                            } else {
-                                callback.onError(new Exception("Empty response"));
-                            }
-                        } else {
-                            callback.onError(new Exception(String.valueOf(response.code())));
-                        }
-                    }
-
-                    @Override
-                    public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
-                        callback.onError(new Exception(t.getMessage()));
+                    protected Void extractData(SubsonicResponse response) {
+                        return null;
                     }
                 });
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/base/NetworkError.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/base/NetworkError.java
@@ -1,0 +1,56 @@
+package com.cappielloantonio.tempo.subsonic.base;
+
+import androidx.annotation.Keep;
+import androidx.annotation.Nullable;
+
+/**
+ * A categorised request failure. The category lets the UI tell apart the cases a user (and a
+ * hardened login flow, see #829) needs to act on differently: wrong credentials, an unreachable
+ * server, and a server that answered with something unexpected.
+ */
+@Keep
+public class NetworkError {
+    public enum Type {
+        /** No usable response: connection refused, timeout, DNS/TLS failure, airplane mode. */
+        UNREACHABLE,
+        /** A non-2xx HTTP response. */
+        SERVER_ERROR,
+        /** A 2xx response whose body was missing or could not be parsed. */
+        INVALID_RESPONSE,
+        /** Subsonic replied "failed" with a credential/authorization error code. */
+        AUTH_FAILED,
+        /** Subsonic replied "failed" with any other error code. */
+        API_ERROR
+    }
+
+    private final Type type;
+    @Nullable
+    private final String message;
+    @Nullable
+    private final Integer code;
+
+    public NetworkError(Type type, @Nullable String message, @Nullable Integer code) {
+        this.type = type;
+        this.message = message;
+        this.code = code;
+    }
+
+    public Type getType() {
+        return type;
+    }
+
+    @Nullable
+    public String getMessage() {
+        return message;
+    }
+
+    /** The Subsonic error code, or the HTTP status code, when one is available. */
+    @Nullable
+    public Integer getCode() {
+        return code;
+    }
+
+    public boolean isAuthFailure() {
+        return type == Type.AUTH_FAILED;
+    }
+}

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/base/Resource.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/base/Resource.java
@@ -1,0 +1,62 @@
+package com.cappielloantonio.tempo.subsonic.base;
+
+import androidx.annotation.Keep;
+import androidx.annotation.Nullable;
+
+/**
+ * A small Loading / Success / Error wrapper for a repository result, so callers can render a
+ * uniform "loading", "loaded" or "couldn't reach server" state instead of silently getting an
+ * empty list when a request fails.
+ *
+ * @param <T> the success payload type
+ */
+@Keep
+public class Resource<T> {
+    public enum Status {LOADING, SUCCESS, ERROR}
+
+    private final Status status;
+    @Nullable
+    private final T data;
+    @Nullable
+    private final NetworkError error;
+
+    private Resource(Status status, @Nullable T data, @Nullable NetworkError error) {
+        this.status = status;
+        this.data = data;
+        this.error = error;
+    }
+
+    public static <T> Resource<T> loading() {
+        return new Resource<>(Status.LOADING, null, null);
+    }
+
+    public static <T> Resource<T> success(@Nullable T data) {
+        return new Resource<>(Status.SUCCESS, data, null);
+    }
+
+    public static <T> Resource<T> error(NetworkError error) {
+        return new Resource<>(Status.ERROR, null, error);
+    }
+
+    public Status getStatus() {
+        return status;
+    }
+
+    @Nullable
+    public T getData() {
+        return data;
+    }
+
+    @Nullable
+    public NetworkError getError() {
+        return error;
+    }
+
+    public boolean isSuccess() {
+        return status == Status.SUCCESS;
+    }
+
+    public boolean isError() {
+        return status == Status.ERROR;
+    }
+}

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/base/ResourceCallback.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/base/ResourceCallback.java
@@ -1,0 +1,14 @@
+package com.cappielloantonio.tempo.subsonic.base;
+
+import androidx.annotation.Keep;
+
+/**
+ * Delivers a repository result to a consumer. Implementations are typically called on the main
+ * thread (Retrofit's callback executor), so they may update the UI directly.
+ *
+ * @param <T> the success payload type
+ */
+@Keep
+public interface ResourceCallback<T> {
+    void onResult(Resource<T> resource);
+}

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/base/SubsonicCallback.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/base/SubsonicCallback.java
@@ -1,0 +1,83 @@
+package com.cappielloantonio.tempo.subsonic.base;
+
+import androidx.annotation.NonNull;
+
+import com.cappielloantonio.tempo.subsonic.models.ErrorCode;
+import com.cappielloantonio.tempo.subsonic.models.ResponseStatus;
+import com.cappielloantonio.tempo.subsonic.models.SubsonicResponse;
+
+import retrofit2.Call;
+import retrofit2.Callback;
+import retrofit2.Response;
+
+/**
+ * Shared Retrofit callback that maps every failure mode of a Subsonic call — transport failure,
+ * non-2xx status, unparseable body, and a "failed" Subsonic response — into a single
+ * {@link Resource} in one place, instead of each repository re-implementing an anonymous
+ * {@code Callback} whose {@code onFailure} is usually empty.
+ *
+ * Subclasses only pull the payload they care about out of a successful response via
+ * {@link #extractData(SubsonicResponse)}.
+ *
+ * @param <T> the success payload type
+ */
+public abstract class SubsonicCallback<T> implements Callback<ApiResponse> {
+    private final ResourceCallback<T> callback;
+
+    protected SubsonicCallback(ResourceCallback<T> callback) {
+        this.callback = callback;
+    }
+
+    /** Extract the payload from a successful response. May return null when there is no payload. */
+    protected abstract T extractData(SubsonicResponse response);
+
+    @Override
+    public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
+        if (!response.isSuccessful()) {
+            callback.onResult(Resource.error(new NetworkError(
+                    NetworkError.Type.SERVER_ERROR, "HTTP " + response.code(), response.code())));
+            return;
+        }
+
+        try {
+            ApiResponse body = response.body();
+            SubsonicResponse subsonicResponse = body != null ? body.getSubsonicResponse() : null;
+
+            if (subsonicResponse == null) {
+                callback.onResult(Resource.error(new NetworkError(
+                        NetworkError.Type.INVALID_RESPONSE, "Empty server response", null)));
+                return;
+            }
+
+            if (ResponseStatus.FAILED.equals(subsonicResponse.getStatus())) {
+                callback.onResult(Resource.error(toNetworkError(subsonicResponse)));
+                return;
+            }
+
+            callback.onResult(Resource.success(extractData(subsonicResponse)));
+        } catch (Exception e) {
+            callback.onResult(Resource.error(new NetworkError(
+                    NetworkError.Type.INVALID_RESPONSE, e.getMessage(), null)));
+        }
+    }
+
+    @Override
+    public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
+        callback.onResult(Resource.error(new NetworkError(
+                NetworkError.Type.UNREACHABLE, t.getMessage(), null)));
+    }
+
+    private static NetworkError toNetworkError(SubsonicResponse response) {
+        Integer code = response.getError() != null ? response.getError().getCode() : null;
+        String message = response.getError() != null ? response.getError().getMessage() : null;
+
+        NetworkError.Type type = isAuthCode(code) ? NetworkError.Type.AUTH_FAILED : NetworkError.Type.API_ERROR;
+        return new NetworkError(type, message, code);
+    }
+
+    private static boolean isAuthCode(Integer code) {
+        return code != null && (code == ErrorCode.WRONG_USERNAME_OR_PASSWORD
+                || code == ErrorCode.TOKEN_AUTHENTICATION_NOT_SUPPORTED
+                || code == ErrorCode.USER_NOT_AUTHORIZED);
+    }
+}

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/models/ErrorCode.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/models/ErrorCode.kt
@@ -5,14 +5,14 @@ import androidx.annotation.Keep
 @Keep
 class ErrorCode(val value: Int) {
     companion object {
-        var GENERIC_ERROR = 0
-        var REQUIRED_PARAMETER_MISSING = 10
-        var INCOMPATIBLE_VERSION_CLIENT = 20
-        var INCOMPATIBLE_VERSION_SERVER = 30
-        var WRONG_USERNAME_OR_PASSWORD = 40
-        var TOKEN_AUTHENTICATION_NOT_SUPPORTED = 41
-        var USER_NOT_AUTHORIZED = 50
-        var TRIAL_PERIOD_OVER = 60
-        var DATA_NOT_FOUND = 70
+        const val GENERIC_ERROR = 0
+        const val REQUIRED_PARAMETER_MISSING = 10
+        const val INCOMPATIBLE_VERSION_CLIENT = 20
+        const val INCOMPATIBLE_VERSION_SERVER = 30
+        const val WRONG_USERNAME_OR_PASSWORD = 40
+        const val TOKEN_AUTHENTICATION_NOT_SUPPORTED = 41
+        const val USER_NOT_AUTHORIZED = 50
+        const val TRIAL_PERIOD_OVER = 60
+        const val DATA_NOT_FOUND = 70
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LoginFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LoginFragment.java
@@ -22,9 +22,9 @@ import com.cappielloantonio.tempo.R;
 import com.cappielloantonio.tempo.ui.adapter.ServerAdapter;
 import com.cappielloantonio.tempo.databinding.FragmentLoginBinding;
 import com.cappielloantonio.tempo.interfaces.ClickCallback;
-import com.cappielloantonio.tempo.interfaces.SystemCallback;
 import com.cappielloantonio.tempo.model.Server;
 import com.cappielloantonio.tempo.repository.SystemRepository;
+import com.cappielloantonio.tempo.subsonic.base.NetworkError;
 import com.cappielloantonio.tempo.ui.activity.MainActivity;
 import com.cappielloantonio.tempo.ui.dialog.ServerSignupDialog;
 import com.cappielloantonio.tempo.util.Preferences;
@@ -120,19 +120,33 @@ public class LoginFragment extends Fragment implements ClickCallback {
         saveServerPreference(server.getServerId(), server.getAddress(), server.getLocalAddress(), server.getUsername(), server.getPassword(), server.isLowSecurity(), server.getClientCert());
 
         SystemRepository systemRepository = new SystemRepository();
-        systemRepository.checkUserCredential(new SystemCallback() {
-            @Override
-            public void onError(Exception exception) {
+        systemRepository.checkUserCredential(resource -> {
+            if (resource.isSuccess()) {
+                activity.goFromLogin();
+            } else if (resource.isError()) {
                 Preferences.switchInUseServerAddress();
                 resetServerPreference();
-                Toast.makeText(requireContext(), exception.getMessage(), Toast.LENGTH_SHORT).show();
-            }
-
-            @Override
-            public void onSuccess(String password, String token, String salt) {
-                activity.goFromLogin();
+                Toast.makeText(requireContext(), loginErrorMessage(resource.getError()), Toast.LENGTH_SHORT).show();
             }
         });
+    }
+
+    private String loginErrorMessage(NetworkError error) {
+        if (error == null) return getString(R.string.login_error_generic);
+
+        switch (error.getType()) {
+            case AUTH_FAILED:
+                return getString(R.string.login_error_credentials);
+            case UNREACHABLE:
+                return getString(R.string.login_error_unreachable);
+            case SERVER_ERROR:
+                return getString(R.string.login_error_server, error.getCode() != null ? error.getCode() : 0);
+            case INVALID_RESPONSE:
+                return getString(R.string.login_error_invalid_response);
+            case API_ERROR:
+            default:
+                return error.getMessage() != null ? error.getMessage() : getString(R.string.login_error_generic);
+        }
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -217,6 +217,11 @@
     <string name="library_title_playlist_see_all_button">See all</string>
     <string name="library_toast_long_press_to_refresh">Long press to refresh</string>
     <string name="login_empty">No server added</string>
+    <string name="login_error_credentials">Wrong username or password</string>
+    <string name="login_error_generic">Login failed</string>
+    <string name="login_error_invalid_response">The server returned an unexpected response</string>
+    <string name="login_error_server">Server error (HTTP %1$d)</string>
+    <string name="login_error_unreachable">Couldn\'t reach the server</string>
     <string name="login_title">Subsonic servers</string>
     <string name="login_title_expanded">Subsonic servers</string>
     <string name="media_route_menu_title">Cast</string>


### PR DESCRIPTION
Closes #912 (split out from #858).

## Problem

Repositories use anonymous Retrofit callbacks whose `onFailure` is almost always empty (or a bare `Log.d`), and non-2xx responses in `onResponse` are ignored. When a request fails the LiveData never updates, so the user sees an empty list or an endless shimmer with no message and no way to tell *why* — a likely contributor to reports like #853.

## Change

This ships the **mechanism** the issue describes, plus **one** real consumer, so the rollout to the other repositories can happen incrementally without a 90-file mega-PR.

**Mechanism (`subsonic/base/`):**
- `Resource<T>` — Loading / Success / Error.
- `NetworkError` — a categorised failure: `UNREACHABLE` (transport), `SERVER_ERROR` (non-2xx), `INVALID_RESPONSE` (2xx but missing/unparseable body), `AUTH_FAILED` (Subsonic `failed` with a credential/authorization code), `API_ERROR` (any other `failed`). This is the distinction a hardened login needs: *wrong credentials* vs *server unreachable* vs *server returned garbage*.
- `SubsonicCallback<T>` — one Retrofit adapter that maps all of the above into a `Resource` in a single place; subclasses only implement `extractData(SubsonicResponse)`. This is what removes the duplicated anonymous-callback boilerplate as callsites migrate.

**First consumer — the login credential check:**
- `SystemRepository.checkUserCredential` now reports a `Resource<Void>`.
- `LoginFragment` shows a specific message per category (wrong credentials / couldn't reach server / server error / unexpected response) instead of a raw exception string.
- The now-unused `SystemCallback` interface is removed.

`ErrorCode`'s constants are changed from `var` to `const val` so they're usable from Java (they were previously unreferenced).

## Deliberately out of scope

The other ~95 `enqueue` callsites are **not** touched — they're the incremental follow-up the issue calls for. This PR keeps the diff reviewable and proves the mechanism end-to-end on the path #829 most needs it.

## Milestone placement

Per the #858 thread, @eddyizm noted Tom may want to decide where this lands. It's broader than login (it's repository-wide infrastructure) but the login flow is its first consumer, matching the "build it first with `LoginActivity` as first consumer" plan in #829. Flagging for you both to slot as you see fit.

## Testing

Not build-verified locally (no build env set up here) — CI/maintainer build appreciated. The login path is exercised by the existing server-tap flow; error categories map straight from Retrofit/Subsonic responses.