### PR TITLE
fix: podcast crash when missing field

### DIFF
--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PodcastEpisodeAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PodcastEpisodeAdapter.java
@@ -18,6 +18,7 @@ import com.cappielloantonio.tempo.util.MusicUtil;
 
 import java.text.SimpleDateFormat;
 import java.util.Collections;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
@@ -45,9 +46,12 @@ public class PodcastEpisodeAdapter extends RecyclerView.Adapter<PodcastEpisodeAd
         PodcastEpisode podcastEpisode = podcastEpisodes.get(position);
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("MMM d");
 
+        Date publishedDate = podcastEpisode.getPublishDate() != null ? podcastEpisode.getPublishDate() : new Date(0L);
+        int duration = podcastEpisode.getDuration() != null ? podcastEpisode.getDuration() : 0;
+
         holder.item.podcastTitleLabel.setText(podcastEpisode.getTitle());
         holder.item.podcastSubtitleLabel.setText(podcastEpisode.getArtist());
-        holder.item.podcastReleasesAndDurationLabel.setText(holder.itemView.getContext().getString(R.string.podcast_release_date_duration_formatter, simpleDateFormat.format(podcastEpisode.getPublishDate()), MusicUtil.getReadablePodcastDurationString(podcastEpisode.getDuration())));
+        holder.item.podcastReleasesAndDurationLabel.setText(holder.itemView.getContext().getString(R.string.podcast_release_date_duration_formatter, simpleDateFormat.format(publishedDate), MusicUtil.getReadablePodcastDurationString(duration)));
         holder.item.podcastDescriptionText.setText(MusicUtil.getReadableString(podcastEpisode.getDescription()));
 
         CustomGlideRequest.Builder

--- a/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PodcastEpisodeAdapter.java
+++ b/app/src/main/java/com/cappielloantonio/tempo/ui/adapter/PodcastEpisodeAdapter.java
@@ -1,5 +1,6 @@
 package com.cappielloantonio.tempo.ui.adapter;
 
+import android.content.Context;
 import android.os.Bundle;
 import android.view.LayoutInflater;
 import android.view.View;
@@ -46,12 +47,27 @@ public class PodcastEpisodeAdapter extends RecyclerView.Adapter<PodcastEpisodeAd
         PodcastEpisode podcastEpisode = podcastEpisodes.get(position);
         SimpleDateFormat simpleDateFormat = new SimpleDateFormat("MMM d");
 
-        Date publishedDate = podcastEpisode.getPublishDate() != null ? podcastEpisode.getPublishDate() : new Date(0L);
-        int duration = podcastEpisode.getDuration() != null ? podcastEpisode.getDuration() : 0;
+        Context context = holder.itemView.getContext();
+
+        Date publishedDate = podcastEpisode.getPublishDate();
+        String dateStr = (publishedDate != null)
+                ? simpleDateFormat.format(publishedDate)
+                : context.getString(R.string.podcast_release_no_date);
+
+        Integer duration = podcastEpisode.getDuration();
+        String durationStr = (duration != null)
+                ? MusicUtil.getReadablePodcastDurationString(duration)
+                : context.getString(R.string.podcast_release_unknown_duration);
+
+        String releasesAndDurationLabel = context.getString(
+                R.string.podcast_release_date_duration_formatter,
+                dateStr,
+                durationStr
+        );
 
         holder.item.podcastTitleLabel.setText(podcastEpisode.getTitle());
         holder.item.podcastSubtitleLabel.setText(podcastEpisode.getArtist());
-        holder.item.podcastReleasesAndDurationLabel.setText(holder.itemView.getContext().getString(R.string.podcast_release_date_duration_formatter, simpleDateFormat.format(publishedDate), MusicUtil.getReadablePodcastDurationString(duration)));
+        holder.item.podcastReleasesAndDurationLabel.setText(releasesAndDurationLabel);
         holder.item.podcastDescriptionText.setText(MusicUtil.getReadableString(podcastEpisode.getDescription()));
 
         CustomGlideRequest.Builder

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -357,6 +357,8 @@
     <string name="podcast_info_empty_subtitle">Once you add a channel, you\'ll find it here</string>
     <string name="podcast_info_empty_title">No podcasts found!</string>
     <string name="podcast_release_date_duration_formatter">%1$s  •  %2$s</string>
+    <string name="podcast_release_no_date">No date</string>
+    <string name="podcast_release_unknown_duration">Unknown duration</string>
     <string name="radio_editor_dialog_hint_homepage_url">Radio Homepage URL</string>
     <string name="radio_editor_dialog_hint_name">Radio Name</string>
     <string name="radio_editor_dialog_hint_stream_url">Radio Stream URL</string>


### PR DESCRIPTION
Solves #864.

Adds fallbacks for missing (`null`) fields:
* *No date* when the field is null.
* *Unknown duration* when the field is null.

I'll submit a screenshot if I find the time, but this addresses directly the source of the crash and fails graciously both in code and in the UI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved podcast episode details when release dates or durations are unavailable.
  * Displays localized fallback text instead of showing missing or incorrectly formatted metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->