### PR TITLE
build: pin the FFmpeg source to a commit in bin/build.sh

### DIFF
--- a/bin/build.sh
+++ b/bin/build.sh
@@ -10,6 +10,8 @@ HOST_PLATFORM="linux-x86_64"
 ANDROID_API=24
 ENABLED_DECODERS=(alac)
 MEDIA3_VERSION="1.9.2"
+# Full commit hash, and must match the FFmpeg srclib pin in the F-Droid recipe
+FFMPEG_COMMIT="bda1c6f1f9041910ec5b2c279a08861203a1c95c"
 
 # ------------------------------------------------------------------
 # Deterministic build flags – must match F-Droid
@@ -32,12 +34,15 @@ step "🚀 Starting FFmpeg + AAR build"
 rm -rf ffmpeg media
 
 # ---------- 1. Clone ffmpeg ----------
-step "📦 Cloning ffmpeg (release/6.0) via HTTPS"
-git clone --depth 1 --branch release/6.0 https://github.com/FFmpeg/FFmpeg.git ffmpeg
+step "📦 Fetching ffmpeg (pinned commit $FFMPEG_COMMIT) via HTTPS"
+git init -q ffmpeg
 cd ffmpeg
+git remote add origin https://github.com/FFmpeg/FFmpeg.git
+git fetch --depth 1 origin "$FFMPEG_COMMIT"
+git checkout "$FFMPEG_COMMIT"
 FFMPEG_PATH="$(pwd)"
 cd ..
-echo "✅ ffmpeg cloned to $FFMPEG_PATH"
+echo "✅ ffmpeg fetched to $FFMPEG_PATH"
 
 # ---------- 2. Clone androidx/media ----------
 step "📦 Cloning androidx/media (shallow, version: $MEDIA3_VERSION) via HTTPS"


### PR DESCRIPTION
`bin/build.sh` clones FFmpeg from `release/6.0`. That branch moves, so the `.aar` the script produces depends on whatever the tip happened to be the day it ran. Two people running the same script a month apart get different binaries.

The F-Droid recipe already pins FFmpeg to a commit for version code 41, and it has a `scandelete` on `libs/`, so it deletes the checked in `.aar` and rebuilds from that pinned source. This script was the last piece still tracking a moving branch, so regenerating the `.aar` with it could produce something that no longer matches.

The change adds `FFMPEG_COMMIT` alongside the other settings at the top of the script, then fetches only that one commit into an empty repository and checks it out, instead of cloning a branch. It stays a depth 1 fetch, so the build is no slower. The hash is set to the same commit the recipe pins, and there is a comment on the line saying the two have to stay in step.

Testing: ran the script in the container and every file inside the `.aar` it produced is identical to the one currently in `libs/`.
