### PR TITLE
Fix a crash when the server reports no playlists

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/repository/PlaylistRepository.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/repository/PlaylistRepository.java
@@ -81,6 +81,9 @@ public class PlaylistRepository {
                     public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
                         if (response.isSuccessful() && response.body() != null && response.body().getSubsonicResponse().getPlaylists() != null) {
                             List<Playlist> playlists = response.body().getSubsonicResponse().getPlaylists().getPlaylists();
+                            if (playlists == null) {
+                                playlists = new ArrayList<>();
+                            }
                             allPlaylistsLiveData.postValue(playlists);
                             // cache all playlists
                             cacheAllPlaylists(playlists);
@@ -487,7 +490,7 @@ public class PlaylistRepository {
                         .enqueue(new Callback<ApiResponse>() {
                             @Override
                             public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
-                                if (response.isSuccessful() && response.body() != null && response.body().getSubsonicResponse().getPlaylists() != null) {
+                                if (response.isSuccessful() && response.body() != null && response.body().getSubsonicResponse().getPlaylists() != null && response.body().getSubsonicResponse().getPlaylists().getPlaylists() != null) {
                                     List<Playlist> remotes = response.body().getSubsonicResponse().getPlaylists().getPlaylists();
                                     new Thread(() -> {
                                         for (Playlist p : pinned) {


### PR DESCRIPTION
### What happens

Deleting your last playlist kills the app. The process dies outright instead of surfacing an error, because the failure happens on a bare thread with no handler.

From a debug build:

```
FATAL EXCEPTION: Thread-23
Process: com.eddyizm.degoogled.tempus.debug
java.lang.NullPointerException: Attempt to invoke interface method
'java.util.Iterator java.util.List.iterator()' on a null object reference
	at ...PlaylistRepository.lambda$cacheAllPlaylists$1(PlaylistRepository.java:104)
	at java.lang.Thread.run(Thread.java:1572)
```

### Why

Navidrome declares the inner list as `json:"playlist,omitempty"` inside a container its `getPlaylists` handler always assigns. With zero playlists the slice is empty, `omitempty` drops the key, and the response is:

```json
{"subsonic-response":{"status":"ok","playlists":{}}}
```

`Playlists.playlists` is nullable, so Gson leaves it null. `refreshAllPlaylists` checks the container but never the list inside it, and passes that null to `cacheAllPlaylists`, which iterates it.

There are three ways a server can report zero playlists, and only one of them crashed:

| Response | Inner list | Before this change |
|---|---|---|
| `"playlists":{}` | null | crash |
| `"playlists":{"playlist":[]}` | empty | worked |
| no `playlists` element | container null | already rejected by the existing check |

So this is not one server's quirk. Any server that omits the key hits it; any server that sends an empty array never did.

### The change

Normalize the absent list to an empty one where it is read. That is the idiom this file already uses for the entry list in `getPlaylistSongs` a few lines above. The orphan cleanup then runs with an empty remote set instead of dying, which is the right outcome when the server genuinely has none.

`updatePinnedPlaylists` reads the same field with the same missing check. Nothing calls it today so it cannot crash, but it is guarded to match the condition `getPlaylists` already uses.

### What this touches

One file, four lines added and one condition extended. Nothing changes for a response that already worked: an empty array took the same path before and takes it now.

### Verification

Reproduced and fixed against a stub Subsonic server that serves the empty container on demand, since reaching this state otherwise means deleting every playlist on a real server.

Before the change, on an emulator and on a physical device running Android 16: delete the last playlist, process dies, trace above.

After the change, same server and same steps on both: the process id is identical before and after, the crash buffer is empty, and the repository logs that it cached zero playlists, so the method ran to completion rather than being skipped. The list is empty afterwards with no stale row left behind.

### Noticed while reading, not changed here

`getPlaylists(boolean, int)` checks the inner list and skips the whole block when it is missing. On a server that omits the key that path never reaches the cleanup, while on a server that sends an empty array it does. Same state, two outcomes, decided only by how the server encoded it. Relaxing that check would change behavior on a live screen path, so this leaves it alone.

`deletePlaylist` removes the playlist and its songs from the local database but never unpins it, so a pinned playlist leaves a row behind.
