### PR TITLE
Add a canWrite check to external storage before trying to use it

### DIFF
--- a/app/src/main/java/com/eddyizm/tempus/util/DownloadUtil.java
+++ b/app/src/main/java/com/eddyizm/tempus/util/DownloadUtil.java
@@ -214,6 +214,8 @@ public final class DownloadUtil {
         if (streamingCacheDirectory == null) {
             if (Preferences.getStreamingCacheStoragePreference() == 0) {
                 streamingCacheDirectory = context.getExternalFilesDirs(null)[0];
+                // workaround for crdroid degoogled android 16 sometimes unable to write to the
+                // default external files dir, fall back to internal dir if we can't write
                 if (streamingCacheDirectory == null || !streamingCacheDirectory.canWrite()) {
                     streamingCacheDirectory = context.getFilesDir();
                 }
@@ -236,6 +238,8 @@ public final class DownloadUtil {
             int pref = Preferences.getDownloadStoragePreference();
             if (pref == 0) {
                 downloadDirectory = context.getExternalFilesDirs(null)[0];
+                // workaround for crdroid degoogled android 16 sometimes unable to write to the
+                // default external files dir, fall back to internal dir if we can't write
                 if (downloadDirectory == null || !downloadDirectory.canWrite()) {
                     downloadDirectory = context.getFilesDir();
                 }

--- a/app/src/main/java/com/eddyizm/tempus/util/DownloadUtil.java
+++ b/app/src/main/java/com/eddyizm/tempus/util/DownloadUtil.java
@@ -214,7 +214,7 @@ public final class DownloadUtil {
         if (streamingCacheDirectory == null) {
             if (Preferences.getStreamingCacheStoragePreference() == 0) {
                 streamingCacheDirectory = context.getExternalFilesDirs(null)[0];
-                if (streamingCacheDirectory == null) {
+                if (streamingCacheDirectory == null || !streamingCacheDirectory.canWrite()) {
                     streamingCacheDirectory = context.getFilesDir();
                 }
             } else {
@@ -236,7 +236,7 @@ public final class DownloadUtil {
             int pref = Preferences.getDownloadStoragePreference();
             if (pref == 0) {
                 downloadDirectory = context.getExternalFilesDirs(null)[0];
-                if (downloadDirectory == null) {
+                if (downloadDirectory == null || !downloadDirectory.canWrite()) {
                     downloadDirectory = context.getFilesDir();
                 }
             } else if (pref == 1) {


### PR DESCRIPTION
Mitigates the problem present in #501 