### PR TITLE
Show the actual decoded format in the player instead of the requested transcode

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
@@ -26,9 +26,12 @@ import androidx.appcompat.widget.PopupMenu;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.media3.common.C;
+import androidx.media3.common.Format;
 import androidx.media3.common.MediaMetadata;
 import androidx.media3.common.PlaybackParameters;
 import androidx.media3.common.Player;
+import androidx.media3.common.Tracks;
 import androidx.media3.common.util.RepeatModeUtil;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.session.MediaBrowser;
@@ -266,6 +269,23 @@ public class PlayerControllerFragment extends Fragment {
             }
 
             @Override
+            public void onTracksChanged(@NonNull Tracks tracks) {
+                // The real decoded format is only known once the player has loaded the
+                // track, which happens after the metadata change, so refresh then. See #579.
+                applyActualPlaybackFormat();
+            }
+
+            @Override
+            public void onPlaybackStateChanged(int playbackState) {
+                // onTracksChanged can arrive before the audio track is fully synced on the
+                // first load, so re-apply once the player reaches READY, when the decoded
+                // format is reliably available and without needing a track change. See #579.
+                if (playbackState == Player.STATE_READY) {
+                    applyActualPlaybackFormat();
+                }
+            }
+
+            @Override
             public void onShuffleModeEnabledChanged(boolean shuffleModeEnabled) {
                 Preferences.setShuffleModeEnabled(shuffleModeEnabled);
             }
@@ -351,22 +371,7 @@ public class PlayerControllerFragment extends Fragment {
     }
 
     private void setMediaInfo(MediaMetadata mediaMetadata) {
-        boolean isLocal = false;
-
-        if (mediaBrowserListenableFuture != null && mediaBrowserListenableFuture.isDone()) {
-            try {
-                MediaBrowser browser = mediaBrowserListenableFuture.get();
-                if (browser != null && browser.getCurrentMediaItem() != null) {
-                    android.net.Uri currentUri = browser.getCurrentMediaItem().requestMetadata.mediaUri;
-                    if (currentUri != null) {
-                        String scheme = currentUri.getScheme();
-                        isLocal = "content".equals(scheme) || "file".equals(scheme);
-                    }
-                }
-            } catch (Exception e) {
-                Log.e("DEBUG_PLAYER", "Error getting browser for UI update", e);
-            }
-        }
+        boolean isLocal = isCurrentTrackLocal();
 
         if (mediaMetadata.extras != null) {
             String extension = mediaMetadata.extras.getString("suffix", getString(R.string.player_unknown_format));
@@ -400,16 +405,12 @@ public class PlayerControllerFragment extends Fragment {
         }
 
         if (!isLocal) {
-            boolean isTranscodingExtension = !MusicUtil.getTranscodingFormatPreference().equals("raw");
-            boolean isTranscodingBitrate = !MusicUtil.getBitratePreference().equals("0");
-            if (isTranscodingExtension || isTranscodingBitrate) {
-                playerMediaExtension.setText(MusicUtil.getTranscodingFormatPreference() + " ("
-                        + getString(R.string.player_transcoding) + ")");
-                playerMediaBitrate.setText(
-                        !MusicUtil.getBitratePreference().equals("0") ? MusicUtil.getBitratePreference() + "kbps"
-                                : getString(R.string.player_transcoding_requested));
-            }
-
+            // Show the format/bitrate the player is actually decoding (the server's real
+            // output) instead of the client's requested transcode preference, which the
+            // server can ignore or override, e.g. when server settings are prioritized, or
+            // when the server has no matching transcoding rule and serves the original.
+            // See issue #579.
+            applyActualPlaybackFormat();
         }
 
         playerTrackInfo.setOnClickListener(view -> {
@@ -422,6 +423,94 @@ public class PlayerControllerFragment extends Fragment {
 
         playerMediaBitrate.setOnClickListener(v -> toggleBitrateVisibility());
         playerMediaBitrate.setOnLongClickListener(v -> toggleQuickActionVisiblity());
+    }
+
+    // True when the current item is played from the device (content://, file://) rather than
+    // streamed/transcoded by the server.
+    private boolean isCurrentTrackLocal() {
+        if (mediaBrowserListenableFuture != null && mediaBrowserListenableFuture.isDone()) {
+            try {
+                MediaBrowser browser = mediaBrowserListenableFuture.get();
+                if (browser != null && browser.getCurrentMediaItem() != null) {
+                    android.net.Uri currentUri = browser.getCurrentMediaItem().requestMetadata.mediaUri;
+                    if (currentUri != null) {
+                        String scheme = currentUri.getScheme();
+                        return "content".equals(scheme) || "file".equals(scheme);
+                    }
+                }
+            } catch (Exception e) {
+                Log.e("DEBUG_PLAYER", "Error resolving current track locality", e);
+            }
+        }
+        return false;
+    }
+
+    // Reads the audio format the player is actually decoding (the server's output) and shows
+    // it, rather than the client's requested transcode preference. The server can ignore the
+    // request (server settings prioritized, or no matching transcoding rule), so the requested
+    // format/bitrate may differ from what is really playing. See issue #579.
+    // Scope note: TrackInfoDialog still reports the requested transcode preference, so that
+    // dialog and this player label can intentionally differ for the same track.
+    private void applyActualPlaybackFormat() {
+        if (playerMediaExtension == null) return;
+        // Local files are played from disk, not transcoded, so their format/bitrate must come
+        // from the file metadata (handled in setMediaInfo), not the decoder label. onTracksChanged
+        // also calls this, so guard here to keep both entry points consistent and stop a local
+        // file's display from being overwritten with the decoded-format label. See #579.
+        if (isCurrentTrackLocal()) return;
+
+        Format format = getCurrentAudioFormat();
+        if (format == null) return; // tracks not ready yet; onTracksChanged will retry
+
+        String actual = MusicUtil.audioFormatLabel(format.sampleMimeType);
+        if (actual != null && !actual.isEmpty()) {
+            String original = getCurrentOriginalSuffix();
+            boolean transcoded = original != null && !original.isEmpty() && !actual.equalsIgnoreCase(original);
+            playerMediaExtension.setText(transcoded
+                    ? actual + " (" + getString(R.string.player_transcoding) + ")"
+                    : actual);
+        }
+
+        if (format.bitrate != Format.NO_VALUE && format.bitrate > 0) {
+            playerMediaBitrate.setText((format.bitrate / 1000) + "kbps");
+            playerMediaBitrate.setVisibility(Preferences.getBitrateVisible() ? View.VISIBLE : View.GONE);
+        }
+    }
+
+    private Format getCurrentAudioFormat() {
+        try {
+            if (mediaBrowserListenableFuture == null || !mediaBrowserListenableFuture.isDone()) return null;
+            MediaBrowser browser = mediaBrowserListenableFuture.get();
+            if (browser == null) return null;
+            // Prefer the selected audio track. On the first load the controller can report
+            // tracks before any is marked selected, so fall back to the first audio track and
+            // show the format immediately instead of only after the next track change. See #579.
+            Format firstAudio = null;
+            for (Tracks.Group group : browser.getCurrentTracks().getGroups()) {
+                if (group.getType() != C.TRACK_TYPE_AUDIO) continue;
+                for (int i = 0; i < group.length; i++) {
+                    if (group.isTrackSelected(i)) return group.getTrackFormat(i);
+                    if (firstAudio == null) firstAudio = group.getTrackFormat(i);
+                }
+            }
+            return firstAudio;
+        } catch (Exception e) {
+            Log.e(TAG, "Unable to read current audio format", e);
+        }
+        return null;
+    }
+
+    private String getCurrentOriginalSuffix() {
+        try {
+            if (mediaBrowserListenableFuture == null || !mediaBrowserListenableFuture.isDone()) return null;
+            MediaBrowser browser = mediaBrowserListenableFuture.get();
+            if (browser != null && browser.getMediaMetadata().extras != null) {
+                return browser.getMediaMetadata().extras.getString("suffix", null);
+            }
+        } catch (Exception e) {
+            Log.e(TAG, "Unable to read original suffix", e);
+        }
+        return null;
     }
 
     private void toggleBitrateVisibility() {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
@@ -465,7 +465,7 @@ public class PlayerControllerFragment extends Fragment {
         String actual = MusicUtil.audioFormatLabel(format.sampleMimeType);
         if (actual != null && !actual.isEmpty()) {
             String original = getCurrentOriginalSuffix();
-            boolean transcoded = original != null && !original.isEmpty() && !actual.equalsIgnoreCase(original);
+            boolean transcoded = MusicUtil.isTranscodedFormat(actual, original);
             playerMediaExtension.setText(transcoded
                     ? actual + " (" + getString(R.string.player_transcoding) + ")"
                     : actual);

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
@@ -26,7 +26,6 @@ import androidx.appcompat.widget.PopupMenu;
 import androidx.constraintlayout.widget.ConstraintLayout;
 import androidx.fragment.app.Fragment;
 import androidx.lifecycle.ViewModelProvider;
-import androidx.media3.common.C;
 import androidx.media3.common.Format;
 import androidx.media3.common.MediaMetadata;
 import androidx.media3.common.PlaybackParameters;
@@ -270,18 +269,13 @@ public class PlayerControllerFragment extends Fragment {
 
             @Override
             public void onTracksChanged(@NonNull Tracks tracks) {
-                // The real decoded format is only known once the player has loaded the
-                // track, which happens after the metadata change, so refresh then. See #579.
-                applyActualPlaybackFormat();
+                setMediaFormatFromFileReturnedByServer();
             }
 
             @Override
             public void onPlaybackStateChanged(int playbackState) {
-                // onTracksChanged can arrive before the audio track is fully synced on the
-                // first load, so re-apply once the player reaches READY, when the decoded
-                // format is reliably available and without needing a track change. See #579.
                 if (playbackState == Player.STATE_READY) {
-                    applyActualPlaybackFormat();
+                    setMediaFormatFromFileReturnedByServer();
                 }
             }
 
@@ -371,7 +365,7 @@ public class PlayerControllerFragment extends Fragment {
     }
 
     private void setMediaInfo(MediaMetadata mediaMetadata) {
-        boolean isLocal = isCurrentTrackLocal();
+        boolean isLocal = MusicUtil.isCurrentTrackLocal(getBrowser());
 
         if (mediaMetadata.extras != null) {
             String extension = mediaMetadata.extras.getString("suffix", getString(R.string.player_unknown_format));
@@ -405,12 +399,7 @@ public class PlayerControllerFragment extends Fragment {
         }
 
         if (!isLocal) {
-            // Show the format/bitrate the player is actually decoding (the server's real
-            // output) instead of the client's requested transcode preference, which the
-            // server can ignore or override, e.g. when server settings are prioritized, or
-            // when the server has no matching transcoding rule and serves the original.
-            // See issue #579.
-            applyActualPlaybackFormat();
+            setMediaFormatFromFileReturnedByServer();
         }
 
         playerTrackInfo.setOnClickListener(view -> {
@@ -425,46 +414,30 @@ public class PlayerControllerFragment extends Fragment {
         playerMediaBitrate.setOnLongClickListener(v -> toggleQuickActionVisiblity());
     }
 
-    // True when the current item is played from the device (content://, file://) rather than
-    // streamed/transcoded by the server.
-    private boolean isCurrentTrackLocal() {
-        if (mediaBrowserListenableFuture != null && mediaBrowserListenableFuture.isDone()) {
-            try {
-                MediaBrowser browser = mediaBrowserListenableFuture.get();
-                if (browser != null && browser.getCurrentMediaItem() != null) {
-                    android.net.Uri currentUri = browser.getCurrentMediaItem().requestMetadata.mediaUri;
-                    if (currentUri != null) {
-                        String scheme = currentUri.getScheme();
-                        return "content".equals(scheme) || "file".equals(scheme);
-                    }
-                }
-            } catch (Exception e) {
-                Log.e("DEBUG_PLAYER", "Error resolving current track locality", e);
-            }
+    private MediaBrowser getBrowser() {
+        if (mediaBrowserListenableFuture == null || !mediaBrowserListenableFuture.isDone()) return null;
+        try {
+            return mediaBrowserListenableFuture.get();
+        } catch (Exception e) {
+            Log.e(TAG, "Unable to resolve media browser", e);
+            return null;
         }
-        return false;
     }
 
-    // Reads the audio format the player is actually decoding (the server's output) and shows
-    // it, rather than the client's requested transcode preference. The server can ignore the
-    // request (server settings prioritized, or no matching transcoding rule), so the requested
-    // format/bitrate may differ from what is really playing. See issue #579.
-    // Scope note: TrackInfoDialog still reports the requested transcode preference, so that
-    // dialog and this player label can intentionally differ for the same track.
-    private void applyActualPlaybackFormat() {
+    private void setMediaFormatFromFileReturnedByServer() {
         if (playerMediaExtension == null) return;
-        // Local files are played from disk, not transcoded, so their format/bitrate must come
-        // from the file metadata (handled in setMediaInfo), not the decoder label. onTracksChanged
-        // also calls this, so guard here to keep both entry points consistent and stop a local
-        // file's display from being overwritten with the decoded-format label. See #579.
-        if (isCurrentTrackLocal()) return;
 
-        Format format = getCurrentAudioFormat();
-        if (format == null) return; // tracks not ready yet; onTracksChanged will retry
+        MediaBrowser browser = getBrowser();
+        // Guard against local files here too: onTracksChanged also calls this, and a local
+        // file's format comes from its metadata in setMediaInfo, not the decoder label.
+        if (MusicUtil.isCurrentTrackLocal(browser)) return;
+
+        Format format = MusicUtil.getCurrentAudioFormat(browser);
+        if (format == null) return;
 
         String actual = MusicUtil.audioFormatLabel(format.sampleMimeType);
         if (actual != null && !actual.isEmpty()) {
-            String original = getCurrentOriginalSuffix();
+            String original = MusicUtil.getCurrentOriginalSuffix(browser);
             boolean transcoded = MusicUtil.isTranscodedFormat(actual, original);
             playerMediaExtension.setText(transcoded
                     ? actual + " (" + getString(R.string.player_transcoding) + ")"
@@ -475,42 +448,6 @@ public class PlayerControllerFragment extends Fragment {
             playerMediaBitrate.setText((format.bitrate / 1000) + "kbps");
             playerMediaBitrate.setVisibility(Preferences.getBitrateVisible() ? View.VISIBLE : View.GONE);
         }
-    }
-
-    private Format getCurrentAudioFormat() {
-        try {
-            if (mediaBrowserListenableFuture == null || !mediaBrowserListenableFuture.isDone()) return null;
-            MediaBrowser browser = mediaBrowserListenableFuture.get();
-            if (browser == null) return null;
-            // Prefer the selected audio track. On the first load the controller can report
-            // tracks before any is marked selected, so fall back to the first audio track and
-            // show the format immediately instead of only after the next track change. See #579.
-            Format firstAudio = null;
-            for (Tracks.Group group : browser.getCurrentTracks().getGroups()) {
-                if (group.getType() != C.TRACK_TYPE_AUDIO) continue;
-                for (int i = 0; i < group.length; i++) {
-                    if (group.isTrackSelected(i)) return group.getTrackFormat(i);
-                    if (firstAudio == null) firstAudio = group.getTrackFormat(i);
-                }
-            }
-            return firstAudio;
-        } catch (Exception e) {
-            Log.e(TAG, "Unable to read current audio format", e);
-        }
-        return null;
-    }
-
-    private String getCurrentOriginalSuffix() {
-        try {
-            if (mediaBrowserListenableFuture == null || !mediaBrowserListenableFuture.isDone()) return null;
-            MediaBrowser browser = mediaBrowserListenableFuture.get();
-            if (browser != null && browser.getMediaMetadata().extras != null) {
-                return browser.getMediaMetadata().extras.getString("suffix", null);
-            }
-        } catch (Exception e) {
-            Log.e(TAG, "Unable to read original suffix", e);
-        }
-        return null;
     }
 
     private void toggleBitrateVisibility() {

--- a/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
@@ -337,6 +337,26 @@ public class MusicUtil {
         return Preferences.getAudioTranscodeFormatTranscodedDownload();
     }
 
+    // Maps a Media3 sample MIME type (e.g. "audio/flac") to a short, user-facing format
+    // label (e.g. "flac"). Returns null when the mime is null. Used to show the format the
+    // player is actually decoding rather than the requested transcode preference. See #579.
+    public static String audioFormatLabel(String sampleMimeType) {
+        if (sampleMimeType == null) return null;
+        String mime = sampleMimeType.toLowerCase();
+        if (mime.contains("flac")) return "flac";
+        if (mime.contains("opus")) return "opus";
+        if (mime.contains("vorbis")) return "vorbis";
+        if (mime.contains("mp4a") || mime.contains("aac")) return "aac";
+        if (mime.contains("mpeg") || mime.contains("mp3")) return "mp3";
+        if (mime.contains("alac")) return "alac";
+        if (mime.contains("eac3")) return "eac3";
+        if (mime.contains("ac3")) return "ac3";
+        if (mime.contains("pcm") || mime.contains("raw") || mime.contains("wav")) return "wav";
+        if (mime.contains("ogg")) return "ogg";
+        int slash = mime.indexOf('/');
+        return slash >= 0 && slash < mime.length() - 1 ? mime.substring(slash + 1) : mime;
+    }
+
     public static List<Child> limitPlayableMedia(List<Child> toLimit, int position) {
         if (!toLimit.isEmpty() && toLimit.size() > Constants.PLAYABLE_MEDIA_LIMIT) {
             int from = position < Constants.PRE_PLAYABLE_MEDIA ? 0 : position - Constants.PRE_PLAYABLE_MEDIA;

--- a/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
@@ -357,6 +357,28 @@ public class MusicUtil {
         return slash >= 0 && slash < mime.length() - 1 ? mime.substring(slash + 1) : mime;
     }
 
+    // The player reports the decoded codec (aac, vorbis, opus), but the source "suffix" is often a
+    // container name (m4a, ogg, oga) that legitimately holds that codec. Treating a container/codec
+    // pair as a mismatch would tag direct-played files as "(transcoding)". Only report a transcode
+    // when the decoded codec is not one the source container can carry. See issue 579 and 669.
+    public static boolean isTranscodedFormat(String decodedLabel, String sourceSuffix) {
+        if (decodedLabel == null || decodedLabel.isEmpty()) return false;
+        if (sourceSuffix == null || sourceSuffix.isEmpty()) return false;
+        if (decodedLabel.equalsIgnoreCase(sourceSuffix)) return false;
+        switch (sourceSuffix.toLowerCase()) {
+            case "m4a":
+            case "m4b":
+            case "mp4":
+                return !decodedLabel.equals("aac") && !decodedLabel.equals("alac");
+            case "ogg":
+            case "oga":
+                return !decodedLabel.equals("vorbis") && !decodedLabel.equals("opus")
+                        && !decodedLabel.equals("flac");
+            default:
+                return true;
+        }
+    }
+
     public static List<Child> limitPlayableMedia(List<Child> toLimit, int position) {
         if (!toLimit.isEmpty() && toLimit.size() > Constants.PLAYABLE_MEDIA_LIMIT) {
             int from = position < Constants.PRE_PLAYABLE_MEDIA ? 0 : position - Constants.PRE_PLAYABLE_MEDIA;

--- a/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
@@ -8,6 +8,12 @@ import android.net.Uri;
 import android.text.Html;
 import android.util.Log;
 
+import androidx.media3.common.C;
+import androidx.media3.common.Format;
+import androidx.media3.common.Tracks;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.session.MediaBrowser;
+
 import com.cappielloantonio.tempo.App;
 import com.cappielloantonio.tempo.R;
 import com.cappielloantonio.tempo.model.Download;
@@ -377,6 +383,46 @@ public class MusicUtil {
             default:
                 return true;
         }
+    }
+
+    // True when the current item is played from the device (a content or file uri scheme)
+    // rather than streamed and transcoded by the server. Returns false when the browser is
+    // null or the current item has no resolvable uri. See issue 579.
+    @UnstableApi
+    public static boolean isCurrentTrackLocal(MediaBrowser browser) {
+        if (browser == null || browser.getCurrentMediaItem() == null) return false;
+        Uri currentUri = browser.getCurrentMediaItem().requestMetadata.mediaUri;
+        if (currentUri == null) return false;
+        String scheme = currentUri.getScheme();
+        return "content".equals(scheme) || "file".equals(scheme);
+    }
+
+    // The audio Format the player is currently decoding, so callers can show what is really
+    // playing instead of the requested transcode preference. Prefers the selected audio track;
+    // on the first load the controller can report tracks before one is marked selected, so it
+    // falls back to the first audio track and returns null only when no audio track is
+    // available yet. See issue 579.
+    @UnstableApi
+    public static Format getCurrentAudioFormat(MediaBrowser browser) {
+        if (browser == null) return null;
+        Format firstAudio = null;
+        for (Tracks.Group group : browser.getCurrentTracks().getGroups()) {
+            if (group.getType() != C.TRACK_TYPE_AUDIO) continue;
+            for (int i = 0; i < group.length; i++) {
+                if (group.isTrackSelected(i)) return group.getTrackFormat(i);
+                if (firstAudio == null) firstAudio = group.getTrackFormat(i);
+            }
+        }
+        return firstAudio;
+    }
+
+    // The original source suffix (for example "flac" or "m4a") stored on the current item's
+    // metadata, used to decide whether the decoded format differs from the source. Returns
+    // null when the browser is null or no suffix is present. See issue 579.
+    @UnstableApi
+    public static String getCurrentOriginalSuffix(MediaBrowser browser) {
+        if (browser == null || browser.getMediaMetadata().extras == null) return null;
+        return browser.getMediaMetadata().extras.getString("suffix", null);
     }
 
     public static List<Child> limitPlayableMedia(List<Child> toLimit, int position) {

--- a/app/src/test/java/com/cappielloantonio/tempo/util/MusicUtilTest.java
+++ b/app/src/test/java/com/cappielloantonio/tempo/util/MusicUtilTest.java
@@ -1,7 +1,9 @@
 package com.cappielloantonio.tempo.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -48,5 +50,32 @@ public class MusicUtilTest {
     @Test
     public void audioFormatLabel_returnsNullForNull() {
         assertNull(MusicUtil.audioFormatLabel(null));
+    }
+
+    @Test
+    public void isTranscodedFormat_sameCodecIsNotTranscoded() {
+        assertFalse(MusicUtil.isTranscodedFormat("flac", "flac"));
+        assertFalse(MusicUtil.isTranscodedFormat("FLAC", "flac"));
+    }
+
+    @Test
+    public void isTranscodedFormat_containerCodecIsNotTranscoded() {
+        assertFalse(MusicUtil.isTranscodedFormat("aac", "m4a"));
+        assertFalse(MusicUtil.isTranscodedFormat("alac", "m4a"));
+        assertFalse(MusicUtil.isTranscodedFormat("vorbis", "ogg"));
+        assertFalse(MusicUtil.isTranscodedFormat("opus", "oga"));
+    }
+
+    @Test
+    public void isTranscodedFormat_differentCodecIsTranscoded() {
+        assertTrue(MusicUtil.isTranscodedFormat("mp3", "flac"));
+        assertTrue(MusicUtil.isTranscodedFormat("mp3", "m4a"));
+        assertTrue(MusicUtil.isTranscodedFormat("opus", "flac"));
+    }
+
+    @Test
+    public void isTranscodedFormat_missingSuffixIsNotTranscoded() {
+        assertFalse(MusicUtil.isTranscodedFormat("flac", null));
+        assertFalse(MusicUtil.isTranscodedFormat("flac", ""));
     }
 }

--- a/app/src/test/java/com/cappielloantonio/tempo/util/MusicUtilTest.java
+++ b/app/src/test/java/com/cappielloantonio/tempo/util/MusicUtilTest.java
@@ -1,0 +1,52 @@
+package com.cappielloantonio.tempo.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class MusicUtilTest {
+
+    @Test
+    public void audioFormatLabel_mapsKnownMimeTypes() {
+        assertEquals("flac", MusicUtil.audioFormatLabel("audio/flac"));
+        assertEquals("opus", MusicUtil.audioFormatLabel("audio/opus"));
+        assertEquals("vorbis", MusicUtil.audioFormatLabel("audio/vorbis"));
+        assertEquals("aac", MusicUtil.audioFormatLabel("audio/mp4a-latm"));
+        assertEquals("aac", MusicUtil.audioFormatLabel("audio/aac"));
+        assertEquals("mp3", MusicUtil.audioFormatLabel("audio/mpeg"));
+        assertEquals("alac", MusicUtil.audioFormatLabel("audio/alac"));
+        assertEquals("ogg", MusicUtil.audioFormatLabel("audio/ogg"));
+    }
+
+    // eac3 must be matched before ac3, otherwise "audio/eac3" would fall through to "ac3".
+    @Test
+    public void audioFormatLabel_disambiguatesEac3FromAc3() {
+        assertEquals("eac3", MusicUtil.audioFormatLabel("audio/eac3"));
+        assertEquals("ac3", MusicUtil.audioFormatLabel("audio/ac3"));
+    }
+
+    @Test
+    public void audioFormatLabel_treatsRawAndWavAsWav() {
+        assertEquals("wav", MusicUtil.audioFormatLabel("audio/raw"));
+        assertEquals("wav", MusicUtil.audioFormatLabel("audio/wav"));
+    }
+
+    @Test
+    public void audioFormatLabel_isCaseInsensitive() {
+        assertEquals("flac", MusicUtil.audioFormatLabel("AUDIO/FLAC"));
+    }
+
+    @Test
+    public void audioFormatLabel_fallsBackToSubtypeForUnknownMime() {
+        assertEquals("xyz", MusicUtil.audioFormatLabel("audio/xyz"));
+    }
+
+    @Test
+    public void audioFormatLabel_returnsNullForNull() {
+        assertNull(MusicUtil.audioFormatLabel(null));
+    }
+}


### PR DESCRIPTION
### What

The player's format and bitrate labels showed the client's requested transcode preference even when the server did not honor it (server settings prioritized, or no matching transcoding rule so the original is served). The chip could read "mp3 (transcoding)" while flac was actually streaming.

This reads the decoded audio Format off the player's currently selected track and shows that instead, tagging "(transcoding)" only when the real format differs from the track's original suffix. The MIME to label mapping is extracted to MusicUtil.audioFormatLabel and covered by a unit test.

### Scope

The issue is the "server settings prioritized" case, but this shows the actual decoded format for all streamed playback (anything not played from local disk), not only when the server overrides.

Local and downloaded tracks (content://, file://) are left alone: they play from disk rather than transcoded, so they keep their file metadata format and bitrate. The locality check lives inside setMediaFormatFromFileReturnedByServer so both entry points stay consistent.

### Container formats

Some suffixes name a container, not a codec: an m4a holds aac or alac, and an ogg or oga holds vorbis, opus, or flac. Comparing the decoded codec against the container name alone would wrongly tag a direct played m4a or oga as transcoding. The transcode check treats a decoded codec as a match when the source container legitimately carries it, so direct play of those files shows the real codec with no spurious tag. This also fixes the inverse case in issue 669, where an Opus stream cached as oga was displayed as FLAC.

### TrackInfoDialog

TrackInfoDialog still describes the requested transcode preference, so for the same track the player label (actual) and that dialog (requested) can differ. This PR keeps the change focused on the player display; the dialog can be aligned in a follow up.

### How to reproduce and verify

This is not specific to any one server. The bug appears whenever the server sends a transcoded stream while Tempus is set to prioritize the server's transcoding, because the old label echoed the client's requested format instead of what the server actually sent. To reproduce on any Subsonic or OpenSubsonic server, make the server transcode the stream (send a format different from the source), then play a source of a different format, for example a flac delivered as mp3.

General steps (any server):
1. On the server, enable transcoding for the Tempus playback client and point it at a lossy format such as mp3 with a bitrate. This is the per client transcoding setting, not a global toggle. Note: Tempus streams audio through ExoPlayer's data source, which reaches the server under the Dalvik/Android user agent, so if your server lists clients by user agent that Dalvik/Android entry is the one to configure. The separate okhttp entry is Tempus's API and cover art traffic, not the audio stream, so setting it there has no effect on playback.
2. In Tempus, Settings > Transcoding: turn "Prioritize server transcode settings" ON, and set the client transcode format to something other than the server target (or Direct play).
3. Play a flac track.
   - Before: the chip reads the client setting (e.g. "raw" or "opus"), which is wrong since the server is sending mp3.
   - After: the chip reads "mp3 (transcoding)", matching what is actually streaming.

Direct play control (any server):
4. Turn off that server side transcoding so the client direct plays, then play the flac. The chip reads "flac" both before and after (nothing transcoded).

Concrete example on Navidrome: Settings > Players > the Tempus [Dalvik/Android] client > Transcoding = mp3, Max bitrate = 192. This uses the built in transcoder, with no global config change or server restart.

The label follows what is really decoding in both directions instead of echoing the client preference. Verified on device: a flac to mp3 transcode shows "mp3 (transcoding)", and direct play of flac, an m4a (aac), an ogg (vorbis), and an oga (opus) each shows the real codec with no spurious tag. Covered by JUnit tests (10 cases: the MusicUtil.audioFormatLabel MIME mapping including the eac3 before ac3 ordering, plus the container to codec matching).

### Note on the label refresh

The decoded format is only known once the player has the track, so the label is applied on track change, on reaching READY, and falls back to the first audio track when none is marked selected yet. Without this the chip only updated after switching tracks.

Fixes #579
Fixes #669

