### PR TITLE
fix: stop the 4.23 upgrade wiping downloads, and restore them for users already hit

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/database/AppDatabase.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/database/AppDatabase.java
@@ -63,6 +63,7 @@ import com.cappielloantonio.tempo.subsonic.models.Playlist;
                 @AutoMigration(from = 17, to = 18),
                 @AutoMigration(from = 18, to = 19),
                 @AutoMigration(from = 19, to = 20),
+                @AutoMigration(from = 20, to = 21),
         }
 )
 @TypeConverters({DateConverters.class, StringListConverter.class})

--- a/app/src/main/java/com/cappielloantonio/tempo/database/dao/DownloadDao.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/database/dao/DownloadDao.java
@@ -27,6 +27,9 @@ public interface DownloadDao {
     @Insert(onConflict = OnConflictStrategy.REPLACE)
     void insertAll(List<Download> downloads);
 
+    @Insert(onConflict = OnConflictStrategy.IGNORE)
+    void insertAllKeepingExisting(List<Download> downloads);
+
     @Query("UPDATE download SET download_state = 1 WHERE id = :id")
     void update(String id);
 

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/activity/MainActivity.java
@@ -58,6 +58,7 @@ import com.cappielloantonio.tempo.ui.fragment.PlayerBottomSheetFragment;
 import com.cappielloantonio.tempo.util.AssetLinkNavigator;
 import com.cappielloantonio.tempo.util.AssetLinkUtil;
 import com.cappielloantonio.tempo.util.Constants;
+import com.cappielloantonio.tempo.util.DownloadRepair;
 import com.cappielloantonio.tempo.util.Preferences;
 import com.cappielloantonio.tempo.viewmodel.MainViewModel;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
@@ -148,6 +149,8 @@ public class MainActivity extends BaseActivity {
         checkConnectionType();
         getOpenSubsonicExtensions();
         checkTempoUpdate();
+
+        DownloadRepair.repairIfNeeded(this);
 
         maybeSchedulePlaybackIntent(getIntent());
     }

--- a/app/src/main/java/com/cappielloantonio/tempo/util/DownloadRepair.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/DownloadRepair.java
@@ -1,0 +1,308 @@
+package com.cappielloantonio.tempo.util;
+
+import android.content.Context;
+import android.net.Uri;
+import android.util.Log;
+
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.exoplayer.offline.DownloadCursor;
+import androidx.media3.exoplayer.offline.DownloadIndex;
+import androidx.media3.exoplayer.offline.DownloadRequest;
+
+import com.cappielloantonio.tempo.App;
+import com.cappielloantonio.tempo.database.AppDatabase;
+import com.cappielloantonio.tempo.database.dao.DownloadDao;
+import com.cappielloantonio.tempo.model.Download;
+import com.cappielloantonio.tempo.subsonic.base.ApiResponse;
+import com.cappielloantonio.tempo.subsonic.Subsonic;
+import com.cappielloantonio.tempo.subsonic.models.Child;
+import com.cappielloantonio.tempo.subsonic.models.ResponseStatus;
+import com.cappielloantonio.tempo.subsonic.models.SubsonicResponse;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import retrofit2.Response;
+
+/**
+ * Rebuilds the download table from the ExoPlayer download index.
+ *
+ * A version bump shipped without a matching migration, so upgrading from 4.22.x dropped every table
+ * in tempo_db. The audio and the ExoPlayer index that tracks it are a separate store and survived,
+ * leaving files on disk and an empty Download page. The index is keyed by the same song id the
+ * download table uses, so any id present there and missing here is fetched from the server again.
+ *
+ * Recorded as done when the server answered for every song it was asked about and at least one row
+ * came back. A pass that restores nothing is tried again on a later launch, up to MAX_ATTEMPTS,
+ * because the likeliest cause is being pointed at the wrong server rather than a library that truly
+ * lost every track the device still holds. After that it stops, so a user it can never help does not
+ * pay for the scan forever.
+ *
+ * Two gaps. Song ids are unique only within one server, so downloads from two servers with small
+ * integer ids can put one server's title on a row that plays the other's file. And restored rows
+ * carry no playlist, because nothing on the device records which playlist a download came from.
+ */
+@UnstableApi
+public class DownloadRepair {
+    private static final String TAG = "DownloadRepair";
+
+    // ErrorCode holds this, but its companion members are plain vars, so they are not usable as a
+    // Java constant without going through Companion.
+    private static final int DATA_NOT_FOUND = 70;
+
+    private static final int BATCH_SIZE = 50;
+
+    private static final int ABORT_AFTER_FAILURES = 3;
+
+    private static final int MAX_ATTEMPTS = 3;
+
+    private static final AtomicBoolean RUNNING = new AtomicBoolean(false);
+
+    private DownloadRepair() {
+    }
+
+    public static void repairIfNeeded(Context context) {
+        if (!RUNNING.compareAndSet(false, true)) return;
+
+        Context applicationContext = context.getApplicationContext();
+
+        new Thread(() -> {
+            try {
+                repair(applicationContext);
+            } catch (Exception exception) {
+                Log.w(TAG, "Download repair failed", exception);
+            } finally {
+                RUNNING.set(false);
+            }
+        }, "DownloadRepair").start();
+    }
+
+    private static void repair(Context context) {
+        // Not in repairIfNeeded: reaching this opens the database, and that caller is the main thread.
+        int schemaVersion = AppDatabase.getInstance().getOpenHelper().getReadableDatabase().getVersion();
+
+        if (Preferences.getRepairedDownloadDatabaseVersion() == schemaVersion) return;
+        if (!isUserAuthenticated()) return;
+
+        List<CachedDownload> cached = readCachedDownloads(context);
+        if (cached == null) return;
+
+        DownloadDao downloadDao = AppDatabase.getInstance().downloadDao();
+
+        List<CachedDownload> missing = new ArrayList<>();
+        for (CachedDownload entry : cached) {
+            if (downloadDao.getOne(entry.id) == null) missing.add(entry);
+        }
+
+        if (missing.isEmpty()) {
+            markRepaired(schemaVersion);
+            return;
+        }
+
+        // Resolved once, so switching servers mid pass cannot retarget the remaining songs.
+        Subsonic subsonic = App.getSubsonicClientInstance(false);
+
+        List<Download> batch = new ArrayList<>();
+        int restored = 0;
+        int consecutiveFailures = 0;
+        boolean retryLater = false;
+
+        try {
+            for (CachedDownload entry : missing) {
+                Child song;
+
+                try {
+                    song = fetchSong(subsonic, entry.id);
+                    consecutiveFailures = 0;
+                } catch (IOException exception) {
+                    // One failure says nothing about the next song, so keep going. A run of them is
+                    // the server rather than the songs, and the rest of the list would only buy a
+                    // request timeout each.
+                    retryLater = true;
+
+                    if (++consecutiveFailures < ABORT_AFTER_FAILURES) {
+                        Log.w(TAG, "Skipped " + entry.id, exception);
+                        continue;
+                    }
+
+                    Log.w(TAG, "Stopped the repair, " + consecutiveFailures + " failures in a row", exception);
+                    return;
+                }
+
+                // Gone as far as this server is concerned.
+                if (song == null) {
+                    Log.d(TAG, "Skipped " + entry.id + ": the server no longer has it");
+                    continue;
+                }
+
+                // The row is keyed by the returned id, which the index would never match again.
+                if (!entry.id.equals(song.getId())) {
+                    Log.w(TAG, "Skipped " + entry.id + ": the server answered with id " + song.getId());
+                    continue;
+                }
+
+                Download download = new Download(song);
+                download.setDownloadState(1);
+                download.setDownloadUri(entry.uri);
+                applyTranscodeFromUri(download, entry.uri);
+
+                batch.add(download);
+
+                // Batched because the Downloads screen redraws on every insert.
+                if (batch.size() >= BATCH_SIZE) restored += flush(context, downloadDao, batch);
+            }
+        } finally {
+            // So an abort, or a throw nothing here predicts, still commits what was fetched.
+            restored += flush(context, downloadDao, batch);
+            Log.d(TAG, "Restored " + restored + " of " + missing.size() + " download rows");
+        }
+
+        if (retryLater) return;
+
+        if (restored > 0) {
+            markRepaired(schemaVersion);
+            return;
+        }
+
+        // Nothing came back. Worth another launch or two in case this was the wrong server, but not
+        // worth a full scan and a request per song on every launch for the rest of time.
+        int attempts = Preferences.getDownloadRepairAttempts() + 1;
+        Preferences.setDownloadRepairAttempts(attempts);
+
+        if (attempts >= MAX_ATTEMPTS) markRepaired(schemaVersion);
+    }
+
+    /**
+     * A row can wait in the batch for many round trips, and the user can act on the Downloads screen
+     * meanwhile, so the checks belong here rather than next to the fetch.
+     */
+    private static int flush(Context context, DownloadDao downloadDao, List<Download> batch) {
+        if (batch.isEmpty()) return 0;
+
+        List<Download> writable = new ArrayList<>();
+
+        for (Download download : batch) {
+            if (downloadDao.getOne(download.getId()) != null) continue;
+            if (!DownloadUtil.getDownloadTracker(context).isDownloaded(download.getId())) continue;
+
+            writable.add(download);
+        }
+
+        batch.clear();
+
+        if (writable.isEmpty()) return 0;
+
+        // Never overwrite: a row written since the check carries a live state and a playlist.
+        downloadDao.insertAllKeepingExisting(writable);
+
+        return writable.size();
+    }
+
+    // The schema version rather than a flag, so a later version repeating this finds it armed.
+    private static void markRepaired(int schemaVersion) {
+        Preferences.setDownloadDatabaseRepaired(schemaVersion);
+    }
+
+    private static boolean isUserAuthenticated() {
+        return Preferences.getPassword() != null
+                || (Preferences.getToken() != null && Preferences.getSalt() != null);
+    }
+
+    // Null when the index cannot be read: a reason to retry, not an empty result to act on.
+    private static List<CachedDownload> readCachedDownloads(Context context) {
+        DownloadIndex index = DownloadUtil.getDownloadManager(context).getDownloadIndex();
+
+        List<CachedDownload> cached = new ArrayList<>();
+
+        try (DownloadCursor cursor = index.getDownloads(androidx.media3.exoplayer.offline.Download.STATE_COMPLETED)) {
+            while (cursor.moveToNext()) {
+                androidx.media3.exoplayer.offline.Download download = cursor.getDownload();
+
+                // An index entry can outlive its bytes, and that row would claim a file that is gone.
+                if (download.getBytesDownloaded() <= 0) continue;
+
+                DownloadRequest request = download.request;
+                cached.add(new CachedDownload(request.id, request.uri.toString()));
+            }
+        } catch (Exception exception) {
+            Log.w(TAG, "Failed to read the download index", exception);
+            return null;
+        }
+
+        return cached;
+    }
+
+    /**
+     * Null means the server says the song is gone, which no later attempt improves on. Everything
+     * else throws, because an unreadable answer looks exactly like a deleted track from here, and a
+     * pass that restores anything at all is recorded as done, taking those songs down with it.
+     */
+    private static Child fetchSong(Subsonic subsonic, String id) throws IOException {
+        Response<ApiResponse> response = subsonic
+                .getBrowsingClient()
+                .getSong(id)
+                .execute();
+
+        // An HTTP level refusal is about the connection or the credentials, not this song.
+        if (!response.isSuccessful()) {
+            throw new IOException("getSong for " + id + " returned HTTP " + response.code());
+        }
+
+        if (response.body() == null) {
+            throw new IOException("getSong for " + id + " returned an empty body");
+        }
+
+        SubsonicResponse subsonicResponse = response.body().getSubsonicResponse();
+
+        if (subsonicResponse == null) {
+            throw new IOException("getSong for " + id + " returned no subsonic response");
+        }
+
+        if (ResponseStatus.FAILED.equals(subsonicResponse.getStatus())) {
+            com.cappielloantonio.tempo.subsonic.models.Error error = subsonicResponse.getError();
+
+            if (error == null || error.getCode() == null) {
+                throw new IOException("getSong for " + id + " failed without an error code");
+            }
+
+            if (error.getCode() == DATA_NOT_FOUND) return null;
+
+            throw new IOException("getSong for " + id + " failed with " + error.getCode()
+                    + " " + error.getMessage());
+        }
+
+        Child song = subsonicResponse.getSong();
+
+        if (song == null) {
+            throw new IOException("getSong for " + id + " succeeded without a song");
+        }
+
+        return song;
+    }
+
+    /**
+     * Same rewrite the live download path applies, but driven by the stored uri rather than the
+     * current preferences, because the uri records what was actually requested at download time.
+     */
+    private static void applyTranscodeFromUri(Download download, String downloadUri) {
+        Uri uri = Uri.parse(downloadUri);
+
+        // getQueryParameter refuses an opaque uri.
+        if (uri.isOpaque()) return;
+
+        MusicUtil.applyTranscodeMetadata(download, uri.getQueryParameter("format"),
+                uri.getQueryParameter("maxBitRate"));
+    }
+
+    private static class CachedDownload {
+        private final String id;
+        private final String uri;
+
+        private CachedDownload(String id, String uri) {
+            this.id = id;
+            this.uri = uri;
+        }
+    }
+}

--- a/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/MusicUtil.java
@@ -366,7 +366,14 @@ public class MusicUtil {
         if (!Preferences.preferTranscodedDownload() || Preferences.isServerPrioritizedInTranscodedDownload())
             return;
 
-        String format = getTranscodingFormatPreferenceForDownload();
+        applyTranscodeMetadata(download, getTranscodingFormatPreferenceForDownload(),
+                getBitratePreferenceForDownload());
+    }
+
+    // The same rewrite, for a caller that knows the format and ceiling a file was actually fetched
+    // with rather than the ones configured now.
+    public static void applyTranscodeMetadata(Download download, String format, String maxBitRate) {
+        if (download == null) return;
         if (format == null || format.equals("raw")) return;
 
         download.setSuffix(format);
@@ -379,7 +386,7 @@ public class MusicUtil {
         // maxBitRate is the configured ceiling; "0" means no limit, so the real bitrate is unknown.
         Integer bitrate = null;
         try {
-            int parsed = Integer.parseInt(getBitratePreferenceForDownload());
+            int parsed = Integer.parseInt(maxBitRate);
             if (parsed > 0) bitrate = parsed;
         } catch (NumberFormatException ignored) {
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
+++ b/app/src/main/java/com/cappielloantonio/tempo/util/Preferences.kt
@@ -47,6 +47,8 @@ object Preferences {
     private const val AUDIO_TRANSCODE_FORMAT_MOBILE = "audio_transcode_format_mobile"
     private const val WIFI_ONLY = "wifi_only"
     private const val DOWNLOAD_WIFI_ONLY = "download_wifi_only"
+    private const val DOWNLOAD_DATABASE_REPAIRED = "download_database_repaired_version"
+    private const val DOWNLOAD_REPAIR_ATTEMPTS = "download_repair_attempts"
     private const val DATA_SAVING_MODE = "data_saving_mode"
     private const val SERVER_UNREACHABLE = "server_unreachable"
     private const val SYNC_STARRED_ARTISTS_FOR_OFFLINE_USE = "sync_starred_artists_for_offline_use"
@@ -477,6 +479,26 @@ object Preferences {
     @JvmStatic
     fun setDownloadWifiOnly(enabled: Boolean) {
         App.getInstance().preferences.edit().putBoolean(DOWNLOAD_WIFI_ONLY, enabled).apply()
+    }
+
+    @JvmStatic
+    fun getRepairedDownloadDatabaseVersion(): Int {
+        return App.getInstance().preferences.getInt(DOWNLOAD_DATABASE_REPAIRED, 0)
+    }
+
+    @JvmStatic
+    fun setDownloadDatabaseRepaired(version: Int) {
+        App.getInstance().preferences.edit().putInt(DOWNLOAD_DATABASE_REPAIRED, version).apply()
+    }
+
+    @JvmStatic
+    fun getDownloadRepairAttempts(): Int {
+        return App.getInstance().preferences.getInt(DOWNLOAD_REPAIR_ATTEMPTS, 0)
+    }
+
+    @JvmStatic
+    fun setDownloadRepairAttempts(attempts: Int) {
+        App.getInstance().preferences.edit().putInt(DOWNLOAD_REPAIR_ATTEMPTS, attempts).apply()
     }
 
     @JvmStatic


### PR DESCRIPTION
Fixes #959

## Cause

`AppDatabase` went from `version = 20` to `21`, but `autoMigrations` stops at `@AutoMigration(from = 19, to = 20)` and the builder still calls `.fallbackToDestructiveMigration()`. With no path from 20 to 21, the first launch after upgrading from 4.22.x drops and recreates every table in `tempo_db`.

Most of that comes back from the server. The `download` table does not: it is the only record of which tracks a user pinned for offline use. The audio survives, because downloaded files sit in the ExoPlayer cache tracked by its own index, a separate store the migration never touches. That is why the reporter still sees the downloaded badge inside a playlist while the Download page shows nothing.

## Two commits

**1. Add `@AutoMigration(from = 20, to = 21)`.** One line. The schema change is a single added column, `playlist.lastPlayed`, notNull with a default of 0, and both schema JSON files are committed, so Room generates the migration itself.

That protects everyone still on 4.22.x. It cannot help anyone already on 4.23, whose tables were dropped before it existed, and rolling the release back does not reach them either.

**2. Rebuild the table from the ExoPlayer index.** `DownloadRepair` runs once at startup on a background thread and, for any completed index entry the `download` table no longer has, fetches the song and inserts the row again. The index is keyed by the same song id the table uses, which is what makes this possible at all.

## One thing to look at closely

**The uri is carried out of the index, never rebuilt from preferences.** It is the key the download cache is stored under, since nothing sets a `customCacheKey`. Rebuilt from current settings it becomes a different key for anyone whose transcoding options or server address changed since the download, and the restored row would then stream instead of playing the local copy. The transcode metadata comes from that same uri for the same reason.

The rest is guard rails: only entries with bytes on disk are restored, rows are rechecked immediately before writing and never overwrite an existing row, a run of server failures stops the pass early, and a pass that restores nothing retries a few launches then gives up rather than scanning forever.

Not covered: downloads written to a user chosen folder never reach the ExoPlayer index, so nothing here can rebuild them, and restored rows carry no playlist because the device holds no record of one.

## Testing

Reproduced first, then fixed, on an Android 16 emulator and a Galaxy S25 Ultra against Navidrome. The wipe was never simulated: every run installed a real 4.22.2 build, downloaded tracks, then installed the later build over the top.

| Run | Result |
|---|---|
| 4.22.2 to stock 4.23.1 | schema 20 to 21, 300 rows to 0, empty state on screen, index still 300 |
| 4.22.2 to this branch | all 300 rows survive, `lastPlayed` present, repair correctly finds nothing to do |
| Already wiped, index intact | 300 of 300 restored in 5.99s, every uri byte identical to the index |

About 20ms a song on device, with the activity on screen at 1.08s and never waiting on it. No crashes in any run.

The transcode branch has only ever run as a no op, because every test download was a raw `/rest/download` uri with no `format` parameter. Anyone reviewing with client side transcoding on would be covering ground I could not.