### PR TITLE
feat!: deprecate equalizer from quick actions button

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
@@ -44,7 +44,6 @@ import androidx.viewpager2.widget.ViewPager2;
 
 import com.cappielloantonio.tempo.R;
 import com.cappielloantonio.tempo.databinding.InnerFragmentPlayerControllerBinding;
-import com.cappielloantonio.tempo.equalizer.EqualizerManager;
 import com.cappielloantonio.tempo.service.MediaService;
 import com.cappielloantonio.tempo.ui.activity.MainActivity;
 import com.cappielloantonio.tempo.ui.dialog.PlaybackSpeedDialog;
@@ -68,8 +67,6 @@ import com.google.android.material.elevation.SurfaceColors;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -884,7 +881,6 @@ public class PlayerControllerFragment extends Fragment {
         public void onServiceConnected(ComponentName name, IBinder service) {
             mediaServiceBinder = (MediaService.LocalBinder) service;
             isServiceBound = true;
-            checkEqualizerBands();
         }
 
         @Override
@@ -899,13 +895,6 @@ public class PlayerControllerFragment extends Fragment {
         intent.setAction(MediaService.ACTION_BIND_EQUALIZER);
         requireActivity().bindService(intent, serviceConnection, Context.BIND_AUTO_CREATE);
         isServiceBound = true;
-    }
-
-    private void checkEqualizerBands() {
-        if (mediaServiceBinder != null) {
-            EqualizerManager eqManager = mediaServiceBinder.getEqualizerManager();
-            short numBands = eqManager.getNumberOfBands();
-        }
     }
 
     @Override

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlayerControllerFragment.java
@@ -95,7 +95,6 @@ public class PlayerControllerFragment extends Fragment {
     private ImageButton playerOpenLyricsButton;
     private ImageButton playerTrackInfo;
     private LinearLayout ratingContainer;
-    private ImageButton equalizerButton;
     private LinearLayout sleepTimerContainer;
     private ImageButton sleepTimerButton;
     private android.widget.TextView sleepTimerLabel;
@@ -128,7 +127,6 @@ public class PlayerControllerFragment extends Fragment {
         initMediaListenable();
         initMediaLabelButton();
         initArtistLabelButton();
-        initEqualizerButton();
 
         // Sync UI immediately in case a timer survived a rotation.
         updateSleepTimerUI();
@@ -171,7 +169,6 @@ public class PlayerControllerFragment extends Fragment {
         playerTrackInfo = bind.getRoot().findViewById(R.id.player_info_track);
         songRatingBar = bind.getRoot().findViewById(R.id.song_rating_bar);
         ratingContainer = bind.getRoot().findViewById(R.id.rating_container);
-        equalizerButton = bind.getRoot().findViewById(R.id.player_open_equalizer_button);
         assetLinkChipGroup = bind.getRoot().findViewById(R.id.asset_link_chip_group);
         playerSongLinkChip = bind.getRoot().findViewById(R.id.asset_link_song_chip);
         playerAlbumLinkChip = bind.getRoot().findViewById(R.id.asset_link_album_chip);
@@ -805,10 +802,6 @@ public class PlayerControllerFragment extends Fragment {
         });
     }
 
-    private void initEqualizerButton() {
-        equalizerButton.setOnClickListener(v -> navigateToEqualizerFragment());
-    }
-
     private void navigateToEqualizerFragment() {
         NavController navController = NavHostFragment.findNavController(this);
         NavOptions navOptions = new NavOptions.Builder()
@@ -912,24 +905,6 @@ public class PlayerControllerFragment extends Fragment {
         if (mediaServiceBinder != null) {
             EqualizerManager eqManager = mediaServiceBinder.getEqualizerManager();
             short numBands = eqManager.getNumberOfBands();
-
-            if (equalizerButton != null && sleepTimerContainer != null) {
-                ConstraintLayout.LayoutParams sleepParams = (ConstraintLayout.LayoutParams) sleepTimerContainer
-                        .getLayoutParams();
-                if (numBands == 0) {
-                    equalizerButton.setVisibility(View.GONE);
-                    // Equalizer gone: anchor sleep timer to parent start so the
-                    // two remaining buttons (sleep timer + queue) stay centred.
-                    sleepParams.startToEnd = ConstraintLayout.LayoutParams.UNSET;
-                    sleepParams.startToStart = ConstraintLayout.LayoutParams.PARENT_ID;
-                } else {
-                    equalizerButton.setVisibility(View.VISIBLE);
-                    // Equalizer visible: restore the three-button spread chain.
-                    sleepParams.startToStart = ConstraintLayout.LayoutParams.UNSET;
-                    sleepParams.startToEnd = R.id.player_open_equalizer_button;
-                }
-                sleepTimerContainer.setLayoutParams(sleepParams);
-            }
         }
     }
 

--- a/app/src/main/res/layout-land/inner_fragment_player_controller_layout.xml
+++ b/app/src/main/res/layout-land/inner_fragment_player_controller_layout.xml
@@ -404,28 +404,15 @@
         android:visibility="gone"
         tools:visibility="visible">
 
-        <!-- Equalizer: first element of the horizontal spread chain -->
-        <ImageButton
-            android:id="@+id/player_open_equalizer_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:padding="16dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            app:layout_constraintHorizontal_chainStyle="spread"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/player_sleep_timer_container"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:srcCompat="@drawable/ic_eq" />
-
-        <!-- Sleep timer: button + countdown label wrapped so they centre as a unit -->
+        <!-- Sleep timer: first element of the horizontal spread chain -->
         <LinearLayout
             android:id="@+id/player_sleep_timer_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:gravity="center_horizontal"
-            app:layout_constraintStart_toEndOf="@+id/player_open_equalizer_button"
+            app:layout_constraintHorizontal_chainStyle="spread"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/player_open_lyrics_button"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent">

--- a/app/src/main/res/layout-sw600dp-land/inner_fragment_player_controller_layout.xml
+++ b/app/src/main/res/layout-sw600dp-land/inner_fragment_player_controller_layout.xml
@@ -386,28 +386,15 @@
         app:layout_constraintEnd_toEndOf="parent"
         android:visibility="gone">
 
-        <!-- Equalizer: first element of the horizontal spread chain -->
-        <ImageButton
-            android:id="@+id/player_open_equalizer_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:padding="16dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            app:layout_constraintHorizontal_chainStyle="spread"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/player_sleep_timer_container"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:srcCompat="@drawable/ic_eq" />
-
-        <!-- Sleep timer: button + countdown label wrapped so they centre as a unit -->
+        <!-- Sleep timer: first element of the horizontal spread chain -->
         <LinearLayout
             android:id="@+id/player_sleep_timer_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:gravity="center_horizontal"
-            app:layout_constraintStart_toEndOf="@+id/player_open_equalizer_button"
+            app:layout_constraintHorizontal_chainStyle="spread"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/player_open_lyrics_button"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent">

--- a/app/src/main/res/layout-sw600dp/inner_fragment_player_controller_layout.xml
+++ b/app/src/main/res/layout-sw600dp/inner_fragment_player_controller_layout.xml
@@ -400,28 +400,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 
-        <!-- Equalizer: first element of the horizontal spread chain -->
-        <ImageButton
-            android:id="@+id/player_open_equalizer_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:padding="16dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            app:layout_constraintHorizontal_chainStyle="spread"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/player_sleep_timer_container"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:srcCompat="@drawable/ic_eq" />
-
-        <!-- Sleep timer: button + countdown label wrapped so they centre as a unit -->
+        <!-- Sleep timer: first element of the horizontal spread chain -->
         <LinearLayout
             android:id="@+id/player_sleep_timer_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:gravity="center_horizontal"
-            app:layout_constraintStart_toEndOf="@+id/player_open_equalizer_button"
+            app:layout_constraintHorizontal_chainStyle="spread"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/player_open_lyrics_button"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent">

--- a/app/src/main/res/layout/inner_fragment_player_controller_layout.xml
+++ b/app/src/main/res/layout/inner_fragment_player_controller_layout.xml
@@ -408,28 +408,15 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent">
 
-        <!-- Equalizer: first element of the horizontal spread chain -->
-        <ImageButton
-            android:id="@+id/player_open_equalizer_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:padding="16dp"
-            android:background="?attr/selectableItemBackgroundBorderless"
-            app:layout_constraintHorizontal_chainStyle="spread"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintEnd_toStartOf="@+id/player_sleep_timer_container"
-            app:layout_constraintTop_toTopOf="parent"
-            app:layout_constraintBottom_toBottomOf="parent"
-            app:srcCompat="@drawable/ic_eq" />
-
-        <!-- Sleep timer: button + countdown label wrapped so they centre as a unit -->
+        <!-- Sleep timer: first element of the horizontal spread chain -->
         <LinearLayout
             android:id="@+id/player_sleep_timer_container"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:orientation="vertical"
             android:gravity="center_horizontal"
-            app:layout_constraintStart_toEndOf="@+id/player_open_equalizer_button"
+            app:layout_constraintHorizontal_chainStyle="spread"
+            app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintEnd_toStartOf="@+id/player_open_lyrics_button"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintBottom_toBottomOf="parent">


### PR DESCRIPTION
~~This causes ANR.~~ Fixed ANR by preventing fragment from requesting an equalizer.

Equalizer is no longer accessible through the bottom quick actions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Removed the standalone Equalizer button from the player controls.
  * Moved the Sleep Timer control to the beginning of the quick-action area.
  * Equalizer access remains available through the overflow menu.
  * Simplified the player controls layout across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->