### PR TITLE
Download notification (#62, #755, #902, #345)

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/DownloadProgressState.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/DownloadProgressState.java
@@ -3,6 +3,7 @@ package com.cappielloantonio.tempo.service;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.content.Context;
+import android.os.SystemClock;
 
 import androidx.annotation.GuardedBy;
 import androidx.core.app.NotificationCompat;
@@ -11,6 +12,7 @@ import androidx.media3.common.util.UnstableApi;
 import com.cappielloantonio.tempo.R;
 import com.cappielloantonio.tempo.util.DownloadUtil;
 
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -35,6 +37,11 @@ public final class DownloadProgressState {
     @GuardedBy("lock") private int failedCount = 0;
     @GuardedBy("lock") private int skippedCount = 0;
 
+    @GuardedBy("lock") private long batchStartTimeMs = 0;
+    @GuardedBy("lock") private long lastBytesTotal = 0;
+    @GuardedBy("lock") private long lastSampleMs = 0;
+    @GuardedBy("lock") private float currentSpeedBytesPerSec = 0f;
+
     private DownloadProgressState() {}
 
     public static DownloadProgressState getInstance() {
@@ -55,6 +62,9 @@ public final class DownloadProgressState {
     public void onEnqueue(Context context) {
         synchronized (lock) {
             enqueuedCount++;
+            if (batchStartTimeMs == 0) {
+                batchStartTimeMs = SystemClock.elapsedRealtime();
+            }
             postProgressNotification(context.getApplicationContext());
         }
     }
@@ -89,6 +99,23 @@ public final class DownloadProgressState {
         }
     }
 
+    /**
+     * Called periodically during an active download to report byte progress.
+     * Updates speed and refreshes the progress notification (throttled internally).
+     */
+    public void reportBytesProgress(Context context, long bytesDownloadedSoFar) {
+        synchronized (lock) {
+            long now = SystemClock.elapsedRealtime();
+            long elapsed = now - lastSampleMs;
+            if (elapsed > 500 && lastSampleMs > 0) {
+                currentSpeedBytesPerSec = (bytesDownloadedSoFar - lastBytesTotal) * 1000f / elapsed;
+            }
+            lastBytesTotal = bytesDownloadedSoFar;
+            lastSampleMs = now;
+            postProgressNotification(context.getApplicationContext());
+        }
+    }
+
     @GuardedBy("lock")
     private void checkBatchDone(Context context) {
         int doneCount = completedCount + failedCount + skippedCount;
@@ -109,6 +136,9 @@ public final class DownloadProgressState {
         String contentText;
         if (inFlight > 0) {
             contentText = "Downloading " + doneCount + " of " + total;
+            if (currentSpeedBytesPerSec > 0f) {
+                contentText += " • " + formatSpeed(currentSpeedBytesPerSec);
+            }
         } else {
             contentText = "Processing…";
         }
@@ -175,5 +205,19 @@ public final class DownloadProgressState {
         completedCount = 0;
         failedCount = 0;
         skippedCount = 0;
+        batchStartTimeMs = 0;
+        lastBytesTotal = 0;
+        lastSampleMs = 0;
+        currentSpeedBytesPerSec = 0f;
+    }
+
+    private static String formatSpeed(float bytesPerSec) {
+        if (bytesPerSec >= 1_000_000f) {
+            return String.format(Locale.US, "%.1f MB/s", bytesPerSec / 1_000_000f);
+        } else if (bytesPerSec >= 1_000f) {
+            return String.format(Locale.US, "%.0f KB/s", bytesPerSec / 1_000f);
+        } else {
+            return String.format(Locale.US, "%.0f B/s", bytesPerSec);
+        }
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/service/DownloadProgressState.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/DownloadProgressState.java
@@ -24,7 +24,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @UnstableApi
 public final class DownloadProgressState {
 
-    // Fixed notification IDs — never conflict with Path A IDs (1, 2) or unavailable (1011)
+    // Fixed notification IDs — Path A uses (1, 2), ExternalAudioWriter errors use (1009, 1010)
     public static final int EXTERNAL_PROGRESS_NOTIFICATION_ID = 1012;
     public static final int EXTERNAL_COMPLETE_NOTIFICATION_ID = 1013;
 

--- a/app/src/main/java/com/cappielloantonio/tempo/service/DownloadProgressState.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/DownloadProgressState.java
@@ -42,6 +42,8 @@ public final class DownloadProgressState {
     @GuardedBy("lock") private long lastSampleMs = 0;
     @GuardedBy("lock") private float currentSpeedBytesPerSec = 0f;
 
+    private volatile String currentTrackTitle = null;
+
     private DownloadProgressState() {}
 
     public static DownloadProgressState getInstance() {
@@ -67,6 +69,10 @@ public final class DownloadProgressState {
             }
             postProgressNotification(context.getApplicationContext());
         }
+    }
+
+    public void setCurrentTrackTitle(String title) {
+        this.currentTrackTitle = title;
     }
 
     /**
@@ -133,9 +139,13 @@ public final class DownloadProgressState {
         int total = enqueuedCount;
         int inFlight = total - doneCount;
 
+        String contentTitle = currentTrackTitle != null
+                ? "Downloading " + currentTrackTitle
+                : "Downloading";
+
         String contentText;
         if (inFlight > 0) {
-            contentText = "Downloading " + doneCount + " of " + total;
+            contentText = doneCount + " of " + total;
             if (currentSpeedBytesPerSec > 0f) {
                 contentText += " • " + formatSpeed(currentSpeedBytesPerSec);
             }
@@ -144,7 +154,7 @@ public final class DownloadProgressState {
         }
 
         Notification notification = new NotificationCompat.Builder(context, DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID)
-                .setContentTitle("Downloading")
+                .setContentTitle(contentTitle)
                 .setContentText(contentText)
                 .setSmallIcon(R.drawable.ic_download)
                 .setProgress(total, doneCount, false)
@@ -209,6 +219,7 @@ public final class DownloadProgressState {
         lastBytesTotal = 0;
         lastSampleMs = 0;
         currentSpeedBytesPerSec = 0f;
+        currentTrackTitle = null;
     }
 
     private static String formatSpeed(float bytesPerSec) {

--- a/app/src/main/java/com/cappielloantonio/tempo/service/DownloadProgressState.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/DownloadProgressState.java
@@ -75,7 +75,7 @@ public final class DownloadProgressState {
         this.currentTrackTitle = title;
         synchronized (lock) {
             lastBytesTotal = 0;
-            lastSampleMs = 0;
+            lastSampleMs = SystemClock.elapsedRealtime();
             currentSpeedBytesPerSec = 0f;
         }
     }
@@ -118,7 +118,7 @@ public final class DownloadProgressState {
         synchronized (lock) {
             long now = SystemClock.elapsedRealtime();
             long elapsed = now - lastSampleMs;
-            if (elapsed > 500 && lastSampleMs > 0) {
+            if (elapsed >= 500) {
                 currentSpeedBytesPerSec = (bytesDownloadedSoFar - lastBytesTotal) * 1000f / elapsed;
             }
             lastBytesTotal = bytesDownloadedSoFar;
@@ -145,17 +145,17 @@ public final class DownloadProgressState {
         int inFlight = total - doneCount;
 
         String contentTitle = currentTrackTitle != null
-                ? "Downloading " + currentTrackTitle
-                : "Downloading";
+                ? context.getString(R.string.notification_downloading_title, currentTrackTitle)
+                : context.getString(R.string.notification_downloading);
 
         String contentText;
-        if (inFlight > 0) {
-            contentText = doneCount + " of " + total;
-            if (currentSpeedBytesPerSec > 0f) {
-                contentText += " • " + formatSpeed(currentSpeedBytesPerSec);
-            }
+        if (total > 0) {
+            contentText = context.getString(R.string.notification_download_progress_format, doneCount, total);
+            contentText += currentSpeedBytesPerSec > 0f
+                    ? " • " + formatSpeed(currentSpeedBytesPerSec)
+                    : " • ? KB/s";
         } else {
-            contentText = "Processing…";
+            contentText = context.getString(R.string.notification_processing);
         }
 
         Notification notification = new NotificationCompat.Builder(context, DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID)
@@ -185,14 +185,16 @@ public final class DownloadProgressState {
         StringBuilder detail = new StringBuilder();
 
         if (completedCount > 0 && failedCount == 0) {
-            title.append("Downloads complete");
-            detail.append(completedCount).append(completedCount == 1 ? " track saved" : " tracks saved");
+            title.append(context.getString(R.string.notification_downloads_complete));
+            detail.append(context.getResources().getQuantityString(
+                    R.plurals.notification_tracks_saved, completedCount, completedCount));
         } else if (completedCount > 0) {
-            title.append("Downloads complete");
-            detail.append(completedCount).append(" saved, ").append(failedCount).append(" failed");
+            title.append(context.getString(R.string.notification_downloads_complete));
+            detail.append(context.getString(R.string.notification_download_mixed_saved, completedCount, failedCount));
         } else if (failedCount > 0) {
-            title.append("Downloads failed");
-            detail.append(failedCount).append(failedCount == 1 ? " track failed" : " tracks failed");
+            title.append(context.getString(R.string.notification_download_failed));
+            detail.append(context.getResources().getQuantityString(
+                    R.plurals.notification_tracks_failed, failedCount, failedCount));
         } else {
             // Only skipped — silently dismiss the progress notification, no final notification needed
             return;
@@ -222,7 +224,7 @@ public final class DownloadProgressState {
         skippedCount = 0;
         batchStartTimeMs = 0;
         lastBytesTotal = 0;
-        lastSampleMs = 0;
+        lastSampleMs = SystemClock.elapsedRealtime();
         currentSpeedBytesPerSec = 0f;
         currentTrackTitle = null;
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/service/DownloadProgressState.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/DownloadProgressState.java
@@ -73,6 +73,11 @@ public final class DownloadProgressState {
 
     public void setCurrentTrackTitle(String title) {
         this.currentTrackTitle = title;
+        synchronized (lock) {
+            lastBytesTotal = 0;
+            lastSampleMs = 0;
+            currentSpeedBytesPerSec = 0f;
+        }
     }
 
     /**

--- a/app/src/main/java/com/cappielloantonio/tempo/service/DownloadProgressState.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/DownloadProgressState.java
@@ -1,0 +1,179 @@
+package com.cappielloantonio.tempo.service;
+
+import android.app.Notification;
+import android.app.NotificationManager;
+import android.content.Context;
+
+import androidx.annotation.GuardedBy;
+import androidx.core.app.NotificationCompat;
+import androidx.media3.common.util.UnstableApi;
+
+import com.cappielloantonio.tempo.R;
+import com.cappielloantonio.tempo.util.DownloadUtil;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Singleton that tracks external (Path B / ExternalAudioWriter) download progress
+ * and maintains a single consolidated progress notification.
+ *
+ * Thread-safe: all public methods may be called from any thread.
+ */
+@UnstableApi
+public final class DownloadProgressState {
+
+    // Fixed notification IDs — never conflict with Path A IDs (1, 2) or unavailable (1011)
+    public static final int EXTERNAL_PROGRESS_NOTIFICATION_ID = 1012;
+    public static final int EXTERNAL_COMPLETE_NOTIFICATION_ID = 1013;
+
+    private static volatile DownloadProgressState instance;
+
+    private final Object lock = new Object();
+
+    @GuardedBy("lock") private int enqueuedCount = 0;
+    @GuardedBy("lock") private int completedCount = 0;
+    @GuardedBy("lock") private int failedCount = 0;
+    @GuardedBy("lock") private int skippedCount = 0;
+
+    private DownloadProgressState() {}
+
+    public static DownloadProgressState getInstance() {
+        if (instance == null) {
+            synchronized (DownloadProgressState.class) {
+                if (instance == null) {
+                    instance = new DownloadProgressState();
+                }
+            }
+        }
+        return instance;
+    }
+
+    /**
+     * Called once per track at the moment it is enqueued into the executor.
+     * This increments the total expected count so the "X of N" is accurate.
+     */
+    public void onEnqueue(Context context) {
+        synchronized (lock) {
+            enqueuedCount++;
+            postProgressNotification(context.getApplicationContext());
+        }
+    }
+
+    /**
+     * Called when a track finishes downloading successfully.
+     */
+    public void onSuccess(Context context) {
+        synchronized (lock) {
+            completedCount++;
+            checkBatchDone(context.getApplicationContext());
+        }
+    }
+
+    /**
+     * Called when a track was already present — counts as a quiet skip, not an error.
+     */
+    public void onSkipped(Context context) {
+        synchronized (lock) {
+            skippedCount++;
+            checkBatchDone(context.getApplicationContext());
+        }
+    }
+
+    /**
+     * Called when a track fails to download.
+     */
+    public void onFailed(Context context) {
+        synchronized (lock) {
+            failedCount++;
+            checkBatchDone(context.getApplicationContext());
+        }
+    }
+
+    @GuardedBy("lock")
+    private void checkBatchDone(Context context) {
+        int doneCount = completedCount + failedCount + skippedCount;
+        if (doneCount >= enqueuedCount && enqueuedCount > 0) {
+            postFinalNotification(context);
+            reset();
+        } else {
+            postProgressNotification(context);
+        }
+    }
+
+    @GuardedBy("lock")
+    private void postProgressNotification(Context context) {
+        int doneCount = completedCount + failedCount + skippedCount;
+        int total = enqueuedCount;
+        int inFlight = total - doneCount;
+
+        String contentText;
+        if (inFlight > 0) {
+            contentText = "Downloading " + doneCount + " of " + total;
+        } else {
+            contentText = "Processing…";
+        }
+
+        Notification notification = new NotificationCompat.Builder(context, DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID)
+                .setContentTitle("Downloading")
+                .setContentText(contentText)
+                .setSmallIcon(R.drawable.ic_download)
+                .setProgress(total, doneCount, false)
+                .setOngoing(true)
+                .setSilent(true)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setOnlyAlertOnce(true)
+                .build();
+
+        NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+        nm.notify(EXTERNAL_PROGRESS_NOTIFICATION_ID, notification);
+    }
+
+    @GuardedBy("lock")
+    private void postFinalNotification(Context context) {
+        NotificationManager nm = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
+
+        // Cancel the progress notification
+        nm.cancel(EXTERNAL_PROGRESS_NOTIFICATION_ID);
+
+        // Build final summary
+        StringBuilder title = new StringBuilder();
+        StringBuilder detail = new StringBuilder();
+
+        if (completedCount > 0 && failedCount == 0) {
+            title.append("Downloads complete");
+            detail.append(completedCount).append(completedCount == 1 ? " track saved" : " tracks saved");
+        } else if (completedCount > 0) {
+            title.append("Downloads complete");
+            detail.append(completedCount).append(" saved, ").append(failedCount).append(" failed");
+        } else if (failedCount > 0) {
+            title.append("Downloads failed");
+            detail.append(failedCount).append(failedCount == 1 ? " track failed" : " tracks failed");
+        } else {
+            // Only skipped — silently dismiss the progress notification, no final notification needed
+            return;
+        }
+
+        Notification notification = new NotificationCompat.Builder(context, DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID)
+                .setContentTitle(title.toString())
+                .setContentText(detail.toString())
+                .setSmallIcon(failedCount > 0 && completedCount == 0
+                        ? R.drawable.ic_error
+                        : R.drawable.ic_check_circle)
+                .setOngoing(false)
+                .setAutoCancel(false)   // stays until user swipes it away
+                .setSilent(true)
+                .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                .setOnlyAlertOnce(true)
+                .build();
+
+        nm.notify(EXTERNAL_COMPLETE_NOTIFICATION_ID, notification);
+    }
+
+    @GuardedBy("lock")
+    private void reset() {
+        enqueuedCount = 0;
+        completedCount = 0;
+        failedCount = 0;
+        skippedCount = 0;
+    }
+}

--- a/app/src/main/java/com/cappielloantonio/tempo/service/DownloaderService.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/DownloaderService.java
@@ -105,23 +105,18 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
         }
 
         String contentTitle = currentTrack != null
-                ? "Downloading " + currentTrack
-                : "Downloading";
-
-        int inProgress = total - completed;
+                ? getString(R.string.notification_downloading_title, currentTrack)
+                : getString(R.string.notification_downloading);
 
         String contentText;
-        if (total <= 1) {
-            contentText = currentSpeedBytesPerSec > 0f
-                    ? formatSpeed(currentSpeedBytesPerSec)
-                    : "Downloading…";
-        } else if (inProgress > 0) {
-            contentText = (completed + 1) + " of " + total;
-            if (currentSpeedBytesPerSec > 0f) {
-                contentText += " • " + formatSpeed(currentSpeedBytesPerSec);
-            }
+        if (total > 0) {
+            int currentIndex = Math.min(completed + 1, total);
+            contentText = getString(R.string.notification_download_progress_format, currentIndex, total);
+            contentText += currentSpeedBytesPerSec > 0f
+                    ? " • " + formatSpeed(currentSpeedBytesPerSec)
+                    : " • ? KB/s";
         } else {
-            contentText = "Finalizing…";
+            contentText = getString(R.string.notification_downloading_progress);
         }
 
         return new NotificationCompat.Builder(this, DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID)
@@ -182,6 +177,7 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
 
                 case Download.STATE_QUEUED:
                     updateMaxTotal(downloadManager);
+                    updateSpeed(downloadManager);
                     primeTrackTitle(download);
                     return;
 
@@ -269,6 +265,15 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
             int currentSize = downloadManager.getCurrentDownloads().size();
             if (currentSize > DownloaderService.batchMaxTotal) {
                 DownloaderService.batchMaxTotal = currentSize;
+            } else if (DownloaderService.batchMaxTotal > 0
+                    && DownloaderService.batchCompletedCount >= DownloaderService.batchMaxTotal
+                    && currentSize == 1) {
+                // New batch detected: previous batch's items all resolved but reset didn't fire
+                DownloaderService.batchMaxTotal = 0;
+                DownloaderService.batchCompletedCount = 0;
+                completedCount.set(0);
+                failedCount.set(0);
+                DownloaderService.trackTitlesCache.clear();
             }
         }
 
@@ -297,19 +302,19 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
             Notification notification;
 
             if (done > 0 && failed == 0) {
-                String msg = done == 1
-                        ? "1 track downloaded"
-                        : done + " tracks downloaded";
+                String msg = context.getResources().getQuantityString(
+                        R.plurals.notification_tracks_downloaded, done, done);
                 notification = buildSummaryNotification(
-                        "Downloads complete", msg, R.drawable.ic_check_circle);
+                        context.getString(R.string.notification_downloads_complete), msg, R.drawable.ic_check_circle);
             } else if (done > 0) {
-                String msg = done + " downloaded, " + failed + " failed";
+                String msg = context.getString(R.string.notification_download_mixed_result, done, failed);
                 notification = buildSummaryNotification(
-                        "Downloads complete", msg, R.drawable.ic_check_circle);
+                        context.getString(R.string.notification_downloads_complete), msg, R.drawable.ic_check_circle);
             } else {
-                String msg = failed == 1 ? "1 track failed" : failed + " tracks failed";
+                String msg = context.getResources().getQuantityString(
+                        R.plurals.notification_tracks_failed, failed, failed);
                 notification = buildSummaryNotification(
-                        "Download failed", msg, R.drawable.ic_error);
+                        context.getString(R.string.notification_download_failed), msg, R.drawable.ic_error);
             }
 
             NotificationManager nm = (NotificationManager)

--- a/app/src/main/java/com/cappielloantonio/tempo/service/DownloaderService.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/DownloaderService.java
@@ -198,6 +198,7 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
 
                 case Download.STATE_FAILED:
                     failedCount.incrementAndGet();
+                    DownloaderService.batchCompletedCount = completedCount.get() + failedCount.get();
                     break;
 
                 case Download.STATE_REMOVING:

--- a/app/src/main/java/com/cappielloantonio/tempo/service/DownloaderService.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/DownloaderService.java
@@ -20,6 +20,7 @@ import com.cappielloantonio.tempo.util.DownloadUtil;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @UnstableApi
@@ -35,6 +36,13 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
 
     // Shared speed tracking — updated by TerminalStateNotificationHelper, read by getForegroundNotification
     static volatile float currentSpeedBytesPerSec = 0f;
+
+    // Stable batch counters — updated by TerminalStateNotificationHelper, read by getForegroundNotification
+    static volatile int batchMaxTotal = 0;
+    static volatile int batchCompletedCount = 0;
+
+    // Cache: mediaId → track title, populated lazily in TerminalStateNotificationHelper
+    private static final ConcurrentHashMap<String, String> trackTitlesCache = new ConcurrentHashMap<>();
 
     public DownloaderService() {
         super(
@@ -61,11 +69,14 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
     }
 
     /**
-     * Overrides the foreground (progress) notification to show "Downloading X of N".
+     * Overrides the foreground (progress) notification to show "Downloading TrackName" with
+     * "X of N • speed" and stable batch counters that don't shrink as Media3 removes completed
+     * downloads from its active list (see bug #11).
      *
      * <p>Called by Media3 on the service thread each time the download queue changes.
-     * {@code downloads} contains every currently queued/downloading/completed entry
-     * that is still active in this session.
+     * {@code downloads} is the current Media3 snapshot; we prefer static batch counters
+     * ({@link #batchMaxTotal}, {@link #batchCompletedCount}) maintained by
+     * {@link TerminalStateNotificationHelper} for accurate "X of N" across removal events.
      */
     @NonNull
     @Override
@@ -73,32 +84,48 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
             @NonNull List<Download> downloads,
             @Requirements.RequirementFlags int notMetRequirements) {
 
-        int total = downloads.size();
-        int completed = 0;
-        long totalBytes = 0;
+        int total = Math.max(batchMaxTotal, downloads.size());
+        int completed = batchCompletedCount;
 
+        // Find the currently downloading (or next queued) track title from cache
+        String currentTrack = null;
         for (Download d : downloads) {
-            if (d.state == Download.STATE_COMPLETED) completed++;
-            totalBytes += d.getBytesDownloaded();
+            if (d.state == Download.STATE_DOWNLOADING) {
+                currentTrack = trackTitlesCache.get(d.request.id);
+                break;
+            }
         }
+        if (currentTrack == null) {
+            for (Download d : downloads) {
+                if (d.state != Download.STATE_COMPLETED) {
+                    currentTrack = trackTitlesCache.get(d.request.id);
+                    if (currentTrack != null) break;
+                }
+            }
+        }
+
+        String contentTitle = currentTrack != null
+                ? "Downloading " + currentTrack
+                : "Downloading";
 
         int inProgress = total - completed;
 
-        // Build the content text: "Downloading 3 of 10" or speed variant
         String contentText;
         if (total <= 1) {
-            // Single item — show generic label
-            contentText = "Downloading…";
+            contentText = currentSpeedBytesPerSec > 0f
+                    ? formatSpeed(currentSpeedBytesPerSec)
+                    : "Downloading…";
+        } else if (inProgress > 0) {
+            contentText = (completed + 1) + " of " + total;
+            if (currentSpeedBytesPerSec > 0f) {
+                contentText += " • " + formatSpeed(currentSpeedBytesPerSec);
+            }
         } else {
-            contentText = "Downloading " + (completed + 1) + " of " + total;
-        }
-
-        if (currentSpeedBytesPerSec > 0f) {
-            contentText += " • " + formatSpeed(currentSpeedBytesPerSec);
+            contentText = "Finalizing…";
         }
 
         return new NotificationCompat.Builder(this, DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID)
-                .setContentTitle("Downloading")
+                .setContentTitle(contentTitle)
                 .setContentText(contentText)
                 .setSmallIcon(R.drawable.ic_download)
                 .setProgress(total, completed, /* indeterminate= */ false)
@@ -148,10 +175,16 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
 
             switch (download.state) {
                 case Download.STATE_DOWNLOADING:
+                    updateMaxTotal(downloadManager);
                     updateSpeed(downloadManager);
+                    primeTrackTitle(download);
                     return;
 
                 case Download.STATE_QUEUED:
+                    updateMaxTotal(downloadManager);
+                    primeTrackTitle(download);
+                    return;
+
                 case Download.STATE_RESTARTING:
                 case Download.STATE_STOPPED:
                     // Not terminal — nothing to do
@@ -159,6 +192,7 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
 
                 case Download.STATE_COMPLETED:
                     completedCount.incrementAndGet();
+                    DownloaderService.batchCompletedCount = completedCount.get();
                     DownloaderManager.updateRequestDownload(download);
                     break;
 
@@ -188,6 +222,9 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
                 failedCount.set(0);
                 speedBytesPerSec = 0f;
                 DownloaderService.currentSpeedBytesPerSec = 0f;
+                DownloaderService.batchMaxTotal = 0;
+                DownloaderService.batchCompletedCount = 0;
+                DownloaderService.trackTitlesCache.clear();
                 lastBytesTotal = 0;
                 lastSampleMs = 0;
             }
@@ -220,6 +257,36 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
             }
 
             DownloaderService.currentSpeedBytesPerSec = speedBytesPerSec;
+        }
+
+        /**
+         * Updates the stable {@link DownloaderService#batchMaxTotal} so that
+         * {@link #getForegroundNotification(List, int)} shows the correct total
+         * even after Media3 removes completed items from its active list.
+         */
+        private void updateMaxTotal(@NonNull DownloadManager downloadManager) {
+            int currentSize = downloadManager.getCurrentDownloads().size();
+            if (currentSize > DownloaderService.batchMaxTotal) {
+                DownloaderService.batchMaxTotal = currentSize;
+            }
+        }
+
+        /**
+         * Resolves a Media3 download ID to a human-readable track title and caches
+         * it in {@link DownloaderService#trackTitlesCache} so the progress notification
+         * can display which track is currently being downloaded
+         *
+         * <p>Called on the Media3 listener thread (background), so blocking DB lookups
+         * via {@link DownloaderManager#getDownloadNotificationMessage} are acceptable.
+         */
+        private void primeTrackTitle(Download download) {
+            String id = download.request.id;
+            if (!DownloaderService.trackTitlesCache.containsKey(id)) {
+                String title = DownloaderManager.getDownloadNotificationMessage(id);
+                if (title != null) {
+                    DownloaderService.trackTitlesCache.put(id, title);
+                }
+            }
         }
 
         private void postFinalNotification() {

--- a/app/src/main/java/com/cappielloantonio/tempo/service/DownloaderService.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/DownloaderService.java
@@ -1,15 +1,16 @@
 package com.cappielloantonio.tempo.service;
 
 import android.app.Notification;
+import android.app.NotificationManager;
 import android.content.Context;
+import android.os.SystemClock;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-import androidx.media3.common.util.NotificationUtil;
+import androidx.core.app.NotificationCompat;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.exoplayer.offline.Download;
 import androidx.media3.exoplayer.offline.DownloadManager;
-import androidx.media3.exoplayer.offline.DownloadNotificationHelper;
 import androidx.media3.exoplayer.scheduler.PlatformScheduler;
 import androidx.media3.exoplayer.scheduler.Requirements;
 import androidx.media3.exoplayer.scheduler.Scheduler;
@@ -18,23 +19,34 @@ import com.cappielloantonio.tempo.R;
 import com.cappielloantonio.tempo.util.DownloadUtil;
 
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 
 @UnstableApi
 public class DownloaderService extends androidx.media3.exoplayer.offline.DownloadService {
 
     private static final int JOB_ID = 1;
+
+    // Foreground service notification — managed by Media3, must stay ID 1
     private static final int FOREGROUND_NOTIFICATION_ID = 1;
 
+    // Persistent completion/failure notification — fixed ID so updates replace the same one
+    static final int TERMINAL_NOTIFICATION_ID = 2;
+
     public DownloaderService() {
-        super(FOREGROUND_NOTIFICATION_ID, DEFAULT_FOREGROUND_NOTIFICATION_UPDATE_INTERVAL, DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID, R.string.exo_download_notification_channel_name, 0);
+        super(
+                FOREGROUND_NOTIFICATION_ID,
+                DEFAULT_FOREGROUND_NOTIFICATION_UPDATE_INTERVAL,
+                DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID,
+                R.string.exo_download_notification_channel_name,
+                0
+        );
     }
 
     @NonNull
     @Override
     protected DownloadManager getDownloadManager() {
         DownloadManager downloadManager = DownloadUtil.getDownloadManager(this);
-        DownloadNotificationHelper downloadNotificationHelper = DownloadUtil.getDownloadNotificationHelper(this);
-        downloadManager.addListener(new TerminalStateNotificationHelper(this, downloadNotificationHelper, FOREGROUND_NOTIFICATION_ID + 1));
+        downloadManager.addListener(new TerminalStateNotificationHelper(this));
         return downloadManager;
     }
 
@@ -44,72 +56,190 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
         return new PlatformScheduler(this, JOB_ID);
     }
 
+    /**
+     * Overrides the foreground (progress) notification to show "Downloading X of N".
+     *
+     * <p>Called by Media3 on the service thread each time the download queue changes.
+     * {@code downloads} contains every currently queued/downloading/completed entry
+     * that is still active in this session.
+     */
     @NonNull
     @Override
-    protected Notification getForegroundNotification(@NonNull List<Download> downloads, @Requirements.RequirementFlags int notMetRequirements) {
-        return DownloadUtil.getDownloadNotificationHelper(this).buildProgressNotification(this, R.drawable.ic_download, null, null, downloads, notMetRequirements);
+    protected Notification getForegroundNotification(
+            @NonNull List<Download> downloads,
+            @Requirements.RequirementFlags int notMetRequirements) {
+
+        int total = downloads.size();
+        int completed = 0;
+        long totalBytes = 0;
+
+        for (Download d : downloads) {
+            if (d.state == Download.STATE_COMPLETED) completed++;
+            totalBytes += d.getBytesDownloaded();
+        }
+
+        int inProgress = total - completed;
+
+        // Build the content text: "Downloading 3 of 10" or speed variant
+        String contentText;
+        if (total <= 1) {
+            // Single item — show generic label
+            contentText = "Downloading…";
+        } else {
+            contentText = "Downloading " + (completed + 1) + " of " + total;
+        }
+
+        return new NotificationCompat.Builder(this, DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID)
+                .setContentTitle("Downloading")
+                .setContentText(contentText)
+                .setSmallIcon(R.drawable.ic_download)
+                .setProgress(total, completed, /* indeterminate= */ false)
+                .setOngoing(true)
+                .setSilent(true)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setOnlyAlertOnce(true)
+                .build();
     }
 
+    // -------------------------------------------------------------------------
+    // Terminal-state listener — consolidates completed/failed into ONE notification
+    // -------------------------------------------------------------------------
+
     private static final class TerminalStateNotificationHelper implements DownloadManager.Listener {
+
         private final Context context;
-        private final DownloadNotificationHelper notificationHelper;
 
-        private final Notification successfulDownloadGroupNotification;
-        private final Notification failedDownloadGroupNotification;
+        // Counters reset at start of each "batch" (when queue goes from empty → non-empty)
+        private final AtomicInteger completedCount = new AtomicInteger(0);
+        private final AtomicInteger failedCount = new AtomicInteger(0);
 
-        private final int successfulDownloadGroupNotificationId;
-        private final int failedDownloadGroupNotificationId;
+        // Speed tracking
+        private long lastBytesTotal = 0;
+        private long lastSampleMs = 0;
+        private float speedBytesPerSec = 0f;
 
-        private int nextNotificationId;
-
-        public TerminalStateNotificationHelper(Context context, DownloadNotificationHelper notificationHelper, int firstNotificationId) {
+        TerminalStateNotificationHelper(Context context) {
             this.context = context.getApplicationContext();
-            this.notificationHelper = notificationHelper;
-            nextNotificationId = firstNotificationId;
-
-            successfulDownloadGroupNotification = DownloadUtil.buildGroupSummaryNotification(
-                    this.context,
-                    DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID,
-                    DownloadUtil.DOWNLOAD_NOTIFICATION_SUCCESSFUL_GROUP,
-                    R.drawable.ic_check_circle,
-                    "Downloads completed"
-            );
-
-            failedDownloadGroupNotification = DownloadUtil.buildGroupSummaryNotification(
-                    this.context,
-                    DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID,
-                    DownloadUtil.DOWNLOAD_NOTIFICATION_FAILED_GROUP,
-                    R.drawable.ic_error,
-                    "Downloads failed"
-            );
-
-            successfulDownloadGroupNotificationId = nextNotificationId++;
-            failedDownloadGroupNotificationId = nextNotificationId++;
         }
 
         @Override
-        public void onDownloadChanged(@NonNull DownloadManager downloadManager, Download download, @Nullable Exception finalException) {
-            Notification notification;
+        public void onDownloadChanged(
+                @NonNull DownloadManager downloadManager,
+                @NonNull Download download,
+                @Nullable Exception finalException) {
 
-            if (download.state == Download.STATE_COMPLETED) {
-                notification = notificationHelper.buildDownloadCompletedNotification(context, R.drawable.ic_check_circle, null, DownloaderManager.getDownloadNotificationMessage(download.request.id));
-                notification = Notification.Builder.recoverBuilder(context, notification).setGroup(DownloadUtil.DOWNLOAD_NOTIFICATION_SUCCESSFUL_GROUP).build();
-                NotificationUtil.setNotification(this.context, successfulDownloadGroupNotificationId, successfulDownloadGroupNotification);
-                DownloaderManager.updateRequestDownload(download);
-            } else if (download.state == Download.STATE_FAILED) {
-                notification = notificationHelper.buildDownloadFailedNotification(context, R.drawable.ic_error, null, DownloaderManager.getDownloadNotificationMessage(download.request.id));
-                notification = Notification.Builder.recoverBuilder(context, notification).setGroup(DownloadUtil.DOWNLOAD_NOTIFICATION_FAILED_GROUP).build();
-                NotificationUtil.setNotification(this.context, failedDownloadGroupNotificationId, failedDownloadGroupNotification);
-            } else {
-                return;
+            switch (download.state) {
+                case Download.STATE_DOWNLOADING:
+                    updateSpeed(downloadManager);
+                    return;
+
+                case Download.STATE_QUEUED:
+                case Download.STATE_RESTARTING:
+                case Download.STATE_STOPPED:
+                    // Not terminal — nothing to do
+                    return;
+
+                case Download.STATE_COMPLETED:
+                    completedCount.incrementAndGet();
+                    DownloaderManager.updateRequestDownload(download);
+                    break;
+
+                case Download.STATE_FAILED:
+                    failedCount.incrementAndGet();
+                    break;
+
+                case Download.STATE_REMOVING:
+                    // Handled in onDownloadRemoved
+                    return;
+
+                default:
+                    return;
             }
 
-            NotificationUtil.setNotification(context, nextNotificationId++, notification);
+            // After a terminal state, check if the entire queue is done
+            List<Download> currentDownloads = downloadManager.getCurrentDownloads();
+            boolean queueEmpty = currentDownloads.stream().noneMatch(
+                    d -> d.state == Download.STATE_QUEUED
+                            || d.state == Download.STATE_DOWNLOADING
+                            || d.state == Download.STATE_RESTARTING
+            );
+
+            if (queueEmpty) {
+                postFinalNotification();
+                completedCount.set(0);
+                failedCount.set(0);
+                speedBytesPerSec = 0f;
+                lastBytesTotal = 0;
+                lastSampleMs = 0;
+            }
+            // If queue not empty, Media3 will keep calling getForegroundNotification() —
+            // no need to post an intermediate notification here.
         }
 
         @Override
-        public void onDownloadRemoved(@NonNull DownloadManager downloadManager, Download download) {
+        public void onDownloadRemoved(
+                @NonNull DownloadManager downloadManager,
+                @NonNull Download download) {
             DownloaderManager.removeRequestDownload(download);
+        }
+
+        private void updateSpeed(@NonNull DownloadManager downloadManager) {
+            long nowMs = SystemClock.elapsedRealtime();
+            long totalBytes = 0;
+            for (Download d : downloadManager.getCurrentDownloads()) {
+                totalBytes += d.getBytesDownloaded();
+            }
+            if (lastSampleMs > 0) {
+                long elapsed = nowMs - lastSampleMs;
+                if (elapsed > 500) {
+                    speedBytesPerSec = (totalBytes - lastBytesTotal) * 1000f / elapsed;
+                    lastBytesTotal = totalBytes;
+                    lastSampleMs = nowMs;
+                }
+            } else {
+                lastBytesTotal = totalBytes;
+                lastSampleMs = nowMs;
+            }
+        }
+
+        private void postFinalNotification() {
+            int done = completedCount.get();
+            int failed = failedCount.get();
+
+            Notification notification;
+
+            if (done > 0 && failed == 0) {
+                String msg = done == 1
+                        ? "1 track downloaded"
+                        : done + " tracks downloaded";
+                notification = buildSummaryNotification(
+                        "Downloads complete", msg, R.drawable.ic_check_circle);
+            } else if (done > 0) {
+                String msg = done + " downloaded, " + failed + " failed";
+                notification = buildSummaryNotification(
+                        "Downloads complete", msg, R.drawable.ic_check_circle);
+            } else {
+                String msg = failed == 1 ? "1 track failed" : failed + " tracks failed";
+                notification = buildSummaryNotification(
+                        "Download failed", msg, R.drawable.ic_error);
+            }
+
+            NotificationManager nm = (NotificationManager)
+                    context.getSystemService(Context.NOTIFICATION_SERVICE);
+            nm.notify(TERMINAL_NOTIFICATION_ID, notification);
+        }
+
+        private Notification buildSummaryNotification(String title, String text, int iconRes) {
+            return new NotificationCompat.Builder(context, DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID)
+                    .setContentTitle(title)
+                    .setContentText(text)
+                    .setSmallIcon(iconRes)
+                    .setOngoing(false)
+                    .setAutoCancel(false)   // stays until user swipes it
+                    .setSilent(true)
+                    .setPriority(NotificationCompat.PRIORITY_DEFAULT)
+                    .setOnlyAlertOnce(true)
+                    .build();
         }
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/service/DownloaderService.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/DownloaderService.java
@@ -19,6 +19,7 @@ import com.cappielloantonio.tempo.R;
 import com.cappielloantonio.tempo.util.DownloadUtil;
 
 import java.util.List;
+import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 
 @UnstableApi
@@ -31,6 +32,9 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
 
     // Persistent completion/failure notification — fixed ID so updates replace the same one
     static final int TERMINAL_NOTIFICATION_ID = 2;
+
+    // Shared speed tracking — updated by TerminalStateNotificationHelper, read by getForegroundNotification
+    static volatile float currentSpeedBytesPerSec = 0f;
 
     public DownloaderService() {
         super(
@@ -89,6 +93,10 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
             contentText = "Downloading " + (completed + 1) + " of " + total;
         }
 
+        if (currentSpeedBytesPerSec > 0f) {
+            contentText += " • " + formatSpeed(currentSpeedBytesPerSec);
+        }
+
         return new NotificationCompat.Builder(this, DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID)
                 .setContentTitle("Downloading")
                 .setContentText(contentText)
@@ -99,6 +107,16 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
                 .setPriority(NotificationCompat.PRIORITY_LOW)
                 .setOnlyAlertOnce(true)
                 .build();
+    }
+
+    private static String formatSpeed(float bytesPerSec) {
+        if (bytesPerSec >= 1_000_000f) {
+            return String.format(Locale.US, "%.1f MB/s", bytesPerSec / 1_000_000f);
+        } else if (bytesPerSec >= 1_000f) {
+            return String.format(Locale.US, "%.0f KB/s", bytesPerSec / 1_000f);
+        } else {
+            return String.format(Locale.US, "%.0f B/s", bytesPerSec);
+        }
     }
 
     // -------------------------------------------------------------------------
@@ -169,11 +187,11 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
                 completedCount.set(0);
                 failedCount.set(0);
                 speedBytesPerSec = 0f;
+                DownloaderService.currentSpeedBytesPerSec = 0f;
                 lastBytesTotal = 0;
                 lastSampleMs = 0;
             }
-            // If queue not empty, Media3 will keep calling getForegroundNotification() —
-            // no need to post an intermediate notification here.
+
         }
 
         @Override
@@ -200,6 +218,8 @@ public class DownloaderService extends androidx.media3.exoplayer.offline.Downloa
                 lastBytesTotal = totalBytes;
                 lastSampleMs = nowMs;
             }
+
+            DownloaderService.currentSpeedBytesPerSec = speedBytesPerSec;
         }
 
         private void postFinalNotification() {

--- a/app/src/main/java/com/cappielloantonio/tempo/util/ExternalAudioWriter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/ExternalAudioWriter.java
@@ -86,6 +86,9 @@ public class ExternalAudioWriter {
     }
 
     private static void performDownload(Context context, MediaItem mediaItem, String fallbackName, Child child, String playlistId, String playlistName) {
+        DownloadProgressState.getInstance().setCurrentTrackTitle(
+                child.getTitle() != null ? child.getTitle() : fallbackName);
+
         String uriString = Preferences.getDownloadDirectoryUri();
         if (uriString == null) {
             notifyUnavailable(context);

--- a/app/src/main/java/com/cappielloantonio/tempo/util/ExternalAudioWriter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/ExternalAudioWriter.java
@@ -14,8 +14,8 @@ import androidx.media3.common.MediaItem;
 
 import com.cappielloantonio.tempo.model.Download;
 import com.cappielloantonio.tempo.repository.DownloadRepository;
+import com.cappielloantonio.tempo.service.DownloadProgressState;
 import com.cappielloantonio.tempo.subsonic.models.Child;
-import com.cappielloantonio.tempo.ui.activity.MainActivity;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -29,6 +29,9 @@ import java.util.Locale;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
+import androidx.media3.common.util.UnstableApi;
+
+@UnstableApi
 public class ExternalAudioWriter {
 
     private static final ExecutorService EXECUTOR = Executors.newSingleThreadExecutor();
@@ -73,7 +76,11 @@ public class ExternalAudioWriter {
         Context appContext = context.getApplicationContext();
         MediaItem mediaItem = MappingUtil.mapDownload(child);
         String fallbackName = child.getTitle() != null ? child.getTitle() : child.getId();
-        
+
+        // Register with the progress tracker BEFORE submitting to the executor so the
+        // total count is accurate even when many tracks are enqueued in rapid succession.
+        DownloadProgressState.getInstance().onEnqueue(appContext);
+
         EXECUTOR.execute(() -> performDownload(appContext, mediaItem, fallbackName, child, playlistId, playlistName));
     }
 
@@ -81,12 +88,14 @@ public class ExternalAudioWriter {
         String uriString = Preferences.getDownloadDirectoryUri();
         if (uriString == null) {
             notifyUnavailable(context);
+            DownloadProgressState.getInstance().onFailed(context);
             return;
         }
 
         DocumentFile directory = DocumentFile.fromTreeUri(context, Uri.parse(uriString));
         if (directory == null || !directory.canWrite()) {
-            notifyFailure(context, "Cannot write to folder.");
+            DownloadProgressState.getInstance().onFailed(context);
+            notifyFolderError(context);
             return;
         }
 
@@ -104,8 +113,8 @@ public class ExternalAudioWriter {
                 ? mediaItem.requestMetadata.mediaUri
                 : null;
         if (mediaUri == null) {
-            notifyFailure(context, "Invalid media URI.");
             ExternalDownloadMetadataStore.remove(metadataKey);
+            DownloadProgressState.getInstance().onFailed(context);
             return;
         }
 
@@ -128,8 +137,8 @@ public class ExternalAudioWriter {
 
                 int responseCode = connection.getResponseCode();
                 if (responseCode >= HttpURLConnection.HTTP_BAD_REQUEST) {
-                    notifyFailure(context, "Server returned " + responseCode);
                     ExternalDownloadMetadataStore.remove(metadataKey);
+                    DownloadProgressState.getInstance().onFailed(context);
                     return;
                 }
 
@@ -154,8 +163,8 @@ public class ExternalAudioWriter {
                     mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(ext);
                 }
             } else {
-                notifyFailure(context, "Unsupported media URI.");
                 ExternalDownloadMetadataStore.remove(metadataKey);
+                DownloadProgressState.getInstance().onFailed(context);
                 return;
             }
 
@@ -206,7 +215,8 @@ public class ExternalAudioWriter {
                     ExternalDownloadMetadataStore.recordSize(metadataKey, localLength);
                     recordDownload(child, existingFile.getUri(), playlistId, playlistName);
                     ExternalAudioReader.refreshCacheAsync();
-                    notifyExists(context, fileName);
+                    // Already exists — count as a quiet skip so progress resolves correctly
+                    DownloadProgressState.getInstance().onSkipped(context);
                     return;
                 } else {
                     existingFile.delete();
@@ -216,7 +226,7 @@ public class ExternalAudioWriter {
 
             targetFile = directory.createFile(mimeType, fileName);
             if (targetFile == null) {
-                notifyFailure(context, "Failed to create file.");
+                DownloadProgressState.getInstance().onFailed(context);
                 return;
             }
 
@@ -224,8 +234,8 @@ public class ExternalAudioWriter {
             try (InputStream in = openInputStream(context, mediaUri, scheme, connection, sourceFile);
                  OutputStream out = context.getContentResolver().openOutputStream(targetUri)) {
                 if (out == null) {
-                    notifyFailure(context, "Cannot open output stream.");
                     targetFile.delete();
+                    DownloadProgressState.getInstance().onFailed(context);
                     return;
                 }
 
@@ -241,20 +251,20 @@ public class ExternalAudioWriter {
                 if (total <= 0) {
                     targetFile.delete();
                     ExternalDownloadMetadataStore.remove(metadataKey);
-                    notifyFailure(context, "Empty download.");
+                    DownloadProgressState.getInstance().onFailed(context);
                     return;
                 }
 
                 if (remoteLength > 0 && total != remoteLength) {
                     targetFile.delete();
                     ExternalDownloadMetadataStore.remove(metadataKey);
-                    notifyFailure(context, "Incomplete download.");
+                    DownloadProgressState.getInstance().onFailed(context);
                     return;
                 }
 
                 ExternalDownloadMetadataStore.recordSize(metadataKey, total);
                 recordDownload(child, targetUri, playlistId, playlistName);
-                notifySuccess(context, fileName, child, targetUri);
+                DownloadProgressState.getInstance().onSuccess(context);
                 ExternalAudioReader.refreshCacheAsync();
             }
         } catch (Exception e) {
@@ -262,7 +272,7 @@ public class ExternalAudioWriter {
                 targetFile.delete();
             }
             ExternalDownloadMetadataStore.remove(metadataKey);
-            notifyFailure(context, e.getMessage() != null ? e.getMessage() : "Download failed");
+            DownloadProgressState.getInstance().onFailed(context);
         } finally {
             if (connection != null) {
                 connection.disconnect();
@@ -270,6 +280,11 @@ public class ExternalAudioWriter {
         }
     }
 
+    /**
+     * Shown only when the user hasn't set a download folder at all — this is a one-off
+     * actionable notification that remains separate from the progress flow because the
+     * user needs to take action in Settings before anything else can proceed.
+     */
     private static void notifyUnavailable(Context context) {
         NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         Intent settingsIntent = new Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
@@ -286,33 +301,23 @@ public class ExternalAudioWriter {
                 .setContentIntent(openSettings)
                 .setAutoCancel(true);
 
-        manager.notify(1011, builder.build());
+        manager.notify(DownloadProgressState.EXTERNAL_PROGRESS_NOTIFICATION_ID - 1, builder.build());
     }
 
-    private static void notifyFailure(Context context, String message) {
+    /**
+     * Shown only when the download folder exists but is not writable — separate from the
+     * progress flow since it indicates a setup problem the user must resolve.
+     */
+    private static void notifyFolderError(Context context) {
         NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
         NotificationCompat.Builder builder = new NotificationCompat.Builder(context, DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID)
-                .setContentTitle("Download failed")
-                .setContentText(message)
+                .setContentTitle("Download folder error")
+                .setContentText("Cannot write to the selected folder")
                 .setSmallIcon(android.R.drawable.stat_notify_error)
+                .setPriority(NotificationCompat.PRIORITY_LOW)
+                .setSilent(true)
                 .setAutoCancel(true);
-        manager.notify((int) System.currentTimeMillis(), builder.build());
-    }
-
-    private static void notifySuccess(Context context, String name, Child child, Uri fileUri) {
-        NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID)
-                .setContentTitle("Download complete")
-                .setContentText(name)
-                .setSmallIcon(android.R.drawable.stat_sys_download_done)
-                .setAutoCancel(true);
-
-        PendingIntent playIntent = buildPlayIntent(context, child, fileUri);
-        if (playIntent != null) {
-            builder.setContentIntent(playIntent);
-        }
-
-        manager.notify((int) System.currentTimeMillis(), builder.build());
+        manager.notify(DownloadProgressState.EXTERNAL_PROGRESS_NOTIFICATION_ID - 1, builder.build());
     }
 
     private static void recordDownload(Child child, Uri fileUri, String playlistId, String playlistName) {
@@ -329,43 +334,6 @@ public class ExternalAudioWriter {
 
         new DownloadRepository().insert(download);
     }   
-
-    private static void notifyExists(Context context, String name) {
-        NotificationManager manager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(context, DownloadUtil.DOWNLOAD_NOTIFICATION_CHANNEL_ID)
-                .setContentTitle("Already downloaded")
-                .setContentText(name)
-                .setSmallIcon(android.R.drawable.stat_sys_warning)
-                .setAutoCancel(true);
-        manager.notify((int) System.currentTimeMillis(), builder.build());
-    }
-
-    private static PendingIntent buildPlayIntent(Context context, Child child, Uri fileUri) {
-        if (fileUri == null) return null;
-        Intent intent = new Intent(context, MainActivity.class)
-                .setAction(Constants.ACTION_PLAY_EXTERNAL_DOWNLOAD)
-                .putExtra(Constants.EXTRA_DOWNLOAD_URI, fileUri.toString())
-                .putExtra(Constants.EXTRA_DOWNLOAD_MEDIA_ID, child.getId())
-                .putExtra(Constants.EXTRA_DOWNLOAD_TITLE, child.getTitle())
-                .putExtra(Constants.EXTRA_DOWNLOAD_ARTIST, child.getArtist())
-                .putExtra(Constants.EXTRA_DOWNLOAD_ALBUM, child.getAlbum())
-                .putExtra(Constants.EXTRA_DOWNLOAD_DURATION, child.getDuration() != null ? child.getDuration() : 0)
-                .addFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP | Intent.FLAG_ACTIVITY_CLEAR_TOP);
-
-        int requestCode;
-        if (child.getId() != null) {
-            requestCode = Math.abs(child.getId().hashCode());
-        } else {
-            requestCode = Math.abs(fileUri.toString().hashCode());
-        }
-
-        return PendingIntent.getActivity(
-                context,
-                requestCode,
-                intent,
-                PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE
-        );
-    }
 
     private static InputStream openInputStream(Context context,
                                                Uri mediaUri,

--- a/app/src/main/java/com/cappielloantonio/tempo/util/ExternalAudioWriter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/ExternalAudioWriter.java
@@ -5,6 +5,7 @@ import android.app.PendingIntent;
 import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
+import android.os.SystemClock;
 import android.provider.Settings;
 import android.webkit.MimeTypeMap;
 
@@ -242,9 +243,15 @@ public class ExternalAudioWriter {
                 byte[] buffer = new byte[BUFFER_SIZE];
                 int len;
                 long total = 0;
+                long lastProgressMs = 0;
                 while ((len = in.read(buffer)) != -1) {
                     out.write(buffer, 0, len);
                     total += len;
+                    long now = SystemClock.elapsedRealtime();
+                    if (now - lastProgressMs > 500) {
+                        DownloadProgressState.getInstance().reportBytesProgress(context, total);
+                        lastProgressMs = now;
+                    }
                 }
                 out.flush();
 

--- a/app/src/main/java/com/cappielloantonio/tempo/util/ExternalAudioWriter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/ExternalAudioWriter.java
@@ -230,6 +230,7 @@ public class ExternalAudioWriter {
 
             targetFile = directory.createFile(mimeType, fileName);
             if (targetFile == null) {
+                ExternalDownloadMetadataStore.remove(metadataKey);
                 DownloadProgressState.getInstance().onFailed(context);
                 return;
             }
@@ -239,6 +240,7 @@ public class ExternalAudioWriter {
                  OutputStream out = context.getContentResolver().openOutputStream(targetUri)) {
                 if (out == null) {
                     targetFile.delete();
+                    ExternalDownloadMetadataStore.remove(metadataKey);
                     DownloadProgressState.getInstance().onFailed(context);
                     return;
                 }

--- a/app/src/main/java/com/cappielloantonio/tempo/util/ExternalAudioWriter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/ExternalAudioWriter.java
@@ -40,6 +40,10 @@ public class ExternalAudioWriter {
     private static final int CONNECT_TIMEOUT_MS = 15_000;
     private static final int READ_TIMEOUT_MS = 60_000;
 
+    // One-off error notification IDs — distinct from Path A (1, 2) and Path B (1012, 1013)
+    private static final int NO_FOLDER_NOTIFICATION_ID = 1010;
+    private static final int FOLDER_ERROR_NOTIFICATION_ID = 1009;
+
     private ExternalAudioWriter() {
     }
 
@@ -313,7 +317,7 @@ public class ExternalAudioWriter {
                 .setContentIntent(openSettings)
                 .setAutoCancel(true);
 
-        manager.notify(DownloadProgressState.EXTERNAL_PROGRESS_NOTIFICATION_ID - 1, builder.build());
+        manager.notify(NO_FOLDER_NOTIFICATION_ID, builder.build());
     }
 
     /**
@@ -329,7 +333,7 @@ public class ExternalAudioWriter {
                 .setPriority(NotificationCompat.PRIORITY_LOW)
                 .setSilent(true)
                 .setAutoCancel(true);
-        manager.notify(DownloadProgressState.EXTERNAL_PROGRESS_NOTIFICATION_ID - 1, builder.build());
+        manager.notify(FOLDER_ERROR_NOTIFICATION_ID, builder.build());
     }
 
     private static void recordDownload(Child child, Uri fileUri, String playlistId, String playlistName) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -134,6 +134,28 @@
     <string name="error_required">Required</string>
     <string name="error_server_prefix">http or https prefix required</string>
     <string name="exo_download_notification_channel_name">Downloads</string>
+    <string name="notification_downloading">Downloading</string>
+    <string name="notification_downloading_title">Downloading %1$s</string>
+    <string name="notification_download_progress_format">%1$d of %2$d</string>
+    <string name="notification_downloading_progress">Downloading…</string>
+    <string name="notification_finalizing">Finalizing…</string>
+    <string name="notification_processing">Processing…</string>
+    <string name="notification_downloads_complete">Downloads complete</string>
+    <string name="notification_download_failed">Download failed</string>
+    <string name="notification_download_mixed_result">%1$d downloaded, %2$d failed</string>
+    <string name="notification_download_mixed_saved">%1$d saved, %2$d failed</string>
+    <plurals name="notification_tracks_downloaded">
+        <item quantity="one">1 track downloaded</item>
+        <item quantity="other">%d tracks downloaded</item>
+    </plurals>
+    <plurals name="notification_tracks_failed">
+        <item quantity="one">1 track failed</item>
+        <item quantity="other">%d tracks failed</item>
+    </plurals>
+    <plurals name="notification_tracks_saved">
+        <item quantity="one">1 track saved</item>
+        <item quantity="other">%d tracks saved</item>
+    </plurals>
     <string name="exo_controls_heart_off_description">Toggle Heart off</string>
     <string name="exo_controls_heart_on_description">Toggle Heart on</string>
     <string name="cast_expanded_controller_loading">Loading…</string>


### PR DESCRIPTION
Closes #62 
partially resolves  #755
mostly does the work for #902 / #345

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added consolidated download progress notifications showing track counts, current title, and download speed.
  * Added final success or failure summaries for completed download batches.
  * Download progress now remains consistent as tracks finish.

* **Bug Fixes**
  * Existing files are skipped quietly while still being accounted for.
  * Improved handling of failed, incomplete, unsupported, or invalid downloads.
  * Progress notifications are cleared when a batch finishes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->