### PR TITLE
fix: add Basque (eu) to locale_config.xml

### DIFF
--- a/app/src/main/res/xml/locale_config.xml
+++ b/app/src/main/res/xml/locale_config.xml
@@ -15,4 +15,5 @@
     <locale android:name="tr-TR"/>         <!-- Turkish -->
     <locale android:name="ca"/>            <!-- Catalan -->
     <locale android:name="ro"/>            <!-- Romanian -->
+    <locale android:name="eu"/>            <!-- Basque (Euskara) -->
 </locale-config>


### PR DESCRIPTION
Basque strings were added in #928 but locale_config.xml was never updated, so the language picker (Settings -> UI -> Language) never listed Basque as a selectable option even though the translations themselves work fine when the system locale is already Basque.

Fixes #958

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Basque as a supported app language on Android devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->