### PR TITLE
feat: add a music library switcher so browsing and search can be scoped to one library

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/api/albumsonglist/AlbumSongListClient.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/api/albumsonglist/AlbumSongListClient.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import com.cappielloantonio.tempo.subsonic.RetrofitClient;
 import com.cappielloantonio.tempo.subsonic.Subsonic;
 import com.cappielloantonio.tempo.subsonic.base.ApiResponse;
+import com.cappielloantonio.tempo.util.Preferences;
 
 import retrofit2.Call;
 
@@ -26,22 +27,22 @@ public class AlbumSongListClient {
 
     public Call<ApiResponse> getAlbumList2(String type, int size, int offset, Integer fromYear, Integer toYear) {
         Log.d(TAG, "getAlbumList2()");
-        return albumSongListService.getAlbumList2(subsonic.getParams(), type, size, offset, fromYear, toYear);
+        return albumSongListService.getAlbumList2(subsonic.getParams(), type, size, offset, fromYear, toYear, Preferences.getActiveMusicFolderId());
     }
 
     public Call<ApiResponse> getRandomSongs(int size, Integer fromYear, Integer toYear) {
         Log.d(TAG, "getRandomSongs()");
-        return albumSongListService.getRandomSongs(subsonic.getParams(), size, fromYear, toYear);
+        return albumSongListService.getRandomSongs(subsonic.getParams(), size, fromYear, toYear, Preferences.getActiveMusicFolderId());
     }
 
     public Call<ApiResponse> getRandomSongs(int size, Integer fromYear, Integer toYear, String genre) {
         Log.d(TAG, "getRandomSongs()");
-        return albumSongListService.getRandomSongs(subsonic.getParams(), size, fromYear, toYear, genre);
+        return albumSongListService.getRandomSongs(subsonic.getParams(), size, fromYear, toYear, genre, Preferences.getActiveMusicFolderId());
     }
 
     public Call<ApiResponse> getSongsByGenre(String genre, int count, int offset) {
         Log.d(TAG, "getSongsByGenre()");
-        return albumSongListService.getSongsByGenre(subsonic.getParams(), genre, count, offset);
+        return albumSongListService.getSongsByGenre(subsonic.getParams(), genre, count, offset, Preferences.getActiveMusicFolderId());
     }
 
     public Call<ApiResponse> getNowPlaying() {

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/api/albumsonglist/AlbumSongListService.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/api/albumsonglist/AlbumSongListService.java
@@ -14,16 +14,16 @@ public interface AlbumSongListService {
     Call<ApiResponse> getAlbumList(@QueryMap Map<String, String> params, @Query("type") String type, @Query("size") int size, @Query("offset") int offset);
 
     @GET("getAlbumList2")
-    Call<ApiResponse> getAlbumList2(@QueryMap Map<String, String> params, @Query("type") String type, @Query("size") int size, @Query("offset") int offset, @Query("fromYear") Integer fromYear, @Query("toYear") Integer toYear);
+    Call<ApiResponse> getAlbumList2(@QueryMap Map<String, String> params, @Query("type") String type, @Query("size") int size, @Query("offset") int offset, @Query("fromYear") Integer fromYear, @Query("toYear") Integer toYear, @Query("musicFolderId") String musicFolderId);
 
     @GET("getRandomSongs")
-    Call<ApiResponse> getRandomSongs(@QueryMap Map<String, String> params, @Query("size") int size, @Query("fromYear") Integer fromYear, @Query("toYear") Integer toYear);
+    Call<ApiResponse> getRandomSongs(@QueryMap Map<String, String> params, @Query("size") int size, @Query("fromYear") Integer fromYear, @Query("toYear") Integer toYear, @Query("musicFolderId") String musicFolderId);
 
     @GET("getRandomSongs")
-    Call<ApiResponse> getRandomSongs(@QueryMap Map<String, String> params, @Query("size") int size, @Query("fromYear") Integer fromYear, @Query("toYear") Integer toYear, @Query("genre") String genre);
+    Call<ApiResponse> getRandomSongs(@QueryMap Map<String, String> params, @Query("size") int size, @Query("fromYear") Integer fromYear, @Query("toYear") Integer toYear, @Query("genre") String genre, @Query("musicFolderId") String musicFolderId);
 
     @GET("getSongsByGenre")
-    Call<ApiResponse> getSongsByGenre(@QueryMap Map<String, String> params, @Query("genre") String genre, @Query("count") int count, @Query("offset") int offset);
+    Call<ApiResponse> getSongsByGenre(@QueryMap Map<String, String> params, @Query("genre") String genre, @Query("count") int count, @Query("offset") int offset, @Query("musicFolderId") String musicFolderId);
 
     @GET("getNowPlaying")
     Call<ApiResponse> getNowPlaying(@QueryMap Map<String, String> params);

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/api/browsing/BrowsingClient.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/api/browsing/BrowsingClient.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import com.cappielloantonio.tempo.subsonic.RetrofitClient;
 import com.cappielloantonio.tempo.subsonic.Subsonic;
 import com.cappielloantonio.tempo.subsonic.base.ApiResponse;
+import com.cappielloantonio.tempo.util.Preferences;
 
 import retrofit2.Call;
 
@@ -41,7 +42,7 @@ public class BrowsingClient {
 
     public Call<ApiResponse> getArtists() {
         Log.d(TAG, "getArtists()");
-        return browsingService.getArtists(subsonic.getParams());
+        return browsingService.getArtists(subsonic.getParams(), Preferences.getActiveMusicFolderId());
     }
 
     public Call<ApiResponse> getArtist(String id) {

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/api/browsing/BrowsingService.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/api/browsing/BrowsingService.java
@@ -23,7 +23,7 @@ public interface BrowsingService {
     Call<ApiResponse> getGenres(@QueryMap Map<String, String> params);
 
     @GET("getArtists")
-    Call<ApiResponse> getArtists(@QueryMap Map<String, String> params);
+    Call<ApiResponse> getArtists(@QueryMap Map<String, String> params, @Query("musicFolderId") String musicFolderId);
 
     @GET("getArtist")
     Call<ApiResponse> getArtist(@QueryMap Map<String, String> params, @Query("id") String id);

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/api/searching/SearchingClient.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/api/searching/SearchingClient.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import com.cappielloantonio.tempo.subsonic.RetrofitClient;
 import com.cappielloantonio.tempo.subsonic.Subsonic;
 import com.cappielloantonio.tempo.subsonic.base.ApiResponse;
+import com.cappielloantonio.tempo.util.Preferences;
 
 import retrofit2.Call;
 
@@ -26,6 +27,6 @@ public class SearchingClient {
 
     public Call<ApiResponse> search3(String query, int songCount, int songOffset, int albumCount, int albumOffset, int artistCount, int artistOffset) {
         Log.d(TAG, "search3()");
-        return searchingService.search3(subsonic.getParams(), query, songCount, songOffset, albumCount, albumOffset, artistCount, artistOffset);
+        return searchingService.search3(subsonic.getParams(), query, songCount, songOffset, albumCount, albumOffset, artistCount, artistOffset, Preferences.getActiveMusicFolderId());
     }
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/api/searching/SearchingService.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/api/searching/SearchingService.java
@@ -14,5 +14,5 @@ public interface SearchingService {
     Call<ApiResponse> search2(@QueryMap Map<String, String> params, @Query("query") String query, @Query("songCount") int songCount, @Query("albumCount") int albumCount, @Query("artistCount") int artistCount);
 
     @GET("search3")
-    Call<ApiResponse> search3(@QueryMap Map<String, String> params, @Query("query") String query, @Query("songCount") int songCount, @Query("songOffset") int songOffset, @Query("albumCount") int albumCount, @Query("albumOffset") int albumOffset, @Query("artistCount") int artistCount, @Query("artistOffset") int artistOffset);
+    Call<ApiResponse> search3(@QueryMap Map<String, String> params, @Query("query") String query, @Query("songCount") int songCount, @Query("songOffset") int songOffset, @Query("albumCount") int albumCount, @Query("albumOffset") int albumOffset, @Query("artistCount") int artistCount, @Query("artistOffset") int artistOffset, @Query("musicFolderId") String musicFolderId);
 }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/HomeTabMusicFragment.java
@@ -118,6 +118,8 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
         homeViewModel = new ViewModelProvider(requireActivity()).get(HomeViewModel.class);
         playbackViewModel = new ViewModelProvider(requireActivity()).get(PlaybackViewModel.class);
 
+        homeViewModel.clearCacheIfMusicFolderChanged();
+
         init();
 
         return view;

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LibraryFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LibraryFragment.java
@@ -84,6 +84,8 @@ public class LibraryFragment extends Fragment implements ClickCallback {
         View view = bind.getRoot();
         libraryViewModel = new ViewModelProvider(requireActivity()).get(LibraryViewModel.class);
 
+        libraryViewModel.clearCacheIfMusicFolderChanged();
+
         init();
 
         return view;

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsContainerFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SettingsContainerFragment.java
@@ -27,6 +27,7 @@ import androidx.annotation.OptIn;
 import androidx.appcompat.app.AppCompatDelegate;
 import androidx.core.content.ContextCompat;
 import androidx.core.os.LocaleListCompat;
+import androidx.lifecycle.Observer;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.media3.common.util.UnstableApi;
 import androidx.media3.exoplayer.offline.DownloadService;
@@ -61,13 +62,16 @@ import com.cappielloantonio.tempo.ui.dialog.StarredSyncDialog;
 import com.cappielloantonio.tempo.ui.dialog.StreamingCacheStorageDialog;
 import com.cappielloantonio.tempo.util.ClickablePreferenceCategory;
 import com.cappielloantonio.tempo.util.DownloadUtil;
+import com.cappielloantonio.tempo.subsonic.models.MusicFolder;
 import com.cappielloantonio.tempo.util.ExternalAudioReader;
 import com.cappielloantonio.tempo.util.Preferences;
 import com.cappielloantonio.tempo.util.UIUtil;
 import com.cappielloantonio.tempo.viewmodel.SettingViewModel;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
@@ -87,6 +91,11 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
     private ActivityResultLauncher<Intent> equalizerResultLauncher;
 
     private final Set<String> expandedCategories = new HashSet<>();
+
+    private boolean musicFoldersObserved = false;
+
+    // Null until the server answers with its folder list.
+    private Integer musicFolderCount = null;
 
     @Override
     public void onCreate(@Nullable Bundle savedInstanceState) {
@@ -149,6 +158,7 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
 
         setStreamingCacheSize();
         setAppLanguage();
+        setMusicLibrary();
         setVersion();
         setNetorkPingTimeoutBase();
 
@@ -172,6 +182,15 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
         actionReplayGainPreamp();
 
         applyAccordionState();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+
+        // The flag means "this view already has the observer", and a child fragment can outlive
+        // its parent's view, so it has to be cleared with the view rather than the instance.
+        musicFoldersObserved = false;
     }
 
     @Override
@@ -303,6 +322,7 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
         checkDownloadDirectory();
         checkEqualizerBands();
         checkDarkThemeStyle();
+        checkMusicLibrary();
 
         for (int i = 0; i < screen.getPreferenceCount(); i++) {
             Preference pref = screen.getPreference(i);
@@ -478,6 +498,117 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
             }
             return true;
         });
+    }
+
+    private void setMusicLibrary() {
+        ListPreference libraryPref = (ListPreference) findPreference("active_music_folder_id");
+        if (libraryPref == null) return;
+
+        // Opening a ListPreference whose entries are still null throws, and the server folders are
+        // asynchronous and may never arrive, so seed the one entry that needs no server.
+        if (libraryPref.getEntries() == null) {
+            libraryPref.setEntries(new CharSequence[]{getString(R.string.settings_music_library_all)});
+            libraryPref.setEntryValues(new CharSequence[]{Preferences.MUSIC_FOLDER_ALL});
+        }
+
+        // The widget's own key is shared by every server, so left alone it would show whichever
+        // library was picked last, anywhere. Load this server's choice in so the screen cannot
+        // claim a filter that is not being applied.
+        String activeMusicFolderId = Preferences.getActiveMusicFolderId();
+        libraryPref.setValue(activeMusicFolderId != null ? activeMusicFolderId : Preferences.MUSIC_FOLDER_ALL);
+
+        setMusicLibrarySummary(libraryPref);
+
+        libraryPref.setOnPreferenceChangeListener((preference, newValue) -> {
+            libraryPref.setValue((String) newValue);
+            Preferences.setActiveMusicFolderId((String) newValue);
+            setMusicLibrarySummary(libraryPref);
+            return true;
+        });
+
+        // onResume runs this on every return, and the call below is what fires the request, so ask
+        // once per view. A failed load is then not retried until the screen is left and reopened,
+        // which beats enqueueing another request and observer on every resume while a server is down.
+        if (musicFoldersObserved) return;
+        musicFoldersObserved = true;
+
+        settingViewModel.getMusicFolders(getViewLifecycleOwner()).observe(getViewLifecycleOwner(), musicFolderObserver);
+    }
+
+    private final Observer<List<MusicFolder>> musicFolderObserver = new Observer<List<MusicFolder>>() {
+        @Override
+        public void onChanged(List<MusicFolder> folders) {
+            ListPreference libraryPref = (ListPreference) findPreference("active_music_folder_id");
+            if (libraryPref == null || folders == null) return;
+
+            List<CharSequence> entries = new ArrayList<>();
+            List<CharSequence> entryValues = new ArrayList<>();
+
+            entries.add(getString(R.string.settings_music_library_all));
+            entryValues.add(Preferences.MUSIC_FOLDER_ALL);
+
+            List<String> ids = new ArrayList<>();
+            for (MusicFolder folder : folders) {
+                if (folder.getId() == null) continue;
+                ids.add(folder.getId());
+                entries.add(folder.getName() != null ? folder.getName() : folder.getId());
+                entryValues.add(folder.getId());
+            }
+
+            libraryPref.setEntries(entries.toArray(new CharSequence[0]));
+            libraryPref.setEntryValues(entryValues.toArray(new CharSequence[0]));
+
+            // A library removed, or one this account can no longer see, leaves a stale id that
+            // would filter everything away. Discarding the choice is permanent though, so it takes
+            // positive evidence: other libraries came back and this one was not among them. An
+            // empty response is not that, and a server offering none shows nothing either way.
+            String storedMusicFolderId = Preferences.getActiveMusicFolderId();
+            if (storedMusicFolderId != null && !ids.isEmpty() && !ids.contains(storedMusicFolderId)) {
+                libraryPref.setValue(Preferences.MUSIC_FOLDER_ALL);
+                Preferences.setActiveMusicFolderId(null);
+            }
+
+            musicFolderCount = ids.size();
+            applyAccordionState();
+
+            setMusicLibrarySummary(libraryPref);
+        }
+    };
+
+    /**
+     * Below two libraries there is nothing to choose between, so the setting is noise.
+     *
+     * Call applyAccordionState rather than this, including from the folder response. That method
+     * resets every category child to visible, runs these checks, and only then re-hides the
+     * children of collapsed categories. Calling this alone performs only the middle step, so a row
+     * it reveals would stay showing under a category the user has collapsed.
+     */
+    private void checkMusicLibrary() {
+        Preference libraryPref = findPreference("active_music_folder_id");
+        if (libraryPref == null) return;
+
+        // Visible while a filter is in force, since hiding it would remove the only way to clear
+        // one. Also visible on a null count, which means the server has not answered yet or at all:
+        // showing a control with nothing to choose between beats hiding one that was needed.
+        libraryPref.setVisible(musicFolderCount == null
+                || musicFolderCount > 1
+                || Preferences.getActiveMusicFolderId() != null);
+    }
+
+    private void setMusicLibrarySummary(ListPreference libraryPref) {
+        CharSequence entry = libraryPref.getEntry();
+        if (entry != null) {
+            libraryPref.setSummary(entry);
+            return;
+        }
+
+        // getEntry() is null while the value is not among the entries: the folder list has not
+        // arrived, or it arrived without enough evidence to clear a stale id. Saying "all
+        // libraries" would contradict what is still being sent, so name the id, poorly as it reads.
+        String activeMusicFolderId = Preferences.getActiveMusicFolderId();
+        libraryPref.setSummary(activeMusicFolderId != null
+                ? activeMusicFolderId
+                : getString(R.string.settings_music_library_all));
     }
 
     private void setVersion() {

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -123,6 +123,9 @@ object Preferences {
     private const val AA_SHUFFLE_STARRED_TRACKS = "androidauto_shuffle_starred_tracks"
     private const val AA_SHUFFLE_PLAYLISTS = "androidauto_shuffle_playlists"
     private const val AA_SHUFFLE_DOWNLOADED_TRACKS = "androidauto_shuffle_downloaded_tracks"
+    private const val ACTIVE_MUSIC_FOLDER_ID = "active_music_folder_id"
+
+    const val MUSIC_FOLDER_ALL = "default"
 
 	@JvmStatic
     fun getServer(): String? {
@@ -132,6 +135,36 @@ object Preferences {
     @JvmStatic
     fun setServer(server: String?) {
         App.getInstance().preferences.edit().putString(SERVER, server).apply()
+    }
+
+    /**
+     * A folder id means nothing on a server that did not issue it, so each server keeps its own.
+     *
+     * [ACTIVE_MUSIC_FOLDER_ID] stays the ListPreference's key and holds only what that widget is
+     * displaying. It is a separate store, and the two agree only because the settings screen
+     * copies this value into the widget on every resume.
+     */
+    private fun activeMusicFolderKey(): String? {
+        val serverId = getServerId() ?: return null
+        return ACTIVE_MUSIC_FOLDER_ID + "_" + serverId
+    }
+
+    /**
+     * Null means every library, the default and the behaviour before this setting existed. The
+     * ListPreference stores the sentinel "default" for it, same as the language preference.
+     */
+    @JvmStatic
+    fun getActiveMusicFolderId(): String? {
+        val key = activeMusicFolderKey() ?: return null
+        val stored = App.getInstance().preferences.getString(key, MUSIC_FOLDER_ALL)
+        return if (stored == null || stored == MUSIC_FOLDER_ALL) null else stored
+    }
+
+    @JvmStatic
+    fun setActiveMusicFolderId(musicFolderId: String?) {
+        val key = activeMusicFolderKey() ?: return
+        App.getInstance().preferences.edit()
+            .putString(key, musicFolderId ?: MUSIC_FOLDER_ALL).apply()
     }
 
     @JvmStatic

--- a/app/src/main/java/com/cappielloantonio/tempo/viewmodel/HomeViewModel.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/viewmodel/HomeViewModel.java
@@ -37,6 +37,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Objects;
 
 public class HomeViewModel extends AndroidViewModel {
     private static final String TAG = "HomeViewModel";
@@ -72,6 +73,8 @@ public class HomeViewModel extends AndroidViewModel {
     private final MutableLiveData<List<Share>> shares = new MutableLiveData<>(null);
 
     private List<HomeSector> sectors;
+
+    private String cachedMusicFolderId = Preferences.getActiveMusicFolderId();
 
     public HomeViewModel(@NonNull Application application) {
         super(application);
@@ -303,6 +306,28 @@ public class HomeViewModel extends AndroidViewModel {
         }
 
         chronologyRepository.getChronology(server, start, end).observe(owner, thisGridTopSong::postValue);
+    }
+
+    /**
+     * The cached samples were fetched under whichever library was active then, so they go stale
+     * when it changes. Clearing them lets the getters' null guards refetch on the next view creation.
+     *
+     * Starred data stays by choice, not because it cannot be filtered: getStarred2 does take
+     * musicFolderId. getPlaylists does not, and scoping one hand built collection but not the other
+     * would behave differently for no reason a user can see.
+     */
+    public void clearCacheIfMusicFolderChanged() {
+        String activeMusicFolderId = Preferences.getActiveMusicFolderId();
+        if (Objects.equals(activeMusicFolderId, cachedMusicFolderId)) return;
+
+        cachedMusicFolderId = activeMusicFolderId;
+
+        dicoverSongSample.setValue(null);
+        newReleasedAlbum.setValue(null);
+        mostPlayedAlbumSample.setValue(null);
+        recentlyPlayedAlbumSample.setValue(null);
+        recentlyAddedAlbumSample.setValue(null);
+        years.setValue(null);
     }
 
     public void refreshDiscoverySongSample(LifecycleOwner owner) {

--- a/app/src/main/java/com/cappielloantonio/tempo/viewmodel/LibraryViewModel.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/viewmodel/LibraryViewModel.java
@@ -19,8 +19,10 @@ import com.cappielloantonio.tempo.subsonic.models.Genre;
 import com.cappielloantonio.tempo.subsonic.models.Indexes;
 import com.cappielloantonio.tempo.subsonic.models.MusicFolder;
 import com.cappielloantonio.tempo.subsonic.models.Playlist;
+import com.cappielloantonio.tempo.util.Preferences;
 
 import java.util.List;
+import java.util.Objects;
 
 public class LibraryViewModel extends AndroidViewModel {
     private static final String TAG = "LibraryViewModel";
@@ -38,6 +40,8 @@ public class LibraryViewModel extends AndroidViewModel {
     private final MutableLiveData<List<ArtistID3>> sampleArtist = new MutableLiveData<>(null);
     private final MutableLiveData<List<Genre>> sampleGenres = new MutableLiveData<>(null);
 
+    private String cachedMusicFolderId = Preferences.getActiveMusicFolderId();
+
     public LibraryViewModel(@NonNull Application application) {
         super(application);
 
@@ -46,6 +50,20 @@ public class LibraryViewModel extends AndroidViewModel {
         artistRepository = new ArtistRepository();
         genreRepository = new GenreRepository();
         playlistRepository = new PlaylistRepository();
+    }
+
+    /**
+     * Same reasoning as HomeViewModel. Genres, playlists and the folder list take no folder id, so
+     * they stay.
+     */
+    public void clearCacheIfMusicFolderChanged() {
+        String activeMusicFolderId = Preferences.getActiveMusicFolderId();
+        if (Objects.equals(activeMusicFolderId, cachedMusicFolderId)) return;
+
+        cachedMusicFolderId = activeMusicFolderId;
+
+        sampleAlbum.setValue(null);
+        sampleArtist.setValue(null);
     }
 
     public LiveData<List<MusicFolder>> getMusicFolders(LifecycleOwner owner) {

--- a/app/src/main/java/com/cappielloantonio/tempo/viewmodel/SettingViewModel.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/viewmodel/SettingViewModel.java
@@ -4,19 +4,38 @@ import android.app.Application;
 
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
 
 import com.cappielloantonio.tempo.interfaces.ScanCallback;
+import com.cappielloantonio.tempo.repository.DirectoryRepository;
 import com.cappielloantonio.tempo.repository.ScanRepository;
+import com.cappielloantonio.tempo.subsonic.models.MusicFolder;
+
+import java.util.List;
 
 public class SettingViewModel extends AndroidViewModel {
     private static final String TAG = "SettingViewModel";
 
     private final ScanRepository scanRepository;
+    private final DirectoryRepository directoryRepository;
+
+    private final MutableLiveData<List<MusicFolder>> musicFolders = new MutableLiveData<>(null);
 
     public SettingViewModel(@NonNull Application application) {
         super(application);
 
         scanRepository = new ScanRepository();
+        directoryRepository = new DirectoryRepository();
+    }
+
+    public LiveData<List<MusicFolder>> getMusicFolders(LifecycleOwner owner) {
+        if (musicFolders.getValue() == null) {
+            directoryRepository.getMusicFolders().observe(owner, musicFolders::postValue);
+        }
+
+        return musicFolders;
     }
 
     public void launchScan(ScanCallback callback) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -528,6 +528,8 @@
     <string name="settings_rounded_corner_size_summary">Sets the magnitude of the curvature angle.</string>
     <string name="settings_rounded_corner_summary">If enabled, sets a curvature angle for all rendered covers. The changes will take effect on restart.</string>
     <string name="settings_scan_title">Scan library</string>
+    <string name="settings_music_library">Music library</string>
+    <string name="settings_music_library_all">All libraries</string>
     <string name="settings_scrobble_title">Enable music scrobbling</string>
     <string name="settings_system_language">System language</string>
     <string name="settings_share_title">Enable music sharing</string>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -9,6 +9,13 @@
             android:key="scan_library"
             android:title="@string/settings_scan_title" />
 
+        <ListPreference
+            android:layout_height="wrap_content"
+            app:defaultValue="default"
+            app:dialogTitle="@string/settings_music_library"
+            app:key="active_music_folder_id"
+            app:title="@string/settings_music_library" />
+
         <EditTextPreference
             android:key="network_ping_timeout_base"
             android:title="@string/settings_ping_timeout_title"


### PR DESCRIPTION
Fixes #169.

Servers can expose several music folders and Tempus merges them all into one view. The reporter keeps a lossless library plus an MP3 mirror of the same music for another tool, so every album appears twice and nothing says which copy is which.

@marcdjulien asked for this to be built on `getMusicFolders`, which is what it uses.

## What this adds

One preference under **General**, listing the folders the server reports, plus an **All libraries** option that keeps today's behaviour and stays the default.

It hides itself when the server reports fewer than two libraries, since there is nothing to choose between and the settings screen already carries 98 rows. It stays visible whenever a selection is actually in force, so a filter can always be cleared even if the libraries behind it are gone.

| Before | After | Picking a library |
|---|---|---|
| <img width="230" src="https://github.com/user-attachments/assets/7cecedb3-8800-4ad8-bb8b-78d74f5d0842"> | <img width="230" src="https://github.com/user-attachments/assets/0710702b-7b39-443f-b39b-8e18aaf9b3cf"> | <img width="230" src="https://github.com/user-attachments/assets/c48cadd1-fed2-42ea-ae00-ca81900c4863"> |

The issue asks to hide libraries and this is phrased as a switcher. With two libraries those are the same thing, since selecting one hides the other. Multiple selection only begins to differ at three or more and costs a custom dialog, so this solves what the issue describes.

## How it works

The selected id goes to `getArtists`, `getAlbumList2`, `getRandomSongs`, `getSongsByGenre` and `search3`, the endpoints the API accepts it on. It is read inside the API client wrappers, so no repository or view model call site changes, and Retrofit omits a null query parameter, so All libraries sends exactly the request sent before this existed. Home and Library cache their sections in view models that outlive navigation, so both record which library their cache belongs to and clear it when that changes.

A folder id only means something on the server that issued it, so each server keeps its own choice under its own key. Nothing has to notice a server changing, and ids cannot collide across servers even though servers hand out small numbers that repeat.

A library removed on the same server, or one this account loses access to, is caught separately, when the preference loads its list and falls back to All libraries. Discarding the choice is permanent, so it takes positive evidence: other libraries came back and this one was not among them. A server reporting no libraries shows nothing whether or not an id is sent, so clearing the setting there would cost something and prevent nothing.

The preference is created already carrying its All libraries entry rather than waiting for the server list, because a `ListPreference` whose entries are still null throws when its dialog opens.

## What is not scoped, and why
**Starred content**, which is a choice rather than a limit. `getStarred2` takes `musicFolderId` in the Subsonic spec from 1.12.0, this client declares 1.15.0, and Navidrome, gonic and both Airsonic forks honour it, so the option is real on every server worth caring about.

Clients are split on taking it. Supersonic and Feishin scope favorites to the selected library. Sonixd made it a per screen choice and shipped with favorites off. Ultrasonic leaves them whole.

Left unscoped there is no broken state. Playback takes only a track id, so a favorite from a library that is not selected still appears and still plays. Scoping it creates the one state with no good reading, a hand curated list suddenly half its length, which is hard to tell from lost data. `getPlaylists` takes no folder id at all, so playlists stay whole either way, and scoping one of the two collections a user built by hand but not the other is a difference with nothing behind it.

**Playlists**, which have no folder id in the API. **`getIndexes`**, which already took one of its own, so the Library screen's music folder section is untouched.

**Genres are the awkward one.** `getGenres` takes no folder id, so the genre list stays whole, but the songs behind a genre come from `getRandomSongs` and `getSongsByGenre`, which are scoped. With a library selected you can therefore open a genre that holds nothing in it and get an empty page. Scoping the list itself would cost a request per genre to find out which ones still have anything, which seemed worse than the empty page. The Library screen's music folder section has the same shape: it still lists every folder and browsing into one ignores the setting, which is deliberate, since that section is the existing way to look inside a specific folder.

## Verification

The existing 18 unit tests pass. This adds none: the only piece worth isolating had shrunk to a single list containment check, so it lives inline at its one call site rather than behind a helper. Everything else here needs a running app, so it was checked on one.

On an emulator against a live server, confirmed against the server rather than by eye, since the album row is a random sample: the folder used for the test holds three albums and every album shown while scoped to it came from those three. Search, the catalogues and Home scope the same way, and switching back restores everything without a restart. Signing out and back in to the same server keeps the selection; signing in to a different one browses unfiltered.

The crash guard was confirmed by removing it, rebuilding and repeating the same taps with the network off: `IllegalStateException: ListPreference requires an entries array` and the process dies. With it, the dialog opens on All libraries.

Android Auto follows the setting with no extra work, since its browse tree caches only labels and fetches content through the same clients.

On a server with a single music folder the preference offers All libraries and that one folder, so nothing changes. With All libraries selected the requests are byte for byte the ones sent before this existed, since Retrofit omits a null query parameter.

## Known gaps

- **Playback can leave the selected library.** Instant mix, similar songs and top songs take no folder id in the API, so a queue built from them can pull from a library that is not selected. Nothing in the spec fixes that today, and it is the most common complaint reported against this feature in other clients rather than a theoretical one.
- **The control lives only in Settings.** Other clients put it on a screen the user browses, which is also where they notice it is on. Doing that here means new UI, so it is not in this change, but it is the obvious next step: every client with this feature reports users forgetting the filter is active and assuming the app broke.
- **Deleting a server and adding it back loses that server's choice**, since it mints a new id and the old key is left behind.
- The two new strings have no entries in the other locales yet.
- This overlaps #136, which asks for filtering by library on other screens. This does the app wide scoping part; per screen filtering would sit on top of the same preference.


