### PR TITLE
Show the transcoded format for downloaded songs in the quality badge

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/DownloaderManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/DownloaderManager.java
@@ -20,6 +20,7 @@ import androidx.media3.exoplayer.offline.DownloadService;
 
 import com.cappielloantonio.tempo.repository.DownloadRepository;
 import com.cappielloantonio.tempo.util.DownloadUtil;
+import com.cappielloantonio.tempo.util.MusicUtil;
 
 import java.io.IOException;
 import java.util.HashMap;
@@ -70,6 +71,8 @@ public class DownloaderManager {
     }
 
     public void download(MediaItem mediaItem, com.cappielloantonio.tempo.model.Download download) {
+        MusicUtil.applyTranscodedDownloadMetadata(download);
+
         download.setDownloadUri(mediaItem.requestMetadata.mediaUri.toString());
 
         DownloadService.sendAddDownload(context, DownloaderService.class, buildDownloadRequest(mediaItem), false);

--- a/app/src/main/java/com/cappielloantonio/tempo/util/ExternalAudioWriter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/ExternalAudioWriter.java
@@ -340,6 +340,7 @@ public class ExternalAudioWriter {
         if (child == null) return;
 
         Download download = new Download(child);
+        MusicUtil.applyTranscodedDownloadMetadata(download);
         download.setDownloadState(1);
         download.setPlaylistId(playlistId);
         download.setPlaylistName(playlistName);

--- a/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
@@ -201,20 +201,28 @@ public class MusicUtil {
     }
 
     public static String getReadableAudioQualityString(Child child) {
-        if (!Preferences.showAudioQuality() || child.getBitrate() == null) return "";
+        if (!Preferences.showAudioQuality()) return "";
+
+        // A transcode with no bitrate ceiling has a null bitrate, which used to blank the badge.
+        boolean hasBitrate = child.getBitrate() != null;
+        boolean hasSuffix = child.getSuffix() != null && !child.getSuffix().isEmpty();
+        if (!hasBitrate && !hasSuffix) return "";
+
+        String detail = child.getBitDepth() != null && child.getBitDepth() != 0
+                ? child.getBitDepth() + "/" + (child.getSamplingRate() != null ? child.getSamplingRate() / 1000 : "")
+                : (child.getSamplingRate() != null
+                ? new DecimalFormat("0.#").format(child.getSamplingRate() / 1000.0) + "kHz"
+                : "");
+
+        if (hasSuffix) {
+            detail = detail.isEmpty() ? child.getSuffix() : detail + " " + child.getSuffix();
+        }
 
         return "•" +
                 " " +
-                child.getBitrate() +
-                "kbps" +
-                " • " +
-                (child.getBitDepth() != null && child.getBitDepth() != 0
-                        ? child.getBitDepth() + "/" + (child.getSamplingRate() != null ? child.getSamplingRate() / 1000 : "")
-                        : (child.getSamplingRate() != null
-                        ? new DecimalFormat("0.#").format(child.getSamplingRate() / 1000.0) + "kHz"
-                        : "")) +
-                " " +
-                child.getSuffix();
+                (hasBitrate ? child.getBitrate() + "kbps" : "") +
+                (hasBitrate && !detail.isEmpty() ? " • " : "") +
+                detail;
     }
 
     public static String getReadablePodcastDurationString(long duration) {
@@ -341,6 +349,45 @@ public class MusicUtil {
 
     public static String getTranscodingFormatPreferenceForDownload() {
         return Preferences.getAudioTranscodeFormatTranscodedDownload();
+    }
+
+    // A client transcode leaves the row's inherited Child metadata describing the source rather
+    // than the file on disk. Call on any Download row before it is inserted. See issue 502.
+    public static void applyTranscodedDownloadMetadata(Download download) {
+        if (download == null) return;
+        if (!Preferences.preferTranscodedDownload() || Preferences.isServerPrioritizedInTranscodedDownload())
+            return;
+
+        String format = getTranscodingFormatPreferenceForDownload();
+        if (format == null || format.equals("raw")) return;
+
+        download.setSuffix(format);
+        // Moves with the suffix, since the track info dialog reads it.
+        String mime = audioMimeTypeForFormat(format);
+        if (mime != null) download.setContentType(mime);
+        download.setSamplingRate(null);
+        download.setBitDepth(null);
+
+        // maxBitRate is the configured ceiling; "0" means no limit, so the real bitrate is unknown.
+        Integer bitrate = null;
+        try {
+            int parsed = Integer.parseInt(getBitratePreferenceForDownload());
+            if (parsed > 0) bitrate = parsed;
+        } catch (NumberFormatException ignored) {
+        }
+        download.setBitrate(bitrate);
+    }
+
+    // Inverse of audioFormatLabel. Null for an unrecognized format, so callers keep what they have.
+    public static String audioMimeTypeForFormat(String format) {
+        if (format == null) return null;
+        switch (format.toLowerCase()) {
+            case "opus": return "audio/opus";
+            case "aac": return "audio/aac";
+            case "mp3": return "audio/mpeg";
+            case "flac": return "audio/flac";
+            default: return null;
+        }
     }
 
     // Maps a Media3 sample MIME type (e.g. "audio/flac") to a short, user-facing format


### PR DESCRIPTION
Rebased onto `development` at `32cab905`.

### What

When download transcoding is on, the file written to disk is a transcode, but the Download row copies the server's original Child metadata verbatim. The audio quality badge therefore shows the source details, for example flac at a lossless bitrate, for a file that is actually opus at 128, even offline. When no bitrate ceiling is set the badge vanished entirely instead of showing the format it did know.

This stores the transcode target on the download row, so the badge and the recorded content type describe the file that actually exists.

### Mechanism

New `MusicUtil.applyTranscodedDownloadMetadata(download)`. When a client transcode is active (transcoded download on, server not prioritized, format is not raw) it overwrites the row with the transcode target:

* `suffix` becomes the transcode format.
* `contentType` becomes the matching mime type.
* `bitrate` becomes the configured ceiling, and is left unknown when the ceiling is 0, which means unlimited.
* `samplingRate` and `bitDepth` are cleared, since the lossless source values no longer describe a lossy transcode.

Two places build a Download row for a download that may be transcoded, so the helper is called at both, before the row is inserted:

* `DownloaderManager.download(MediaItem, Download)`. Every download entry point in the UI reaches this through `DownloadUtil.getDownloadTracker`, and the List overload delegates to it one item at a time, so a single call covers all of them.
* `ExternalAudioWriter`, which builds its own row on the path that writes into a folder the user picked.

`contentType` has to move with the suffix rather than being left behind, because `MappingUtil` carries it into the MediaItem extras and `TrackInfoDialog` displays it, so correcting only the suffix would leave the dialog reporting the source mime for a transcoded file. The new `MusicUtil.audioMimeTypeForFormat(format)` is the exact inverse of the existing `audioFormatLabel(mimeType)` and sits beside it. It returns null for a format it does not recognise, so an unknown value leaves the existing content type untouched rather than writing a guess.

A transcode with an unlimited bitrate ceiling has an unknown (null) bitrate, so `getReadableAudioQualityString` previously returned an empty string and hid even the format it had just been given. It now suppresses the badge only when there is neither a bitrate nor a format suffix. Clearing sampling rate and bit depth also empties the middle of the badge, which used to emit a stray separator. The segments are now joined only when they carry a value, so the common case, a bitrate and a sampling rate together, renders exactly as before.

### Blast radius

`contentType` on a Download row reaches one user facing surface, the track info dialog, which will now report `audio/opus` instead of `audio/flac` for a transcoded download. That is the same correction the badge makes, on a second surface. Nothing selects a decoder or builds a server request from this field, so a changed content type cannot affect playback.

`suffix` is read by the badge, and in `ExternalAudioWriter` as the final fallback for the exported file extension. That fallback only runs when the served content type yields no extension and the source has no usable name, and it reads the source Child, not the Download row this change corrects, which is a separate object built after the file has already been named. The exported filename is therefore unchanged by this PR.

### Scope

This covers the audio quality badge in list and detail views, and the stored content type. Both read from the stored download metadata.

The exported filename is already derived from the served `Content-Type` in `ExternalAudioWriter`, which is a better source than the stored suffix, since it reflects what the server actually sent rather than what the client asked for. Nothing is needed here for it.

It does not change the format chip on the now playing screen for a played local file. That surface depends on the player format work already merged for issue 579.

One limitation: the stored bitrate is the configured ceiling, not the exact encoded bitrate, because the true bitrate of the transcoded file is not knowable without probing the output. For an unlimited ceiling the bitrate is left unknown rather than guessed.

### How to reproduce and verify

Any Subsonic or OpenSubsonic server that can transcode.

1. Settings: turn on show audio quality.
2. Settings: turn on transcoded download, choose a lossy format (opus) and a bitrate (128), and leave server prioritized off so the client drives the transcode.
3. Download a lossless track (a flac).
4. Read the badge on the Download tab, offline as well, and open the track info dialog.

Before: the badge reads the source, for example 5558kbps flac, and the dialog reports the source mime.

After: the badge reads 128kbps opus, and the dialog reports `audio/opus`.

Validated on an Android 15 emulator against Navidrome:

* Source reported by the server: flac, 5558 kbps, 192 kHz, 24 bit.
* After a client opus 128 download, the stored row read `suffix=opus`, `bitrate=128`, `content_type=audio/opus`, with sampling rate and bit depth cleared.
* The badge read 128kbps opus, offline.
* Both download paths were exercised, and each wrote the same 4.1 MB file against 156 MB for the lossless source, confirming the bytes are the transcode and not a renamed original.

Fixes #502
