### PR TITLE
fix: map playback queues off the UI thread so large playlists stop hanging

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/BaseMediaService.kt
@@ -71,6 +71,10 @@ open class BaseMediaService : MediaLibraryService() {
     private lateinit var equalizerManager: EqualizerManager
     private val widgetUpdateHandler = Handler(Looper.getMainLooper())
     private var widgetUpdateScheduled = false
+    // Set in onDestroy. restorePlayerFromQueue maps the saved queue on a background thread and
+    // posts the player calls back to this handler; if the service is destroyed mid map (the app
+    // swiped away during launch), that post must not touch the now released player.
+    @Volatile private var serviceDestroyed = false
     private val widgetUpdateRunnable = object : Runnable {
         override fun run() {
             val player = mediaLibrarySession.player
@@ -226,28 +230,38 @@ open class BaseMediaService : MediaLibraryService() {
     fun restorePlayerFromQueue(player: Player) {
         if (player.mediaItemCount > 0) return
 
-        val queueRepository = QueueRepository()
-        val storedQueue = queueRepository.media
-        if (storedQueue.isNullOrEmpty()) return
+        // Map off the main thread: mapMediaItems does a blocking lookup per song, so a
+        // large saved queue froze the UI on launch (#600).
+        Thread {
+            val queueRepository = QueueRepository()
+            val storedQueue = queueRepository.media
+            if (storedQueue.isNullOrEmpty()) return@Thread
 
-        val mediaItems = MappingUtil.mapMediaItems(storedQueue)
-        if (mediaItems.isEmpty()) return
+            val mediaItems = MappingUtil.mapMediaItems(storedQueue)
+            if (mediaItems.isEmpty()) return@Thread
 
-        val lastIndex = try {
-            queueRepository.lastPlayedMediaIndex
-        } catch (_: Exception) {
-            0
-        }.coerceIn(0, mediaItems.size - 1)
+            val lastIndex = try {
+                queueRepository.lastPlayedMediaIndex
+            } catch (_: Exception) {
+                0
+            }.coerceIn(0, mediaItems.size - 1)
 
-        val lastPosition = try {
-            queueRepository.lastPlayedMediaTimestamp
-        } catch (_: Exception) {
-            0L
-        }.let { if (it < 0L) 0L else it }
+            val lastPosition = try {
+                queueRepository.lastPlayedMediaTimestamp
+            } catch (_: Exception) {
+                0L
+            }.let { if (it < 0L) 0L else it }
 
-        player.setMediaItems(mediaItems, lastIndex, lastPosition)
-        player.prepare()
-        updateWidget(player)
+            widgetUpdateHandler.post {
+                // onDestroy may have released the player while this queue was still mapping, and
+                // the mediaItemCount check below cannot detect a released player, so bail first.
+                if (serviceDestroyed) return@post
+                if (player.mediaItemCount > 0) return@post
+                player.setMediaItems(mediaItems, lastIndex, lastPosition)
+                player.prepare()
+                updateWidget(player)
+            }
+        }.start()
     }
 
     private var lastRadioArtist: String? = null
@@ -678,6 +692,7 @@ open class BaseMediaService : MediaLibraryService() {
 
     override fun onDestroy() {
         QueuePreloader.cancel()
+        serviceDestroyed = true
         releaseNetworkCallback()
         equalizerManager.release(exoplayer.audioSessionId)
         ReplayGainUtil.release()

--- a/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/service/MediaManager.java
@@ -178,10 +178,23 @@ public class MediaManager {
             mediaBrowserListenableFuture.addListener(() -> {
                 try {
                     if (mediaBrowserListenableFuture.isDone()) {
-                        mediaBrowserListenableFuture.get().clearMediaItems();
-                        mediaBrowserListenableFuture.get().setMediaItems(MappingUtil.mapMediaItems(media));
-                        mediaBrowserListenableFuture.get().seekTo(getQueueRepository().getLastPlayedMediaIndex(), getQueueRepository().getLastPlayedMediaTimestamp());
-                        mediaBrowserListenableFuture.get().prepare();
+                        final MediaBrowser browser = mediaBrowserListenableFuture.get();
+
+                        backgroundExecutor.execute(() -> {
+                            final List<MediaItem> items = MappingUtil.mapMediaItems(media);
+                            final int index = getQueueRepository().getLastPlayedMediaIndex();
+                            final long position = getQueueRepository().getLastPlayedMediaTimestamp();
+
+                            new Handler(Looper.getMainLooper()).post(() -> {
+                                // The user can start something while we map, and check() only
+                                // tested this before the mapping began. Do not stomp their pick.
+                                if (browser.getMediaItemCount() > 0) return;
+                                browser.clearMediaItems();
+                                browser.setMediaItems(items);
+                                browser.seekTo(index, position);
+                                browser.prepare();
+                            });
+                        });
                     }
                 } catch (ExecutionException | InterruptedException e) {
                     e.printStackTrace();
@@ -198,33 +211,36 @@ public class MediaManager {
                 try {
                     if (mediaBrowserListenableFuture.isDone()) {
                         final MediaBrowser browser = mediaBrowserListenableFuture.get();
-                        final List<MediaItem> items = MappingUtil.mapMediaItems(media);
-                        
-                        new Handler(Looper.getMainLooper()).post(() -> {
-                            justStarted.set(true);
-                            browser.setMediaItems(items, startIndex, 0);
-                            browser.prepare();
 
-                            Player.Listener timelineListener = new Player.Listener() {
-                                @Override
-                                public void onTimelineChanged(Timeline timeline, int reason) {
-                                    
-                                    int itemCount = browser.getMediaItemCount();
-                                    if (itemCount > 0 && startIndex >= 0 && startIndex < itemCount) {
-                                        browser.seekTo(startIndex, 0);
-                                        browser.play();
-                                        browser.removeListener(this);
-                                    } else {
-                                        Log.d(TAG, "Cannot start playback: itemCount=" + itemCount + ", startIndex=" + startIndex);
-                                    }
-                                }
-                            };
-                            
-                            browser.addListener(timelineListener);
-                        });
-
+                        // Map off the caller thread. getUri does a blocking DB lookup per song
+                        // (each one spawns a Thread and joins it), and this listener runs via
+                        // directExecutor on the click thread, so a large list froze the UI.
+                        // Only the player calls go back to main.
                         backgroundExecutor.execute(() -> {
-                            Log.d(TAG, "Background: enqueuing to database");
+                            final List<MediaItem> items = MappingUtil.mapMediaItems(media);
+
+                            new Handler(Looper.getMainLooper()).post(() -> {
+                                justStarted.set(true);
+                                browser.setMediaItems(items, startIndex, 0);
+                                browser.prepare();
+
+                                Player.Listener timelineListener = new Player.Listener() {
+                                    @Override
+                                    public void onTimelineChanged(Timeline timeline, int reason) {
+                                        int itemCount = browser.getMediaItemCount();
+                                        if (itemCount > 0 && startIndex >= 0 && startIndex < itemCount) {
+                                            browser.seekTo(startIndex, 0);
+                                            browser.play();
+                                            browser.removeListener(this);
+                                        } else {
+                                            Log.d(TAG, "Cannot start playback: itemCount=" + itemCount + ", startIndex=" + startIndex);
+                                        }
+                                    }
+                                };
+
+                                browser.addListener(timelineListener);
+                            });
+
                             enqueueDatabase(media, true, 0);
                         });
                     }
@@ -400,10 +416,18 @@ public class MediaManager {
                 try {
                     if (mediaBrowserListenableFuture.isDone()) {
                         Log.e(TAG, "shuffle");
-                        MediaBrowser browser = mediaBrowserListenableFuture.get();
-                        browser.removeMediaItems(startIndex, endIndex + 1);
-                        browser.addMediaItems(MappingUtil.mapMediaItems(media).subList(startIndex, endIndex + 1));
-                        swapDatabase(media);
+                        final MediaBrowser browser = mediaBrowserListenableFuture.get();
+
+                        backgroundExecutor.execute(() -> {
+                            final List<MediaItem> mapped = MappingUtil.mapMediaItems(media);
+
+                            new Handler(Looper.getMainLooper()).post(() -> {
+                                browser.removeMediaItems(startIndex, endIndex + 1);
+                                browser.addMediaItems(mapped.subList(startIndex, endIndex + 1));
+                            });
+
+                            swapDatabase(media);
+                        });
                     }
                 } catch (ExecutionException | InterruptedException e) {
                     e.printStackTrace();

--- a/app/src/main/java/com/cappielloantonio/tempo/util/MappingUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/MappingUtil.java
@@ -3,6 +3,7 @@ package com.cappielloantonio.tempo.util;
 import android.content.ContentResolver;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.SystemClock;
 import android.util.Log;
 import android.util.Base64;
 
@@ -27,7 +28,9 @@ import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.nio.charset.StandardCharsets;
 
 @OptIn(markerClass = UnstableApi.class)
@@ -456,14 +459,32 @@ public class MappingUtil {
         return child;
     }
 
-    private static Uri getUri(Child media) {
-        // Check if it's in our local SQL Database
-        DownloadRepository repo = new DownloadRepository();
-        Download localDownload = repo.getDownload(media.getId());
+    // One second memo of the download table so a mapping burst does one query instead of
+    // a Thread spawn and join per song. A download finishing inside the window streams for it.
+    private static final long DOWNLOAD_CACHE_TTL_MS = 1000;
+    private static volatile Map<String, String> cachedDownloadUris;
+    private static volatile long cachedDownloadsAt = -1;
 
-        if (localDownload != null && localDownload.getDownloadUri() != null && !localDownload.getDownloadUri().isEmpty()) {
-            Log.d(TAG, "Playing local file for: " + media.getTitle());
-            return Uri.parse(localDownload.getDownloadUri());
+    private static Map<String, String> getDownloadUris() {
+        Map<String, String> cache = cachedDownloadUris;
+        long now = SystemClock.elapsedRealtime();
+        if (cache != null && cachedDownloadsAt >= 0 && now - cachedDownloadsAt < DOWNLOAD_CACHE_TTL_MS)
+            return cache;
+
+        Map<String, String> map = new HashMap<>();
+        for (Download download : new DownloadRepository().getAllDownloads()) {
+            if (download.getId() != null && download.getDownloadUri() != null && !download.getDownloadUri().isEmpty())
+                map.put(download.getId(), download.getDownloadUri());
+        }
+        cachedDownloadUris = map;
+        cachedDownloadsAt = now;
+        return map;
+    }
+
+    private static Uri getUri(Child media) {
+        String localUri = getDownloadUris().get(media.getId());
+        if (localUri != null) {
+            return Uri.parse(localUri);
         }
 
         // Legacy check for external directory, i think this was broken/buggy
@@ -473,7 +494,6 @@ public class MappingUtil {
         }
 
         // Fallback to streaming
-        Log.d(TAG, "No local file found. Streaming: " + media.getTitle());
         return MusicUtil.getStreamUri(media.getId());
     }
 

--- a/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager;
 import android.net.Network;
 import android.net.NetworkCapabilities;
 import android.net.Uri;
+import android.os.SystemClock;
 import android.text.Html;
 import android.util.Log;
 
@@ -302,40 +303,47 @@ public class MusicUtil {
         return "enc:" + plainPassword.chars().mapToObj(Integer::toHexString).collect(Collectors.joining());
     }
 
-    public static String getBitratePreference() {
+    // One second memo of the active network transport so the per song bitrate and format
+    // lookups stop firing a getActiveNetwork binder call for every song.
+    private static final int TRANSPORT_NONE = -1;
+    private static final int TRANSPORT_OTHER = -2;
+    private static final long NETWORK_CACHE_TTL_MS = 1000;
+    private static volatile int cachedTransport = TRANSPORT_NONE;
+    private static volatile long cachedTransportAt = -1;
+
+    private static int getActiveTransport() {
+        long now = SystemClock.elapsedRealtime();
+        if (cachedTransportAt >= 0 && now - cachedTransportAt < NETWORK_CACHE_TTL_MS) return cachedTransport;
+
         Network network = getConnectivityManager().getActiveNetwork();
-        NetworkCapabilities networkCapabilities = getConnectivityManager().getNetworkCapabilities(network);
-        String audioTranscodeFormat = getTranscodingFormatPreference();
+        NetworkCapabilities caps = network == null ? null : getConnectivityManager().getNetworkCapabilities(network);
 
-        if (audioTranscodeFormat.equals("raw") || network == null || networkCapabilities == null)
+        int transport;
+        if (network == null || caps == null) transport = TRANSPORT_NONE;
+        else if (caps.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) transport = NetworkCapabilities.TRANSPORT_WIFI;
+        else if (caps.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) transport = NetworkCapabilities.TRANSPORT_CELLULAR;
+        else transport = TRANSPORT_OTHER;
+
+        cachedTransport = transport;
+        cachedTransportAt = now;
+        return transport;
+    }
+
+    public static String getBitratePreference() {
+        int transport = getActiveTransport();
+        if (getTranscodingFormatPreference().equals("raw") || transport == TRANSPORT_NONE)
             return "0";
-
-        if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
-            return Preferences.getMaxBitrateWifi();
-        } else if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+        if (transport == NetworkCapabilities.TRANSPORT_CELLULAR)
             return Preferences.getMaxBitrateMobile();
-        } else {
-            return Preferences.getMaxBitrateWifi();
-        }
+        return Preferences.getMaxBitrateWifi();
     }
 
     public static String getTranscodingFormatPreference() {
-        Network network = getConnectivityManager().getActiveNetwork();
-        NetworkCapabilities networkCapabilities = getConnectivityManager().getNetworkCapabilities(network);
-
-        if (network == null || networkCapabilities == null) return "raw";
-
-        String format;
-        if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)) {
-            format = Preferences.getAudioTranscodeFormatWifi();
-            Log.d(TAG, "DEBUG: Using WIFI Format: " + format);
-        } else if (networkCapabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
-            format = Preferences.getAudioTranscodeFormatMobile();
-            Log.d(TAG, "DEBUG: Using MOBILE Format: " + format);
-        } else {
-            format = Preferences.getAudioTranscodeFormatWifi();
-        }
-        return format;
+        int transport = getActiveTransport();
+        if (transport == TRANSPORT_NONE) return "raw";
+        if (transport == NetworkCapabilities.TRANSPORT_CELLULAR)
+            return Preferences.getAudioTranscodeFormatMobile();
+        return Preferences.getAudioTranscodeFormatWifi();
     }
 
     public static String getBitratePreferenceForDownload() {


### PR DESCRIPTION
Fixes #600. Also fixes #937, the same root cause reached from the Downloaded screen.

## What breaks

Starting or shuffling a large playlist freezes the UI, and on a big enough queue reaches an ANR and can crash. Launch does the same, because the service restores the saved queue the same way.

## Root cause

Every play, shuffle and queue restore path maps the whole list to media3 `MediaItem`s on the calling thread, and that thread is main. The mapping is cheap. `MappingUtil.getUri` is not, and it runs once per song:

- `new DownloadRepository().getDownload(id)` starts a `Thread` and `join()`s it for one Room row
- `MusicUtil.getStreamUri` asks for bitrate and transcode format, each calling `getActiveNetwork()`, a binder IPC

At a few thousand items the main thread is gone for tens of seconds.

## The fix

Both halves are needed. Moving the work off main alone stops the ANR but still takes tens of seconds to start.

**Map off the UI thread at the three sites that did it on main:** `MediaManager.startQueue` (Play, and the tail of Shuffle), `MediaManager.init` via `check` (controller restoring the queue on browser connect), and `BaseMediaService.restorePlayerFromQueue` (service restoring it in `onCreate`). Each maps on a background thread and posts back only `setMediaItems`, `seekTo` and `prepare`. The empty player guard is re checked inside the posted block, since the player can fill in between.

**Batch the per song work** so it is fast even off main: `MappingUtil` memoizes the download table as an id to uri map for one second, so a burst does one `getAllDownloads()` rather than one spawn and join per song, and `MusicUtil` memoizes the active network transport for one second.

## Why #937 is the same bug

The Downloaded screen is the worst case. Its adapter hands the entire list to `startQueue` with no cap, and every song there has a real download row, so every one paid the blocking lookup. The reporter's note that grouping by album works is the proof of mechanism: grouping queues only that album. That screen also gains the most from the memo, since all of those lookups collapse into one query.

## What does not change

The mapped `MediaItem`s are identical, so stream URLs, download URIs, ReplayGain data and metadata are untouched. The two memos are the only behaviour change worth review. Both are bounded at one second and return the value they would have computed, so a download finishing inside that window streams for the rest of it and a network change applies one second late. `getBitratePreference` and `getTranscodingFormatPreference` were rewritten on a shared `getActiveTransport()`, and every branch maps one for one to the branch it replaced, including the no network cases returning `"0"` and `"raw"`.

`getUri` also loses two `Log.d` lines that fired once per song, which on these queue sizes was thousands of logcat lines per play.

## Verification

Emulator against a live server, same 5000 item playlist before and after.

| | frames skipped | result |
|---|---|---|
| before | 5412, about 90 seconds frozen | ANR, then a crash |
| after | 172, under 3 seconds | no ANR, playback starts |

The stream URL lookups all land on a background thread afterward, and the memoized methods return the same bitrate and format, so the URLs are identical.

One limitation: the residual delay is media3 building the timeline in `setMediaItems`, still on the app thread. On a very large queue this turns a hang into a short delay rather than into nothing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved playback queue restoration, startup, and shuffle responsiveness.
  * Reduced delays when loading media and preparing playback.
  * Improved handling when queue contents change during loading.
  * Reduced repeated lookups for downloaded media and network conditions.
  * Preserved appropriate streaming and transcoding preferences across connection types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->