### PR TITLE
fix: guard app bar offset listeners against a null view binding

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumCatalogueFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumCatalogueFragment.java
@@ -130,6 +130,8 @@ public class AlbumCatalogueFragment extends Fragment implements ClickCallback {
 
 
         bind.appBarLayout.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
+            if (bind == null) return;
+
             if ((bind.albumInfoSector.getHeight() + verticalOffset) < (2 * ViewCompat.getMinimumHeight(bind.toolbar))) {
                 bind.toolbar.setTitle(R.string.album_catalogue_title);
             } else {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumListPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/AlbumListPageFragment.java
@@ -121,6 +121,8 @@ public class AlbumListPageFragment extends Fragment implements ClickCallback {
         });
 
         bind.appBarLayout.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
+            if (bind == null) return;
+
             if ((bind.albumInfoSector.getHeight() + verticalOffset) < (2 * ViewCompat.getMinimumHeight(bind.toolbar))) {
                 bind.toolbar.setTitle(R.string.album_list_page_title);
             } else {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistCatalogueFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistCatalogueFragment.java
@@ -107,6 +107,8 @@ public class ArtistCatalogueFragment extends Fragment implements ClickCallback {
 
 
         bind.appBarLayout.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
+            if (bind == null) return;
+
             if ((bind.artistInfoSector.getHeight() + verticalOffset) < (2 * ViewCompat.getMinimumHeight(bind.toolbar))) {
                 bind.toolbar.setTitle(R.string.artist_catalogue_title);
             } else {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistListPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/ArtistListPageFragment.java
@@ -101,6 +101,8 @@ public class ArtistListPageFragment extends Fragment implements ClickCallback {
         });
 
         bind.appBarLayout.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
+            if (bind == null) return;
+
             if ((bind.artistInfoSector.getHeight() + verticalOffset) < (2 * ViewCompat.getMinimumHeight(bind.toolbar))) {
                 bind.toolbar.setTitle(R.string.artist_list_page_title);
             } else {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/DirectoryFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/DirectoryFragment.java
@@ -154,10 +154,8 @@ public class DirectoryFragment extends Fragment implements ClickCallback {
             activity.getSupportActionBar().setDisplayShowHomeEnabled(true);
         }
 
-        if (bind != null) {
-            bind.toolbar.setNavigationOnClickListener(v -> activity.navController.navigateUp());
-            bind.directoryBackImageView.setOnClickListener(v -> activity.navController.navigateUp());
-        }
+        bind.toolbar.setNavigationOnClickListener(v -> activity.navController.navigateUp());
+        bind.directoryBackImageView.setOnClickListener(v -> activity.navController.navigateUp());
     }
 
     private void initDirectoryListView() {
@@ -168,6 +166,8 @@ public class DirectoryFragment extends Fragment implements ClickCallback {
         bind.directoryRecyclerView.setAdapter(musicDirectoryAdapter);
         directoryViewModel.loadMusicDirectory(getArguments().getString(Constants.MUSIC_DIRECTORY_ID)).observe(getViewLifecycleOwner(), directory -> {
             bind.appBarLayout.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
+                if (bind == null) return;
+
                 if ((bind.directoryInfoSector.getHeight() + verticalOffset) < (2 * ViewCompat.getMinimumHeight(bind.toolbar))) {
                     bind.toolbar.setTitle(directory.getName());
                 } else {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/FilterFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/FilterFragment.java
@@ -77,6 +77,8 @@ public class FilterFragment extends Fragment {
 
 
         bind.appBarLayout.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
+            if (bind == null) return;
+
             if ((bind.genreFilterInfoSector.getHeight() + verticalOffset) < (2 * ViewCompat.getMinimumHeight(bind.toolbar))) {
                 bind.toolbar.setTitle(R.string.filter_title);
             } else {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/GenreCatalogueFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/GenreCatalogueFragment.java
@@ -98,6 +98,8 @@ public class GenreCatalogueFragment extends Fragment implements ClickCallback {
         });
 
         bind.appBarLayout.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
+            if (bind == null) return;
+
             if ((bind.genreInfoSector.getHeight() + verticalOffset) < (2 * ViewCompat.getMinimumHeight(bind.toolbar))) {
                 bind.toolbar.setTitle(R.string.genre_catalogue_title);
             } else {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/IndexFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/IndexFragment.java
@@ -99,17 +99,17 @@ public class IndexFragment extends Fragment implements ClickCallback {
             activity.getSupportActionBar().setDisplayShowHomeEnabled(true);
         }
 
-        if (bind != null)
-            bind.toolbar.setNavigationOnClickListener(v -> activity.navController.navigateUp());
+        bind.toolbar.setNavigationOnClickListener(v -> activity.navController.navigateUp());
 
-        if (bind != null)
-            bind.appBarLayout.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
-                if ((bind.indexInfoSector.getHeight() + verticalOffset) < (2 * ViewCompat.getMinimumHeight(bind.toolbar))) {
-                    bind.toolbar.setTitle(indexViewModel.getMusicFolderName());
-                } else {
-                    bind.toolbar.setTitle(R.string.empty_string);
-                }
-            });
+        bind.appBarLayout.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
+            if (bind == null) return;
+
+            if ((bind.indexInfoSector.getHeight() + verticalOffset) < (2 * ViewCompat.getMinimumHeight(bind.toolbar))) {
+                bind.toolbar.setTitle(indexViewModel.getMusicFolderName());
+            } else {
+                bind.toolbar.setTitle(R.string.empty_string);
+            }
+        });
     }
 
     private void initDirectoryListView() {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LoginFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/LoginFragment.java
@@ -77,6 +77,8 @@ public class LoginFragment extends Fragment implements ClickCallback {
         activity.setSupportActionBar(bind.toolbar);
 
         bind.appBarLayout.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
+            if (bind == null) return;
+
             if ((bind.serverInfoSector.getHeight() + verticalOffset) < (2 * ViewCompat.getMinimumHeight(bind.toolbar))) {
                 bind.toolbar.setTitle(R.string.login_title);
             } else {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistCatalogueFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistCatalogueFragment.java
@@ -113,6 +113,8 @@ public class PlaylistCatalogueFragment extends Fragment implements ClickCallback
 
 
         bind.appBarLayout.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
+            if (bind == null) return;
+
             if ((bind.albumInfoSector.getHeight() + verticalOffset) < (2 * ViewCompat.getMinimumHeight(bind.toolbar))) {
                 bind.toolbar.setTitle(R.string.playlist_catalogue_title);
             } else {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PlaylistPageFragment.java
@@ -436,12 +436,13 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
         });
 
         // Synchronize scrolling between the list and the header in landscape mode
-        if (bind.playlistInfoScrollView != null) {
+        androidx.core.widget.NestedScrollView playlistInfoScrollView = bind.playlistInfoScrollView;
+        if (playlistInfoScrollView != null) {
             bind.songRecyclerView.addOnScrollListener(new androidx.recyclerview.widget.RecyclerView.OnScrollListener() {
                 @Override
                 public void onScrolled(@NonNull androidx.recyclerview.widget.RecyclerView recyclerView, int dx, int dy) {
                     super.onScrolled(recyclerView, dx, dy);
-                    bind.playlistInfoScrollView.scrollBy(0, dy);
+                    playlistInfoScrollView.scrollBy(0, dy);
                 }
             });
         }

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PodcastChannelCatalogueFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/PodcastChannelCatalogueFragment.java
@@ -83,6 +83,8 @@ public class PodcastChannelCatalogueFragment extends Fragment implements ClickCa
 
 
         bind.appBarLayout.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
+            if (bind == null) return;
+
             if ((bind.podcastChannelInfoSector.getHeight() + verticalOffset) < (2 * ViewCompat.getMinimumHeight(bind.toolbar))) {
                 bind.toolbar.setTitle(R.string.podcast_channel_catalogue_title);
             } else {

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SongListPageFragment.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/fragment/SongListPageFragment.java
@@ -174,20 +174,20 @@ public class SongListPageFragment extends Fragment implements ClickCallback {
             activity.getSupportActionBar().setDisplayShowHomeEnabled(true);
         }
 
-        if (bind != null)
-            bind.toolbar.setNavigationOnClickListener(v -> {
-                hideKeyboard(v);
-                activity.navController.navigateUp();
-            });
+        bind.toolbar.setNavigationOnClickListener(v -> {
+            hideKeyboard(v);
+            activity.navController.navigateUp();
+        });
 
-        if (bind != null)
-            bind.appBarLayout.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
-                if ((bind.albumInfoSector.getHeight() + verticalOffset) < (2 * ViewCompat.getMinimumHeight(bind.toolbar))) {
-                    bind.toolbar.setTitle(songListPageViewModel.toolbarTitle);
-                } else {
-                    bind.toolbar.setTitle(R.string.empty_string);
-                }
-            });
+        bind.appBarLayout.addOnOffsetChangedListener((appBarLayout, verticalOffset) -> {
+            if (bind == null) return;
+
+            if ((bind.albumInfoSector.getHeight() + verticalOffset) < (2 * ViewCompat.getMinimumHeight(bind.toolbar))) {
+                bind.toolbar.setTitle(songListPageViewModel.toolbarTitle);
+            } else {
+                bind.toolbar.setTitle(R.string.empty_string);
+            }
+        });
     }
 
     private void initButtons() {


### PR DESCRIPTION
## What this fixes

Issue #966. A `NullPointerException` thrown from an `AppBarLayout` offset listener on a screen the user has already left. The pattern dates to 2021 and predates this fork.

## Why it happens

All twelve of these layouts carry `snap` in their scroll flags. Releasing a partly scrolled app bar starts `BaseBehavior`'s offset `ValueAnimator` to settle it to the nearest snap position.

That animator is ticked by the thread's `AnimationHandler` rather than by the view hierarchy, so detaching the view does not cancel it, and `removeOnOffsetChangedListener` is never called anywhere in the app, so the listener stays registered as well. Navigate away while the bar is still settling and it keeps calling `onOffsetChanged` after `onDestroyView` has nulled `bind`, which throws.

One correction to the analysis in the issue: it is not a layout pass driving the callback. Deobfuscated stack from a debug build, trimmed:

```
AlbumCatalogueFragment.lambda$initAppBar$1(AlbumCatalogueFragment.java:133)
AppBarLayout.onOffsetChanged(AppBarLayout.java:898)
AppBarLayout$BaseBehavior.setHeaderTopBottomOffset(AppBarLayout.java:2067)
HeaderBehavior.setHeaderTopBottomOffset(HeaderBehavior.java:158)
AppBarLayout$BaseBehavior$1.onAnimationUpdate(AppBarLayout.java:1651)
android.animation.ValueAnimator.doAnimationFrame(ValueAnimator.java:1589)
android.animation.AnimationHandler$1.doFrame(AnimationHandler.java:106)
android.view.Choreographer$CallbackRecord.run(Choreographer.java:1959)
```

The `AppBarLayout` reported `isAttachedToWindow()` as false at every post teardown call.

## Reproducing it

It needs a drag release rather than a fling. A fling runs the bar to a rest position and finishes the animator before you can navigate away, which is why this is easy to miss.

1. Library, Albums, See all
2. Drag the list up so the header is caught partway, then lift
3. Press back while it is still settling

## What the change does

Twelve fragments register an offset listener and every one of them reads `bind` inside it. Each gets the early return already used elsewhere in this code base.

`PlaylistPageFragment`'s landscape scroll sync read `bind.playlistInfoScrollView` inside a `RecyclerView` scroll listener. It now holds the view in a local, which is what `AlbumPageFragment` already does for the same block.

`DirectoryFragment`, `IndexFragment` and `SongListPageFragment` wrapped statements in `initAppBar` in five `bind != null` checks that can never be false. Each of those methods dereferences `bind` unguarded on its first line, so a null `bind` would already have thrown before reaching them. Removed, which also makes those three match the other nine.

## What it does not do

It does not unregister the listener. The animator keeps ticking and the callback still fires after the view is gone, it just returns early instead of throwing. Unregistering would mean holding a listener reference as a field in twelve fragments, which is a wider change than this crash calls for.

## Verification

Galaxy S25 Ultra on Android 16, debug builds of the same commit with and without the change, same scripted gesture, same device, same session.

| Build | Result |
|---|---|
| unmodified | process died on 4 of 5 attempts |
| this branch | survived 6 of 6 |

`IndexFragment` separately survived 5 of 5 with the animator duration scale raised to 10, which widens the window the crash needs.

The landscape scroll sync was checked on a playlist in landscape: the info pane still scrolls with the list, across four back navigations and three rotations taken mid scroll.
