### PR TITLE
feat: display playlist cover art from server if available

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
@@ -15,6 +15,7 @@ import android.view.inputmethod.EditorInfo;
 import android.view.inputmethod.InputMethodManager;
 import android.widget.SearchView;
 import android.widget.Toast;
+import android.widget.ImageView;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -300,40 +301,118 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
         // heap climbed with every playlist opened until OOM. getViewLifecycleOwner()
         // removes the observer at onDestroyView so the view tree can be collected.
         // See issue #696.
-        playlistPageViewModel.getPlaylistSongLiveList().observe(getViewLifecycleOwner(), songs -> {
-            if (bind != null && songs != null && !songs.isEmpty()) {
-                java.util.List<com.cappielloantonio.tempo.subsonic.models.Child> randomSongs = new java.util.ArrayList<>(songs);
-                java.util.Collections.shuffle(randomSongs);
+        Playlist playlist = playlistPageViewModel.getPlaylist();
 
-                // Pic top-left
-                CustomGlideRequest.Builder
-                        .from(requireContext(), !randomSongs.isEmpty() ? randomSongs.get(0).getCoverArtId() : playlistPageViewModel.getPlaylist().getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                        .build()
-                        .transform(new GranularRoundedCorners(CustomGlideRequest.CORNER_RADIUS, 0, 0, 0))
-                        .into(bind.playlistCoverImageViewTopLeft);
+        if (playlist == null || bind == null) return;
 
-                // Pic top-right
-                CustomGlideRequest.Builder
-                        .from(requireContext(), randomSongs.size() > 1 ? randomSongs.get(1).getCoverArtId() : playlistPageViewModel.getPlaylist().getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                        .build()
-                        .transform(new GranularRoundedCorners(0, CustomGlideRequest.CORNER_RADIUS, 0, 0))
-                        .into(bind.playlistCoverImageViewTopRight);
+        String playlistCoverId = playlist.getCoverArtId();
 
-                // Pic bottom-left
-                CustomGlideRequest.Builder
-                        .from(requireContext(), randomSongs.size() > 2 ? randomSongs.get(2).getCoverArtId() : playlistPageViewModel.getPlaylist().getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                        .build()
-                        .transform(new GranularRoundedCorners(0, 0, 0, CustomGlideRequest.CORNER_RADIUS))
-                        .into(bind.playlistCoverImageViewBottomLeft);
+        // Retrieve the parent container holding the cover views
+        ViewGroup coverContainer = (ViewGroup) bind.playlistCoverImageViewTopLeft.getParent();
 
-                // Pic bottom-right
-                CustomGlideRequest.Builder
-                        .from(requireContext(), randomSongs.size() > 3 ? randomSongs.get(3).getCoverArtId() : playlistPageViewModel.getPlaylist().getCoverArtId(), CustomGlideRequest.ResourceType.Song)
-                        .build()
-                        .transform(new GranularRoundedCorners(0, 0, CustomGlideRequest.CORNER_RADIUS, 0))
-                        .into(bind.playlistCoverImageViewBottomRight);
+        // Look for an existing single cover view dynamically added previously
+        ImageView singleCoverView = coverContainer.findViewWithTag("SINGLE_PLAYLIST_COVER");
+
+        // Loads the playlist's own explicit custom cover image
+        if (playlistCoverId != null && !playlistCoverId.trim().isEmpty()) {
+
+            // Dynamically instantiate and attach the single ImageView if it doesn't exist yet
+            if (singleCoverView == null) {
+                singleCoverView = new ImageView(requireContext());
+                singleCoverView.setTag("SINGLE_PLAYLIST_COVER");
+                singleCoverView.setScaleType(ImageView.ScaleType.CENTER_CROP);
+
+                // Generate appropriate LayoutParams based on the parent view container type
+                ViewGroup.MarginLayoutParams params = getMarginLayoutParams(coverContainer);
+
+                // Convert 62dp to pixels for horizontal margin alignment
+                int sideMarginPx = (int) (62 * requireContext().getResources().getDisplayMetrics().density);
+                params.setMargins(sideMarginPx, 0, sideMarginPx, 0);
+
+                coverContainer.addView(singleCoverView, params);
             }
-        });
+
+            singleCoverView.setVisibility(View.VISIBLE);
+
+            // Loads the custom cover image with rounded corners on all four sides using Glide
+            CustomGlideRequest.Builder
+                    .from(requireContext(), playlistCoverId, CustomGlideRequest.ResourceType.Playlist)
+                    .build()
+                    .transform(new GranularRoundedCorners(
+                            CustomGlideRequest.CORNER_RADIUS,
+                            CustomGlideRequest.CORNER_RADIUS,
+                            CustomGlideRequest.CORNER_RADIUS,
+                            CustomGlideRequest.CORNER_RADIUS
+                    ))
+                    .into(singleCoverView);
+
+        } else {
+            // Fallback: Hide the single cover view if it exists and render the 2x2 song collage
+            if (singleCoverView != null) {
+                singleCoverView.setVisibility(View.GONE);
+            }
+
+            playlistPageViewModel.getPlaylistSongLiveList().observe(getViewLifecycleOwner(), songs -> {
+                if (bind != null && songs != null && !songs.isEmpty()) {
+
+                    List<Child> randomSongs = new ArrayList<>(songs);
+                    Collections.shuffle(randomSongs);
+
+                    // Load Top-Left image (round top-left corner only)
+                    CustomGlideRequest.Builder
+                            .from(requireContext(), !randomSongs.isEmpty() ? randomSongs.get(0).getCoverArtId() : null, CustomGlideRequest.ResourceType.Song)
+                            .build()
+                            .transform(new GranularRoundedCorners(CustomGlideRequest.CORNER_RADIUS, 0, 0, 0))
+                            .into(bind.playlistCoverImageViewTopLeft);
+
+                    // Load Top-Right image (round top-right corner only)
+                    CustomGlideRequest.Builder
+                            .from(requireContext(), randomSongs.size() > 1 ? randomSongs.get(1).getCoverArtId() : null, CustomGlideRequest.ResourceType.Song)
+                            .build()
+                            .transform(new GranularRoundedCorners(0, CustomGlideRequest.CORNER_RADIUS, 0, 0))
+                            .into(bind.playlistCoverImageViewTopRight);
+
+                    // Load Bottom-Left image (round bottom-left corner only)
+                    CustomGlideRequest.Builder
+                            .from(requireContext(), randomSongs.size() > 2 ? randomSongs.get(2).getCoverArtId() : null, CustomGlideRequest.ResourceType.Song)
+                            .build()
+                            .transform(new GranularRoundedCorners(0, 0, 0, CustomGlideRequest.CORNER_RADIUS))
+                            .into(bind.playlistCoverImageViewBottomLeft);
+
+                    // Load Bottom-Right image (round bottom-right corner only)
+                    CustomGlideRequest.Builder
+                            .from(requireContext(), randomSongs.size() > 3 ? randomSongs.get(3).getCoverArtId() : null, CustomGlideRequest.ResourceType.Song)
+                            .build()
+                            .transform(new GranularRoundedCorners(0, 0, CustomGlideRequest.CORNER_RADIUS, 0))
+                            .into(bind.playlistCoverImageViewBottomRight);
+                }
+            });
+        }
+    }
+
+    // Creates full-match layout parameters compatible with the type of container group passed.
+    @NonNull
+    private static ViewGroup.MarginLayoutParams getMarginLayoutParams(ViewGroup coverContainer) {
+        ViewGroup.MarginLayoutParams params;
+
+        if (coverContainer instanceof android.widget.FrameLayout) {
+            params = new android.widget.FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+            );
+        } else if (coverContainer instanceof androidx.constraintlayout.widget.ConstraintLayout) {
+            params = new androidx.constraintlayout.widget.ConstraintLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+            );
+        } else {
+            params = new ViewGroup.MarginLayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT
+            );
+        }
+
+        return params;
     }
 
     private void initSongsView() {


### PR DESCRIPTION
## Description
This PR implements functionality to fetch and display playlist cover art directly from the server if it supports it. Previously, playlists would display a 2x2 collage of album cover arts by default; now, the UI displays the full playlist cover art that is also shown in the playlist section.

## Changes
- Updated the playlist view logic to check for server-provided cover art.
- Integrated image loading handling for playlist entities.
- Fallback mechanism remains in place if no cover art is returned by the server.

## Screenshots

| Before | After |
| :---: | :---: |
| <img width="320" height="640" alt="Screenshot_20260728-223248_Tempus" src="https://github.com/user-attachments/assets/aaf50a06-8814-412f-a835-02d2887e6b07" /> | <img width="320" height="640" alt="Screenshot_20260728-223824_Tempus" src="https://github.com/user-attachments/assets/38326b3f-f13d-4c9c-b42c-cd4e152c68d8" /> |

## Additional Notes
Tested on a Pixel 4a & Samsung Galaxy Tab A9.