### PR TITLE
fix: handle insert and insertAll methods crashing with IOBE when afte…

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/repository/QueueRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/QueueRepository.java
@@ -112,13 +112,20 @@ public class QueueRepository {
     public void insert(Child media, boolean reset, int afterIndex) {
         dbExecutor.execute(() -> {
             List<Queue> mediaList = new ArrayList<>();
+            int insertionIndex = afterIndex;
 
             if (!reset) {
                 mediaList = queueDao.getAllSimple();
+            } else {
+                insertionIndex = 0;
+            }
+
+            if (insertionIndex > mediaList.size()) {
+                insertionIndex = mediaList.size();
             }
 
             Queue queueItem = new Queue(media);
-            mediaList.add(afterIndex, queueItem);
+            mediaList.add(insertionIndex, queueItem);
 
             for (int i = 0; i < mediaList.size(); i++) {
                 mediaList.get(i).setTrackOrder(i);
@@ -139,9 +146,12 @@ public class QueueRepository {
     public void insertAll(List<Child> toAdd, boolean reset, int afterIndex) {
         dbExecutor.execute(() -> {
             List<Queue> media = new ArrayList<>();
+            int insertionIndex = afterIndex;
 
             if (!reset) {
                 media = queueDao.getAllSimple();
+            } else {
+                insertionIndex = 0;
             }
 
             final List<Queue> finalMedia = media;
@@ -151,15 +161,19 @@ public class QueueRepository {
                     .collect(Collectors.toList());
 
             for (int i = 0; i < filteredToAdd.size(); i++) {
+                int idx = insertionIndex + i;
+                if (idx > finalMedia.size()) {
+                    idx = finalMedia.size();
+                }
                 Queue queueItem = new Queue(filteredToAdd.get(i));
-                media.add(afterIndex + i, queueItem);
+                finalMedia.add(idx, queueItem);
             }
 
-            for (int i = 0; i < media.size(); i++) {
-                media.get(i).setTrackOrder(i);
+            for (int i = 0; i < finalMedia.size(); i++) {
+                finalMedia.get(i).setTrackOrder(i);
             }
 
-            queueDao.replaceQueue(media);
+            queueDao.replaceQueue(finalMedia);
         });
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/repository/QueueRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/QueueRepository.java
@@ -120,7 +120,9 @@ public class QueueRepository {
                 insertionIndex = 0;
             }
 
-            if (insertionIndex > mediaList.size()) {
+            if (insertionIndex < 0) {
+                insertionIndex = 0;
+            } else if (insertionIndex > mediaList.size()) {
                 insertionIndex = mediaList.size();
             }
 
@@ -154,6 +156,12 @@ public class QueueRepository {
                 insertionIndex = 0;
             }
 
+            if (insertionIndex < 0) {
+                insertionIndex = 0;
+            } else if (insertionIndex > media.size()) {
+                insertionIndex = media.size();
+            }
+
             final List<Queue> finalMedia = media;
             List<Child> toAddCopy = new ArrayList<>(toAdd);
             List<Child> filteredToAdd = toAddCopy.stream()
@@ -162,9 +170,6 @@ public class QueueRepository {
 
             for (int i = 0; i < filteredToAdd.size(); i++) {
                 int idx = insertionIndex + i;
-                if (idx > finalMedia.size()) {
-                    idx = finalMedia.size();
-                }
                 Queue queueItem = new Queue(filteredToAdd.get(i));
                 finalMedia.add(idx, queueItem);
             }


### PR DESCRIPTION
…rIndex exceeded the current list size.
resolves #943

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed queue insertions when the requested position is outside the current queue range.
  * Ensured reset insertions consistently appear at the beginning of the queue.
  * Improved bulk insertions so additional items are added safely without causing errors.
  * Updated queue ordering after multiple items are inserted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->