### PR TITLE
fix: NullPointerException in Subsonic.java (#953) \

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/subsonic/Subsonic.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/subsonic/Subsonic.java
@@ -146,12 +146,15 @@ public class Subsonic {
         Map<String, String> params = new HashMap<>();
         params.put("u", preferences.getUsername());
 
-        if (preferences.getAuthentication().getPassword() != null)
-            params.put("p", preferences.getAuthentication().getPassword());
-        if (preferences.getAuthentication().getSalt() != null)
-            params.put("s", preferences.getAuthentication().getSalt());
-        if (preferences.getAuthentication().getToken() != null)
-            params.put("t", preferences.getAuthentication().getToken());
+        SubsonicPreferences.SubsonicAuthentication auth = preferences.getAuthentication();
+        if (auth != null) {
+            if (auth.getPassword() != null)
+                params.put("p", auth.getPassword());
+            if (auth.getSalt() != null)
+                params.put("s", auth.getSalt());
+            if (auth.getToken() != null)
+                params.put("t", auth.getToken());
+        }
 
         params.put("v", getApiVersion().getVersionString());
         params.put("c", preferences.getClientName());


### PR DESCRIPTION
resolves #953 

  ## Root Cause

  NullPointerException in Subsonic.java at line 149.

  ### Crash path

    MainActivity.onStart()
      → initService() + fragment restored from saved state
          → PlayerBottomSheetFragment.onCreateView()
              → setHeaderBookmarksButton()          [line 70]
    		  → ViewModel.getPlayQueue()         [line 286]
                      → QueueRepository.getPlayQueue()
                          → App.getSubsonicClientInstance(false)
                              → Subsonic.getParams()
                                  → preferences.getAuthentication().getPassword()  💥 NPE

  ### Why it only started in v4.23.0

  The TransactionTooLargeException fix (PR #863) added MainActivity.onSaveInstanceState logic that preserves or clears fragment back-stack state. On upgrade, Android OS can now restore
  the full fragment stack from the previous session — including PlayerBottomSheetFragment — before the user logs in or their credentials are re-loaded.

  In SubsonicPreferences.java, the authentication field is only set if at least one credential is non-null. If SharedPreferences yields all-null credentials (fresh install scenario,
  corrupted prefs after upgrade), authentication stays null — and the old code called .getPassword() on that null reference without a guard.

  ## The Fix

  In Subsonic.java, getParams() now locally captures getAuthentication() and wraps all credential puts in a single auth != null guard:

    -        if (preferences.getAuthentication().getPassword() != null)
    -            params.put("p", preferences.getAuthentication().getPassword());
    -        if (preferences.getAuthentication().getSalt() != null)
    -            params.put("s", preferences.getAuthentication().getSalt());
    -        if (preferences.getAuthentication().getToken() != null)
    -            params.put("t", preferences.getAuthentication().getToken());
    +        SubsonicPreferences.SubsonicAuthentication auth = preferences.getAuthentication();
    +        if (auth != null) {
    +            if (auth.getPassword() != null)
    +                params.put("p", auth.getPassword());
    +            if (auth.getSalt() != null)
    +                params.put("s", auth.getSalt());
    +            if (auth.getToken() != null)
    +                params.put("t", auth.getToken());
    +        }

  This also avoids calling getAuthentication() 6 times — the result is captured once. When credentials are missing, getPlayQueue() will gracefully return an empty/null response instead
  of crashing the app on startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication handling to prevent errors when authentication details are unavailable.
  * Authentication parameters are now included only when valid values are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->