### PR TITLE
Switch music library from the toolbar and see which one you are in

### DIFF
--- a/app/src/degoogled/java/com/eddyizm/tempus/ui/fragment/ToolbarFragment.java
+++ b/app/src/degoogled/java/com/eddyizm/tempus/ui/fragment/ToolbarFragment.java
@@ -7,22 +7,40 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.PopupMenu;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.media3.common.util.UnstableApi;
 
 import com.eddyizm.tempus.R;
 import com.eddyizm.tempus.databinding.FragmentToolbarBinding;
+import com.eddyizm.tempus.subsonic.models.MusicFolder;
 import com.eddyizm.tempus.ui.activity.MainActivity;
+import com.eddyizm.tempus.util.MusicFolderUtil;
+import com.eddyizm.tempus.util.Preferences;
+import com.eddyizm.tempus.viewmodel.LibraryViewModel;
+import com.eddyizm.tempus.viewmodel.MainViewModel;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @UnstableApi
 public class ToolbarFragment extends Fragment {
     private static final String TAG = "ToolbarFragment";
 
+    private static final int MUSIC_LIBRARY_MENU_GROUP = 1;
+    private static final int ALL_LIBRARIES_ITEM_ID = 0;
+    private static final int NO_CHECKED_ITEM = -1;
+
     private FragmentToolbarBinding bind;
     private MainActivity activity;
+    private LibraryViewModel libraryViewModel;
+    private MainViewModel mainViewModel;
+
+    private final List<MusicFolder> musicFolders = new ArrayList<>();
 
     public ToolbarFragment() {
         // Required empty public constructor
@@ -47,7 +65,30 @@ public class ToolbarFragment extends Fragment {
         bind = FragmentToolbarBinding.inflate(inflater, container, false);
         View view = bind.getRoot();
 
+        libraryViewModel = new ViewModelProvider(requireActivity()).get(LibraryViewModel.class);
+        mainViewModel = new ViewModelProvider(requireActivity()).get(MainViewModel.class);
+
         return view;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        initMusicLibrarySwitcher();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        // Catches a restore that put the pager back on Podcast or Radio.
+        updateMusicLibraryIndicator();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        bind = null;
     }
 
     @Override
@@ -61,5 +102,113 @@ public class ToolbarFragment extends Fragment {
         }
 
         return false;
+    }
+
+    private void initMusicLibrarySwitcher() {
+        if (!isLibraryScopedScreen()) return;
+
+        bind.toolbarTitleContainer.setOnClickListener(this::showMusicLibraryMenu);
+
+        // The list is cached on the activity scoped LibraryViewModel, so once it has arrived the
+        // Library tab and this share it. Until then either screen can be the one that fetches it.
+        libraryViewModel.getMusicFolders(getViewLifecycleOwner()).observe(getViewLifecycleOwner(), folders -> {
+            musicFolders.clear();
+            if (folders != null) musicFolders.addAll(folders);
+            updateMusicLibraryIndicator();
+        });
+
+        mainViewModel.getActiveMusicFolderId().observe(getViewLifecycleOwner(), musicFolderId -> updateMusicLibraryIndicator());
+    }
+
+    /**
+     * Home calls this when its pager changes page.
+     */
+    public void refreshMusicLibraryIndicator() {
+        updateMusicLibraryIndicator();
+    }
+
+    /**
+     * Podcasts and internet radio are no more library scoped than downloads are, and they are
+     * pages of Home's pager, so the nav destination cannot tell them apart. Asked of Home on every
+     * update instead of being pushed once.
+     */
+    private boolean isLibraryScopedTab() {
+        Fragment parent = getParentFragment();
+        return !(parent instanceof HomeFragment) || ((HomeFragment) parent).isLibraryScopedTab();
+    }
+
+    /**
+     * Downloads are local files that no library filter reaches, so a line naming one there would
+     * describe something other than what is on the screen.
+     *
+     * Asked of the host fragment, not the NavController: a dialog destination becomes the current
+     * destination without destroying this view, so consulting the graph made Downloads answer yes
+     * while a bottom sheet was open.
+     */
+    private boolean isLibraryScopedScreen() {
+        return !(getParentFragment() instanceof DownloadFragment);
+    }
+
+    private void updateMusicLibraryIndicator() {
+        if (bind == null) return;
+
+        // One library offers no choice. A filter in force has to stay visible whatever the folder
+        // list says, because this is the only way to clear one from outside Settings, and the list
+        // is empty for as long as the server has not answered.
+        boolean canChoose = musicFolders.size() > 1 || Preferences.getActiveMusicFolderId() != null;
+        boolean visible = canChoose && isLibraryScopedScreen() && isLibraryScopedTab();
+
+        bind.toolbarTitleContainer.setClickable(visible);
+        bind.toolbarMusicLibraryTextView.setVisibility(visible ? View.VISIBLE : View.GONE);
+
+        if (!visible) return;
+
+        String name = MusicFolderUtil.resolveMusicFolderName(musicFolders, Preferences.getActiveMusicFolderId());
+        bind.toolbarMusicLibraryTextView.setText(name != null ? name : getString(R.string.settings_music_library_all));
+    }
+
+    private void showMusicLibraryMenu(View anchor) {
+        PopupMenu popup = new PopupMenu(requireContext(), anchor);
+        String activeMusicFolderId = Preferences.getActiveMusicFolderId();
+
+        // Item ids are the folder's position in the list plus one, leaving zero for every library.
+        // NO_CHECKED_ITEM means the stored library is not in the list, which happens when the
+        // server dropped it or never answered. Checking every library there would say no filter is
+        // running while the requests still carry one, so nothing is checked and the line above the
+        // menu keeps naming the id that is actually in force.
+        int checkedItemId = activeMusicFolderId == null ? ALL_LIBRARIES_ITEM_ID : NO_CHECKED_ITEM;
+        popup.getMenu().add(MUSIC_LIBRARY_MENU_GROUP, ALL_LIBRARIES_ITEM_ID, ALL_LIBRARIES_ITEM_ID, R.string.settings_music_library_all);
+
+        for (int i = 0; i < musicFolders.size(); i++) {
+            MusicFolder musicFolder = musicFolders.get(i);
+            if (musicFolder.getId() == null) continue;
+
+            String name = musicFolder.getName() != null ? musicFolder.getName() : musicFolder.getId();
+            popup.getMenu().add(MUSIC_LIBRARY_MENU_GROUP, i + 1, i + 1, name);
+
+            if (musicFolder.getId().equals(activeMusicFolderId)) checkedItemId = i + 1;
+        }
+
+        // Checkable has to be granted to the group before an item will accept being checked.
+        popup.getMenu().setGroupCheckable(MUSIC_LIBRARY_MENU_GROUP, true, true);
+        if (checkedItemId != NO_CHECKED_ITEM) popup.getMenu().findItem(checkedItemId).setChecked(true);
+
+        // Resolve the id while the menu is built. Reading it back by position on click would pick
+        // whatever now sits at that index if a later fetch replaced the list.
+        List<String> itemIds = new ArrayList<>();
+        for (MusicFolder musicFolder : musicFolders) itemIds.add(musicFolder.getId());
+
+        popup.setOnMenuItemClickListener(menuItem -> {
+            int index = menuItem.getItemId() - 1;
+            String selectedId = index < 0 ? Preferences.MUSIC_FOLDER_ALL : itemIds.get(index);
+
+            // A null id never got a menu item, so reaching here with one is not possible today.
+            if (selectedId == null) return true;
+
+            mainViewModel.setActiveMusicFolderId(selectedId);
+            return true;
+        });
+
+        popup.show();
     }
 }

--- a/app/src/degoogled/java/com/eddyizm/tempus/ui/fragment/ToolbarFragment.java
+++ b/app/src/degoogled/java/com/eddyizm/tempus/ui/fragment/ToolbarFragment.java
@@ -17,6 +17,8 @@ import androidx.media3.common.util.UnstableApi;
 
 import com.eddyizm.tempus.R;
 import com.eddyizm.tempus.databinding.FragmentToolbarBinding;
+import com.eddyizm.tempus.model.Server;
+import com.eddyizm.tempus.repository.ServerRepository;
 import com.eddyizm.tempus.subsonic.models.MusicFolder;
 import com.eddyizm.tempus.ui.activity.MainActivity;
 import com.eddyizm.tempus.util.MusicFolderUtil;
@@ -41,6 +43,8 @@ public class ToolbarFragment extends Fragment {
     private MainViewModel mainViewModel;
 
     private final List<MusicFolder> musicFolders = new ArrayList<>();
+
+    private String serverName;
 
     public ToolbarFragment() {
         // Required empty public constructor
@@ -118,6 +122,21 @@ public class ToolbarFragment extends Fragment {
         });
 
         mainViewModel.getActiveMusicFolderId().observe(getViewLifecycleOwner(), musicFolderId -> updateMusicLibraryIndicator());
+
+        // The name lives in the server table, not in Preferences, so it takes a read of every
+        // row and a match on the stored id.
+        new ServerRepository().getLiveServer().observe(getViewLifecycleOwner(), servers -> {
+            String serverId = Preferences.getServerId();
+
+            serverName = null;
+            if (servers != null && serverId != null) {
+                for (Server server : servers) {
+                    if (serverId.equals(server.getServerId())) serverName = server.getServerName();
+                }
+            }
+
+            updateMusicLibraryIndicator();
+        });
     }
 
     /**
@@ -158,8 +177,19 @@ public class ToolbarFragment extends Fragment {
         boolean canChoose = musicFolders.size() > 1 || Preferences.getActiveMusicFolderId() != null;
         boolean visible = canChoose && isLibraryScopedScreen() && isLibraryScopedTab();
 
+        // Podcast and Radio are the tabs the library never reaches, so the line carries the
+        // server instead of nothing. No caret there, since nothing is tappable.
+        boolean showServerName = !visible && serverName != null && isLibraryScopedScreen() && !isLibraryScopedTab();
+
         bind.toolbarTitleContainer.setClickable(visible);
-        bind.toolbarMusicLibraryTextView.setVisibility(visible ? View.VISIBLE : View.GONE);
+        bind.toolbarMusicLibraryTextView.setVisibility(visible || showServerName ? View.VISIBLE : View.GONE);
+        bind.toolbarMusicLibraryTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(
+                0, 0, visible ? R.drawable.ic_expand_more_small : 0, 0);
+
+        if (showServerName) {
+            bind.toolbarMusicLibraryTextView.setText(serverName);
+            return;
+        }
 
         if (!visible) return;
 

--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/HomeFragment.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/HomeFragment.java
@@ -9,6 +9,7 @@ import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import androidx.media3.common.util.UnstableApi;
+import androidx.viewpager2.widget.ViewPager2;
 
 import com.eddyizm.tempus.R;
 import com.eddyizm.tempus.databinding.FragmentHomeBinding;
@@ -105,5 +106,29 @@ public class HomeFragment extends Fragment {
         ).attach();
 
         tabLayout.setVisibility(Preferences.isPodcastSectionVisible() || Preferences.isRadioSectionVisible() ? View.VISIBLE : View.GONE);
+
+        bind.homeViewPager.registerOnPageChangeCallback(new ViewPager2.OnPageChangeCallback() {
+            @Override
+            public void onPageSelected(int position) {
+                refreshToolbarLibraryScope();
+            }
+        });
+    }
+
+    /**
+     * The music library line in the toolbar belongs to the Music tab. Podcast and Radio share the
+     * toolbar and are not filtered by library, so the line would name something with nothing to do
+     * with what is on screen. Music is always the first page; the other two are optional.
+     *
+     * The toolbar reads this on every update instead of being pushed the page once, so a page the
+     * pager put back on its own cannot leave the line naming the wrong tab.
+     */
+    public boolean isLibraryScopedTab() {
+        return bind != null && bind.homeViewPager.getCurrentItem() == 0;
+    }
+
+    private void refreshToolbarLibraryScope() {
+        ToolbarFragment toolbarFragment = (ToolbarFragment) getChildFragmentManager().findFragmentById(R.id.toolbar_fragment);
+        if (toolbarFragment != null) toolbarFragment.refreshMusicLibraryIndicator();
     }
 }

--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/HomeTabMusicFragment.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/HomeTabMusicFragment.java
@@ -71,6 +71,7 @@ import com.eddyizm.tempus.util.Preferences;
 import com.eddyizm.tempus.util.TileSizeManager;
 import com.eddyizm.tempus.util.UIUtil;
 import com.eddyizm.tempus.viewmodel.HomeViewModel;
+import com.eddyizm.tempus.viewmodel.MainViewModel;
 import com.eddyizm.tempus.viewmodel.PlaybackViewModel;
 import com.google.android.material.snackbar.Snackbar;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -87,6 +88,7 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
     private FragmentHomeTabMusicBinding bind;
     private MainActivity activity;
     private HomeViewModel homeViewModel;
+    private MainViewModel mainViewModel;
     private PlaybackViewModel playbackViewModel;
 
     private DiscoverSongAdapter discoverSongAdapter;
@@ -116,6 +118,7 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
         bind = FragmentHomeTabMusicBinding.inflate(inflater, container, false);
         View view = bind.getRoot();
         homeViewModel = new ViewModelProvider(requireActivity()).get(HomeViewModel.class);
+        mainViewModel = new ViewModelProvider(requireActivity()).get(MainViewModel.class);
         playbackViewModel = new ViewModelProvider(requireActivity()).get(PlaybackViewModel.class);
 
         homeViewModel.clearCacheIfMusicFolderChanged();
@@ -148,6 +151,7 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
         initPinnedPlaylistsView();
         initSharesView();
         initHomeReorganizer();
+        initMusicFolderChangeListener();
 
         reorder();
     }
@@ -1107,6 +1111,11 @@ public class HomeTabMusicFragment extends Fragment implements ClickCallback {
                         requireContext().getResources().getColor(R.color.titleTextColor, null),
                         requireContext().getResources().getColor(R.color.titleTextColor, null))
         );
+    }
+
+    private void initMusicFolderChangeListener() {
+        mainViewModel.getActiveMusicFolderId().observe(getViewLifecycleOwner(), musicFolderId ->
+                homeViewModel.reloadIfMusicFolderChanged(getViewLifecycleOwner()));
     }
 
     private void initHomeReorganizer() {

--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/LibraryFragment.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/LibraryFragment.java
@@ -48,6 +48,7 @@ import com.eddyizm.tempus.util.Constants;
 import com.eddyizm.tempus.util.LiveDataUtils;
 import com.eddyizm.tempus.util.Preferences;
 import com.eddyizm.tempus.viewmodel.LibraryViewModel;
+import com.eddyizm.tempus.viewmodel.MainViewModel;
 import com.google.android.material.appbar.MaterialToolbar;
 import com.eddyizm.tempus.service.MediaService;
 import com.google.common.util.concurrent.ListenableFuture;
@@ -64,6 +65,7 @@ public class LibraryFragment extends Fragment implements ClickCallback {
     private MainActivity activity;
     private NavigationController navigationController;
     private LibraryViewModel libraryViewModel;
+    private MainViewModel mainViewModel;
 
     private MusicFolderAdapter musicFolderAdapter;
     private AlbumAdapter albumAdapter;
@@ -83,6 +85,7 @@ public class LibraryFragment extends Fragment implements ClickCallback {
         bind = FragmentLibraryBinding.inflate(inflater, container, false);
         View view = bind.getRoot();
         libraryViewModel = new ViewModelProvider(requireActivity()).get(LibraryViewModel.class);
+        mainViewModel = new ViewModelProvider(requireActivity()).get(MainViewModel.class);
 
         libraryViewModel.clearCacheIfMusicFolderChanged();
 
@@ -102,6 +105,12 @@ public class LibraryFragment extends Fragment implements ClickCallback {
         initGenreView();
         initPlaylistView();
         initSwipeToRefresh();
+        initMusicFolderChangeListener();
+    }
+
+    private void initMusicFolderChangeListener() {
+        mainViewModel.getActiveMusicFolderId().observe(getViewLifecycleOwner(), musicFolderId ->
+                libraryViewModel.reloadIfMusicFolderChanged(getViewLifecycleOwner()));
     }
 
     @Override

--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/SettingsContainerFragment.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/SettingsContainerFragment.java
@@ -67,6 +67,7 @@ import com.eddyizm.tempus.subsonic.models.MusicFolder;
 import com.eddyizm.tempus.util.ExternalAudioReader;
 import com.eddyizm.tempus.util.Preferences;
 import com.eddyizm.tempus.util.UIUtil;
+import com.eddyizm.tempus.viewmodel.MainViewModel;
 import com.eddyizm.tempus.viewmodel.SettingViewModel;
 
 import java.util.ArrayList;
@@ -84,6 +85,7 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
     private MainActivity activity;
 
     private SettingViewModel settingViewModel;
+    private MainViewModel mainViewModel;
 
     private ActivityResultLauncher<Intent> directoryPickerLauncher;
 
@@ -136,6 +138,7 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
 
         View view = super.onCreateView(inflater, container, savedInstanceState);
         settingViewModel = new ViewModelProvider(requireActivity()).get(SettingViewModel.class);
+        mainViewModel = new ViewModelProvider(requireActivity()).get(MainViewModel.class);
 
         if (view != null) {
             getListView().setPadding(0, 0, 0, (int) getResources().getDimension(R.dimen.global_padding_bottom));
@@ -469,7 +472,7 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
 
         libraryPref.setOnPreferenceChangeListener((preference, newValue) -> {
             libraryPref.setValue((String) newValue);
-            Preferences.setActiveMusicFolderId((String) newValue);
+            mainViewModel.setActiveMusicFolderId((String) newValue);
             setMusicLibrarySummary(libraryPref);
             return true;
         });
@@ -513,7 +516,7 @@ public class SettingsContainerFragment extends PreferenceFragmentCompat {
             String storedMusicFolderId = Preferences.getActiveMusicFolderId();
             if (storedMusicFolderId != null && !ids.isEmpty() && !ids.contains(storedMusicFolderId)) {
                 libraryPref.setValue(Preferences.MUSIC_FOLDER_ALL);
-                Preferences.setActiveMusicFolderId(null);
+                mainViewModel.setActiveMusicFolderId(null);
             }
 
             musicFolderCount = ids.size();

--- a/app/src/main/java/com/eddyizm/tempus/util/MusicFolderUtil.java
+++ b/app/src/main/java/com/eddyizm/tempus/util/MusicFolderUtil.java
@@ -1,0 +1,30 @@
+package com.eddyizm.tempus.util;
+
+import com.eddyizm.tempus.subsonic.models.MusicFolder;
+
+import java.util.List;
+
+public class MusicFolderUtil {
+    private MusicFolderUtil() {
+    }
+
+    /**
+     * The name to show for the library currently in force, or null when nothing is filtered and the
+     * caller should name every library instead.
+     *
+     * A stored id with no match in the list is returned as itself. The request layer is still
+     * sending that id, so naming it is true, where saying every library would not be.
+     */
+    public static String resolveMusicFolderName(List<MusicFolder> musicFolders, String activeMusicFolderId) {
+        if (activeMusicFolderId == null) return null;
+        if (musicFolders == null) return activeMusicFolderId;
+
+        for (MusicFolder musicFolder : musicFolders) {
+            if (activeMusicFolderId.equals(musicFolder.getId())) {
+                return musicFolder.getName() != null ? musicFolder.getName() : musicFolder.getId();
+            }
+        }
+
+        return activeMusicFolderId;
+    }
+}

--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/HomeViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/HomeViewModel.java
@@ -75,6 +75,7 @@ public class HomeViewModel extends AndroidViewModel {
     private List<HomeSector> sectors;
 
     private String cachedMusicFolderId = Preferences.getActiveMusicFolderId();
+    private int musicFolderGeneration = 0;
 
     public HomeViewModel(@NonNull Application application) {
         super(application);
@@ -97,7 +98,7 @@ public class HomeViewModel extends AndroidViewModel {
 
     public LiveData<List<Child>> getDiscoverSongSample(LifecycleOwner owner) {
         if (dicoverSongSample.getValue() == null) {
-            songRepository.getRandomSample(10, null, null).observe(owner, dicoverSongSample::postValue);
+            songRepository.getRandomSample(10, null, null).observe(owner, setIfCurrentGeneration(dicoverSongSample));
         }
 
         return dicoverSongSample;
@@ -123,17 +124,23 @@ public class HomeViewModel extends AndroidViewModel {
 
     public LiveData<List<AlbumID3>> getRecentlyReleasedAlbums(LifecycleOwner owner) {
         if (newReleasedAlbum.getValue() == null) {
-            int currentYear = Calendar.getInstance().get(Calendar.YEAR);
-
-            albumRepository.getAlbums("byYear", 500, currentYear, currentYear).observe(owner, albums -> {
-                if (albums != null) {
-                    albums.sort(Comparator.comparing(AlbumID3::getCreated).reversed());
-                    newReleasedAlbum.postValue(albums.subList(0, Math.min(20, albums.size())));
-                }
-            });
+            fetchRecentlyReleasedAlbums(owner);
         }
 
         return newReleasedAlbum;
+    }
+
+    private void fetchRecentlyReleasedAlbums(LifecycleOwner owner) {
+        int currentYear = Calendar.getInstance().get(Calendar.YEAR);
+        // Sorts before posting, so it cannot use setIfCurrentGeneration and checks the same way.
+        int generation = musicFolderGeneration;
+
+        albumRepository.getAlbums("byYear", 500, currentYear, currentYear).observe(owner, albums -> {
+            if (albums != null && generation == musicFolderGeneration) {
+                albums.sort(Comparator.comparing(AlbumID3::getCreated).reversed());
+                newReleasedAlbum.setValue(albums.subList(0, Math.min(20, albums.size())));
+            }
+        });
     }
 
     public LiveData<List<Child>> getStarredTracksSample(LifecycleOwner owner) {
@@ -194,7 +201,7 @@ public class HomeViewModel extends AndroidViewModel {
 
     public LiveData<List<Integer>> getYearList(LifecycleOwner owner) {
         if (years.getValue() == null) {
-            albumRepository.getDecades().observe(owner, years::postValue);
+            albumRepository.getDecades().observe(owner, setIfCurrentGeneration(years));
         }
 
         return years;
@@ -202,7 +209,7 @@ public class HomeViewModel extends AndroidViewModel {
 
     public LiveData<List<AlbumID3>> getMostPlayedAlbums(LifecycleOwner owner) {
         if (mostPlayedAlbumSample.getValue() == null) {
-            albumRepository.getAlbums("frequent", 20, null, null).observe(owner, mostPlayedAlbumSample::postValue);
+            albumRepository.getAlbums("frequent", 20, null, null).observe(owner, setIfCurrentGeneration(mostPlayedAlbumSample));
         }
 
         return mostPlayedAlbumSample;
@@ -210,7 +217,7 @@ public class HomeViewModel extends AndroidViewModel {
 
     public LiveData<List<AlbumID3>> getMostRecentlyAddedAlbums(LifecycleOwner owner) {
         if (recentlyAddedAlbumSample.getValue() == null) {
-            albumRepository.getAlbums("newest", 20, null, null).observe(owner, recentlyAddedAlbumSample::postValue);
+            albumRepository.getAlbums("newest", 20, null, null).observe(owner, setIfCurrentGeneration(recentlyAddedAlbumSample));
         }
 
         return recentlyAddedAlbumSample;
@@ -218,7 +225,7 @@ public class HomeViewModel extends AndroidViewModel {
 
     public LiveData<List<AlbumID3>> getRecentlyPlayedAlbumList(LifecycleOwner owner) {
         if (recentlyPlayedAlbumSample.getValue() == null) {
-            albumRepository.getAlbums("recent", 20, null, null).observe(owner, recentlyPlayedAlbumSample::postValue);
+            albumRepository.getAlbums("recent", 20, null, null).observe(owner, setIfCurrentGeneration(recentlyPlayedAlbumSample));
         }
 
         return recentlyPlayedAlbumSample;
@@ -310,17 +317,22 @@ public class HomeViewModel extends AndroidViewModel {
 
     /**
      * The cached samples were fetched under whichever library was active then, so they go stale
-     * when it changes. Clearing them lets the getters' null guards refetch on the next view creation.
+     * when it changes. Clearing them lets the getters' null guards refetch on the next view
+     * creation, and every observer of these treats null as "hide this section".
+     *
+     * Returns whether the library actually changed, so the caller can decide whether the screen it
+     * is on needs refetching now as well.
      *
      * Starred data stays by choice, not because it cannot be filtered: getStarred2 does take
      * musicFolderId. getPlaylists does not, and scoping one hand built collection but not the other
      * would behave differently for no reason a user can see.
      */
-    public void clearCacheIfMusicFolderChanged() {
+    public boolean clearCacheIfMusicFolderChanged() {
         String activeMusicFolderId = Preferences.getActiveMusicFolderId();
-        if (Objects.equals(activeMusicFolderId, cachedMusicFolderId)) return;
+        if (Objects.equals(activeMusicFolderId, cachedMusicFolderId)) return false;
 
         cachedMusicFolderId = activeMusicFolderId;
+        musicFolderGeneration++;
 
         dicoverSongSample.setValue(null);
         newReleasedAlbum.setValue(null);
@@ -328,10 +340,50 @@ public class HomeViewModel extends AndroidViewModel {
         recentlyPlayedAlbumSample.setValue(null);
         recentlyAddedAlbumSample.setValue(null);
         years.setValue(null);
+
+        return true;
+    }
+
+    /**
+     * The same staleness, for a screen already on display that will not create its views again.
+     * Clearing alone would leave it blank until the user navigated away and back, so this clears
+     * and then refetches into the same LiveData the screen is already observing.
+     */
+    public void reloadIfMusicFolderChanged(LifecycleOwner owner) {
+        if (!clearCacheIfMusicFolderChanged()) return;
+
+        // Guarded the same way the init methods in HomeTabMusicFragment are, so reload asks for a
+        // sector exactly when that sector was set up. The predicate reports the opposite of its
+        // name: true means the id is absent from the saved sector list, which is not the same as
+        // the user hiding it, since hiding keeps the entry and only clears its isVisible flag.
+        if (!checkHomeSectorVisibility(Constants.HOME_SECTOR_DISCOVERY)) refreshDiscoverySongSample(owner);
+        if (!checkHomeSectorVisibility(Constants.HOME_SECTOR_NEW_RELEASES)) refreshRecentlyReleasedAlbums(owner);
+        if (!checkHomeSectorVisibility(Constants.HOME_SECTOR_MOST_PLAYED)) refreshMostPlayedAlbums(owner);
+        if (!checkHomeSectorVisibility(Constants.HOME_SECTOR_LAST_PLAYED)) refreshRecentlyPlayedAlbumList(owner);
+        if (!checkHomeSectorVisibility(Constants.HOME_SECTOR_RECENTLY_ADDED)) refreshMostRecentlyAddedAlbums(owner);
+        if (!checkHomeSectorVisibility(Constants.HOME_SECTOR_FLASHBACK)) refreshYearList(owner);
+    }
+
+    /**
+     * Nothing in the repository layer cancels a request, so a response for the library that was
+     * active when it was sent can land after the library has changed and overwrite the new one.
+     * Switching twice inside one round trip is enough to leave the wrong library's content under
+     * the right library's name, permanently, since the caches then look current.
+     *
+     * A response from a superseded library is dropped instead of stored. setValue and not
+     * postValue: a post would defer the store past the check, and every one of these callbacks
+     * already runs on the main thread.
+     */
+    private <T> Observer<T> setIfCurrentGeneration(MutableLiveData<T> target) {
+        int generation = musicFolderGeneration;
+
+        return value -> {
+            if (generation == musicFolderGeneration) target.setValue(value);
+        };
     }
 
     public void refreshDiscoverySongSample(LifecycleOwner owner) {
-        songRepository.getRandomSample(10, null, null).observe(owner, dicoverSongSample::postValue);
+        songRepository.getRandomSample(10, null, null).observe(owner, setIfCurrentGeneration(dicoverSongSample));
     }
 
     public void refreshSimilarSongSample(LifecycleOwner owner) {
@@ -359,15 +411,23 @@ public class HomeViewModel extends AndroidViewModel {
     }
 
     public void refreshMostPlayedAlbums(LifecycleOwner owner) {
-        albumRepository.getAlbums("frequent", 20, null, null).observe(owner, mostPlayedAlbumSample::postValue);
+        albumRepository.getAlbums("frequent", 20, null, null).observe(owner, setIfCurrentGeneration(mostPlayedAlbumSample));
     }
 
     public void refreshMostRecentlyAddedAlbums(LifecycleOwner owner) {
-        albumRepository.getAlbums("newest", 20, null, null).observe(owner, recentlyAddedAlbumSample::postValue);
+        albumRepository.getAlbums("newest", 20, null, null).observe(owner, setIfCurrentGeneration(recentlyAddedAlbumSample));
     }
 
     public void refreshRecentlyPlayedAlbumList(LifecycleOwner owner) {
-        albumRepository.getAlbums("recent", 20, null, null).observe(owner, recentlyPlayedAlbumSample::postValue);
+        albumRepository.getAlbums("recent", 20, null, null).observe(owner, setIfCurrentGeneration(recentlyPlayedAlbumSample));
+    }
+
+    public void refreshRecentlyReleasedAlbums(LifecycleOwner owner) {
+        fetchRecentlyReleasedAlbums(owner);
+    }
+
+    public void refreshYearList(LifecycleOwner owner) {
+        albumRepository.getDecades().observe(owner, setIfCurrentGeneration(years));
     }
 
     public void refreshShares(LifecycleOwner owner) {

--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/LibraryViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/LibraryViewModel.java
@@ -7,6 +7,7 @@ import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LifecycleOwner;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Observer;
 
 import com.eddyizm.tempus.repository.AlbumRepository;
 import com.eddyizm.tempus.repository.ArtistRepository;
@@ -41,6 +42,7 @@ public class LibraryViewModel extends AndroidViewModel {
     private final MutableLiveData<List<Genre>> sampleGenres = new MutableLiveData<>(null);
 
     private String cachedMusicFolderId = Preferences.getActiveMusicFolderId();
+    private int musicFolderGeneration = 0;
 
     public LibraryViewModel(@NonNull Application application) {
         super(application);
@@ -56,14 +58,38 @@ public class LibraryViewModel extends AndroidViewModel {
      * Same reasoning as HomeViewModel. Genres, playlists and the folder list take no folder id, so
      * they stay.
      */
-    public void clearCacheIfMusicFolderChanged() {
+    public boolean clearCacheIfMusicFolderChanged() {
         String activeMusicFolderId = Preferences.getActiveMusicFolderId();
-        if (Objects.equals(activeMusicFolderId, cachedMusicFolderId)) return;
+        if (Objects.equals(activeMusicFolderId, cachedMusicFolderId)) return false;
 
         cachedMusicFolderId = activeMusicFolderId;
+        musicFolderGeneration++;
 
         sampleAlbum.setValue(null);
         sampleArtist.setValue(null);
+
+        return true;
+    }
+
+    /**
+     * Same reasoning as HomeViewModel.reloadIfMusicFolderChanged.
+     */
+    public void reloadIfMusicFolderChanged(LifecycleOwner owner) {
+        if (!clearCacheIfMusicFolderChanged()) return;
+
+        refreshAlbumSample(owner);
+        refreshArtistSample(owner);
+    }
+
+    /**
+     * Same reasoning as HomeViewModel.setIfCurrentGeneration.
+     */
+    private <T> Observer<T> setIfCurrentGeneration(MutableLiveData<T> target) {
+        int generation = musicFolderGeneration;
+
+        return value -> {
+            if (generation == musicFolderGeneration) target.setValue(value);
+        };
     }
 
     public LiveData<List<MusicFolder>> getMusicFolders(LifecycleOwner owner) {
@@ -84,7 +110,7 @@ public class LibraryViewModel extends AndroidViewModel {
 
     public LiveData<List<AlbumID3>> getAlbumSample(LifecycleOwner owner) {
         if (sampleAlbum.getValue() == null) {
-            albumRepository.getAlbums("random", 10, null, null).observe(owner, sampleAlbum::postValue);
+            albumRepository.getAlbums("random", 10, null, null).observe(owner, setIfCurrentGeneration(sampleAlbum));
         }
 
         return sampleAlbum;
@@ -92,7 +118,7 @@ public class LibraryViewModel extends AndroidViewModel {
 
     public LiveData<List<ArtistID3>> getArtistSample(LifecycleOwner owner) {
         if (sampleArtist.getValue() == null) {
-            artistRepository.getArtists(true, 10).observe(owner, sampleArtist::postValue);
+            artistRepository.getArtists(true, 10).observe(owner, setIfCurrentGeneration(sampleArtist));
         }
 
         return sampleArtist;
@@ -115,11 +141,11 @@ public class LibraryViewModel extends AndroidViewModel {
     }
 
     public void refreshAlbumSample(LifecycleOwner owner) {
-        albumRepository.getAlbums("random", 10, null, null).observe(owner, sampleAlbum::postValue);
+        albumRepository.getAlbums("random", 10, null, null).observe(owner, setIfCurrentGeneration(sampleAlbum));
     }
 
     public void refreshArtistSample(LifecycleOwner owner) {
-        artistRepository.getArtists(true, 10).observe(owner, sampleArtist::postValue);
+        artistRepository.getArtists(true, 10).observe(owner, setIfCurrentGeneration(sampleArtist));
     }
 
     public void refreshGenreSample(LifecycleOwner owner) {

--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/MainViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/MainViewModel.java
@@ -5,12 +5,14 @@ import android.app.Application;
 import androidx.annotation.NonNull;
 import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
 
 import com.eddyizm.tempus.github.models.LatestRelease;
 import com.eddyizm.tempus.repository.QueueRepository;
 import com.eddyizm.tempus.repository.SystemRepository;
 import com.eddyizm.tempus.subsonic.models.OpenSubsonicExtension;
 import com.eddyizm.tempus.subsonic.models.SubsonicResponse;
+import com.eddyizm.tempus.util.Preferences;
 
 import java.util.List;
 
@@ -19,10 +21,33 @@ public class MainViewModel extends AndroidViewModel {
 
     private final SystemRepository systemRepository;
 
+    private final MutableLiveData<String> activeMusicFolderId =
+            new MutableLiveData<>(Preferences.getActiveMusicFolderId());
+
     public MainViewModel(@NonNull Application application) {
         super(application);
 
         systemRepository = new SystemRepository();
+    }
+
+    /**
+     * Signals that the active library changed. Preferences is a plain SharedPreferences read with
+     * no observable, so without this a screen already on display has no way to learn it is showing
+     * the wrong library.
+     *
+     * Observers should treat this as "look again" and read Preferences for the value. The emitted
+     * id can be stale after a server switch, because the stored choice is keyed per server while
+     * this lives as long as the activity.
+     */
+    public LiveData<String> getActiveMusicFolderId() {
+        return activeMusicFolderId;
+    }
+
+    public void setActiveMusicFolderId(String musicFolderId) {
+        Preferences.setActiveMusicFolderId(musicFolderId);
+        // Read back instead of posting the argument, so the sentinel that callers pass for every
+        // library arrives here as the null that getActiveMusicFolderId reports for it.
+        activeMusicFolderId.setValue(Preferences.getActiveMusicFolderId());
     }
 
     public boolean isQueueLoaded() {

--- a/app/src/main/res/drawable/ic_expand_more_small.xml
+++ b/app/src/main/res/drawable/ic_expand_more_small.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="12dp"
+    android:height="12dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24"
+    android:tint="?attr/colorControlNormal">
+    <path
+        android:fillColor="@android:color/white"
+        android:pathData="M7.41,8.59L12,13.17l4.59,-4.58L18,10l-6,6 -6,-6 1.41,-1.41z" />
+</vector>

--- a/app/src/main/res/layout-sw600dp/fragment_toolbar.xml
+++ b/app/src/main/res/layout-sw600dp/fragment_toolbar.xml
@@ -56,7 +56,6 @@
                     android:layout_height="wrap_content"
                     android:background="?attr/selectableItemBackground"
                     android:duplicateParentState="true"
-                    android:drawableEnd="@drawable/ic_expand_more_small"
                     android:drawablePadding="2dp"
                     android:ellipsize="end"
                     android:paddingStart="8dp"

--- a/app/src/main/res/layout-sw600dp/fragment_toolbar.xml
+++ b/app/src/main/res/layout-sw600dp/fragment_toolbar.xml
@@ -12,25 +12,59 @@
         android:background="?attr/colorSurface"
         app:layout_scrollFlags="scroll|enterAlways|snap">
 
+        <!--
+            A minimum height on this container, not a fixed one. Without a minimum the app name
+            sits lower on a screen where the library line is hidden than on one where it is
+            shown, so it moves as you change tabs. A fixed height would hold it too, at the cost
+            of capping a row that has to fit two lines at any font scale.
+        -->
         <LinearLayout
+            android:id="@+id/toolbar_title_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:minHeight="?attr/actionBarSize"
+            android:layout_gravity="top"
             android:orientation="horizontal">
 
             <ImageView
-                android:layout_width="28dp"
-                android:layout_height="28dp"
-                android:layout_gravity="center_vertical"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_gravity="top"
+                android:layout_marginTop="10dp"
                 android:layout_marginEnd="8dp"
                 android:background="@drawable/ic_toolbar_tempo" />
 
-            <TextView
-                style="@style/HeadlineMedium"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingStart="8dp"
-                android:paddingEnd="8dp"
-                android:text="@string/app_name" />
+                android:layout_gravity="top"
+                android:layout_marginTop="6dp"
+                android:orientation="vertical">
+
+                <TextView
+                    style="@style/HeadlineMedium"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingStart="8dp"
+                    android:paddingEnd="8dp"
+                    android:text="@string/app_name" />
+
+                <TextView
+                    android:id="@+id/toolbar_music_library_text_view"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:duplicateParentState="true"
+                    android:drawableEnd="@drawable/ic_expand_more_small"
+                    android:drawablePadding="2dp"
+                    android:ellipsize="end"
+                    android:paddingStart="8dp"
+                    android:paddingEnd="8dp"
+                    android:singleLine="true"
+                    android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                    android:textSize="13sp"
+                    android:visibility="gone" />
+            </LinearLayout>
         </LinearLayout>
     </com.google.android.material.appbar.MaterialToolbar>
 </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout-sw600dp/fragment_toolbar.xml
+++ b/app/src/main/res/layout-sw600dp/fragment_toolbar.xml
@@ -31,7 +31,7 @@
                 android:layout_height="40dp"
                 android:layout_gravity="top"
                 android:layout_marginTop="10dp"
-                android:layout_marginEnd="8dp"
+                android:layout_marginEnd="6dp"
                 android:background="@drawable/ic_toolbar_tempo" />
 
             <LinearLayout
@@ -43,6 +43,7 @@
 
                 <TextView
                     style="@style/HeadlineMedium"
+                    android:textSize="20sp"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:paddingStart="8dp"

--- a/app/src/main/res/layout/fragment_toolbar.xml
+++ b/app/src/main/res/layout/fragment_toolbar.xml
@@ -57,7 +57,6 @@
                     android:layout_height="wrap_content"
                     android:background="?attr/selectableItemBackground"
                     android:duplicateParentState="true"
-                    android:drawableEnd="@drawable/ic_expand_more_small"
                     android:drawablePadding="2dp"
                     android:ellipsize="end"
                     android:paddingStart="@dimen/_8sdp"

--- a/app/src/main/res/layout/fragment_toolbar.xml
+++ b/app/src/main/res/layout/fragment_toolbar.xml
@@ -13,26 +13,61 @@
         android:background="?attr/colorSurface"
         app:layout_scrollFlags="scroll|enterAlways|snap">
 
+        <!--
+            A minimum height on this container, not a fixed one. Without a minimum the app name
+            sits lower on a screen where the library line is hidden than on one where it is
+            shown, so it moves as you change tabs. A fixed height would hold it too, at the cost
+            of capping a row that has to fit two lines at any font scale.
+        -->
         <LinearLayout
+            android:id="@+id/toolbar_title_container"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:minHeight="?attr/actionBarSize"
+            android:layout_gravity="top"
             android:orientation="horizontal">
 
             <ImageView
-                android:layout_width="28dp"
-                android:layout_height="28dp"
-                android:layout_gravity="center_vertical"
+                android:layout_width="40dp"
+                android:layout_height="40dp"
+                android:layout_gravity="top"
+                android:layout_marginTop="10dp"
                 android:layout_marginEnd="8dp"
                 android:background="@drawable/ic_toolbar_tempo" />
 
-            <TextView
-                style="@style/HeadlineMedium"
-                android:textSize="@dimen/_20sdp"
+            <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:paddingStart="@dimen/_8sdp"
-                android:text="@string/app_name"
-                tools:ignore="RtlSymmetry" />
+                android:layout_gravity="top"
+                android:layout_marginTop="6dp"
+                android:orientation="vertical">
+
+                <TextView
+                    style="@style/HeadlineMedium"
+                    android:textSize="@dimen/_20sdp"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:paddingStart="@dimen/_8sdp"
+                    android:text="@string/app_name"
+                    tools:ignore="RtlSymmetry" />
+
+                <TextView
+                    android:id="@+id/toolbar_music_library_text_view"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:background="?attr/selectableItemBackground"
+                    android:duplicateParentState="true"
+                    android:drawableEnd="@drawable/ic_expand_more_small"
+                    android:drawablePadding="2dp"
+                    android:ellipsize="end"
+                    android:paddingStart="@dimen/_8sdp"
+                    android:singleLine="true"
+                    android:textAppearance="@style/TextAppearance.Material3.BodySmall"
+                    android:textSize="13sp"
+                    android:visibility="gone"
+                    tools:ignore="RtlSymmetry"
+                    tools:visibility="visible" />
+            </LinearLayout>
         </LinearLayout>
     </com.google.android.material.appbar.MaterialToolbar>
 </com.google.android.material.appbar.AppBarLayout>

--- a/app/src/main/res/layout/fragment_toolbar.xml
+++ b/app/src/main/res/layout/fragment_toolbar.xml
@@ -32,7 +32,7 @@
                 android:layout_height="40dp"
                 android:layout_gravity="top"
                 android:layout_marginTop="10dp"
-                android:layout_marginEnd="8dp"
+                android:layout_marginEnd="6dp"
                 android:background="@drawable/ic_toolbar_tempo" />
 
             <LinearLayout
@@ -44,7 +44,7 @@
 
                 <TextView
                     style="@style/HeadlineMedium"
-                    android:textSize="@dimen/_20sdp"
+                    android:textSize="@dimen/_17sdp"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:paddingStart="@dimen/_8sdp"

--- a/app/src/tempus/java/com/eddyizm/tempus/ui/fragment/ToolbarFragment.java
+++ b/app/src/tempus/java/com/eddyizm/tempus/ui/fragment/ToolbarFragment.java
@@ -7,23 +7,41 @@ import android.view.MenuInflater;
 import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.PopupMenu;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+import androidx.lifecycle.ViewModelProvider;
 import androidx.media3.common.util.UnstableApi;
 
 import com.eddyizm.tempus.R;
 import com.eddyizm.tempus.databinding.FragmentToolbarBinding;
+import com.eddyizm.tempus.subsonic.models.MusicFolder;
 import com.eddyizm.tempus.ui.activity.MainActivity;
+import com.eddyizm.tempus.util.MusicFolderUtil;
+import com.eddyizm.tempus.util.Preferences;
+import com.eddyizm.tempus.viewmodel.LibraryViewModel;
+import com.eddyizm.tempus.viewmodel.MainViewModel;
 import com.google.android.gms.cast.framework.CastButtonFactory;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @UnstableApi
 public class ToolbarFragment extends Fragment {
     private static final String TAG = "ToolbarFragment";
 
+    private static final int MUSIC_LIBRARY_MENU_GROUP = 1;
+    private static final int ALL_LIBRARIES_ITEM_ID = 0;
+    private static final int NO_CHECKED_ITEM = -1;
+
     private FragmentToolbarBinding bind;
     private MainActivity activity;
+    private LibraryViewModel libraryViewModel;
+    private MainViewModel mainViewModel;
+
+    private final List<MusicFolder> musicFolders = new ArrayList<>();
 
     public ToolbarFragment() {
         // Required empty public constructor
@@ -49,7 +67,30 @@ public class ToolbarFragment extends Fragment {
         bind = FragmentToolbarBinding.inflate(inflater, container, false);
         View view = bind.getRoot();
 
+        libraryViewModel = new ViewModelProvider(requireActivity()).get(LibraryViewModel.class);
+        mainViewModel = new ViewModelProvider(requireActivity()).get(MainViewModel.class);
+
         return view;
+    }
+
+    @Override
+    public void onViewCreated(@NonNull View view, @Nullable Bundle savedInstanceState) {
+        super.onViewCreated(view, savedInstanceState);
+
+        initMusicLibrarySwitcher();
+    }
+
+    @Override
+    public void onResume() {
+        super.onResume();
+        // Catches a restore that put the pager back on Podcast or Radio.
+        updateMusicLibraryIndicator();
+    }
+
+    @Override
+    public void onDestroyView() {
+        super.onDestroyView();
+        bind = null;
     }
 
     @Override
@@ -63,5 +104,113 @@ public class ToolbarFragment extends Fragment {
         }
 
         return false;
+    }
+
+    private void initMusicLibrarySwitcher() {
+        if (!isLibraryScopedScreen()) return;
+
+        bind.toolbarTitleContainer.setOnClickListener(this::showMusicLibraryMenu);
+
+        // The list is cached on the activity scoped LibraryViewModel, so once it has arrived the
+        // Library tab and this share it. Until then either screen can be the one that fetches it.
+        libraryViewModel.getMusicFolders(getViewLifecycleOwner()).observe(getViewLifecycleOwner(), folders -> {
+            musicFolders.clear();
+            if (folders != null) musicFolders.addAll(folders);
+            updateMusicLibraryIndicator();
+        });
+
+        mainViewModel.getActiveMusicFolderId().observe(getViewLifecycleOwner(), musicFolderId -> updateMusicLibraryIndicator());
+    }
+
+    /**
+     * Home calls this when its pager changes page.
+     */
+    public void refreshMusicLibraryIndicator() {
+        updateMusicLibraryIndicator();
+    }
+
+    /**
+     * Podcasts and internet radio are no more library scoped than downloads are, and they are
+     * pages of Home's pager, so the nav destination cannot tell them apart. Asked of Home on every
+     * update instead of being pushed once.
+     */
+    private boolean isLibraryScopedTab() {
+        Fragment parent = getParentFragment();
+        return !(parent instanceof HomeFragment) || ((HomeFragment) parent).isLibraryScopedTab();
+    }
+
+    /**
+     * Downloads are local files that no library filter reaches, so a line naming one there would
+     * describe something other than what is on the screen.
+     *
+     * Asked of the host fragment, not the NavController: a dialog destination becomes the current
+     * destination without destroying this view, so consulting the graph made Downloads answer yes
+     * while a bottom sheet was open.
+     */
+    private boolean isLibraryScopedScreen() {
+        return !(getParentFragment() instanceof DownloadFragment);
+    }
+
+    private void updateMusicLibraryIndicator() {
+        if (bind == null) return;
+
+        // One library offers no choice. A filter in force has to stay visible whatever the folder
+        // list says, because this is the only way to clear one from outside Settings, and the list
+        // is empty for as long as the server has not answered.
+        boolean canChoose = musicFolders.size() > 1 || Preferences.getActiveMusicFolderId() != null;
+        boolean visible = canChoose && isLibraryScopedScreen() && isLibraryScopedTab();
+
+        bind.toolbarTitleContainer.setClickable(visible);
+        bind.toolbarMusicLibraryTextView.setVisibility(visible ? View.VISIBLE : View.GONE);
+
+        if (!visible) return;
+
+        String name = MusicFolderUtil.resolveMusicFolderName(musicFolders, Preferences.getActiveMusicFolderId());
+        bind.toolbarMusicLibraryTextView.setText(name != null ? name : getString(R.string.settings_music_library_all));
+    }
+
+    private void showMusicLibraryMenu(View anchor) {
+        PopupMenu popup = new PopupMenu(requireContext(), anchor);
+        String activeMusicFolderId = Preferences.getActiveMusicFolderId();
+
+        // Item ids are the folder's position in the list plus one, leaving zero for every library.
+        // NO_CHECKED_ITEM means the stored library is not in the list, which happens when the
+        // server dropped it or never answered. Checking every library there would say no filter is
+        // running while the requests still carry one, so nothing is checked and the line above the
+        // menu keeps naming the id that is actually in force.
+        int checkedItemId = activeMusicFolderId == null ? ALL_LIBRARIES_ITEM_ID : NO_CHECKED_ITEM;
+        popup.getMenu().add(MUSIC_LIBRARY_MENU_GROUP, ALL_LIBRARIES_ITEM_ID, ALL_LIBRARIES_ITEM_ID, R.string.settings_music_library_all);
+
+        for (int i = 0; i < musicFolders.size(); i++) {
+            MusicFolder musicFolder = musicFolders.get(i);
+            if (musicFolder.getId() == null) continue;
+
+            String name = musicFolder.getName() != null ? musicFolder.getName() : musicFolder.getId();
+            popup.getMenu().add(MUSIC_LIBRARY_MENU_GROUP, i + 1, i + 1, name);
+
+            if (musicFolder.getId().equals(activeMusicFolderId)) checkedItemId = i + 1;
+        }
+
+        // Checkable has to be granted to the group before an item will accept being checked.
+        popup.getMenu().setGroupCheckable(MUSIC_LIBRARY_MENU_GROUP, true, true);
+        if (checkedItemId != NO_CHECKED_ITEM) popup.getMenu().findItem(checkedItemId).setChecked(true);
+
+        // Resolve the id while the menu is built. Reading it back by position on click would pick
+        // whatever now sits at that index if a later fetch replaced the list.
+        List<String> itemIds = new ArrayList<>();
+        for (MusicFolder musicFolder : musicFolders) itemIds.add(musicFolder.getId());
+
+        popup.setOnMenuItemClickListener(menuItem -> {
+            int index = menuItem.getItemId() - 1;
+            String selectedId = index < 0 ? Preferences.MUSIC_FOLDER_ALL : itemIds.get(index);
+
+            // A null id never got a menu item, so reaching here with one is not possible today.
+            if (selectedId == null) return true;
+
+            mainViewModel.setActiveMusicFolderId(selectedId);
+            return true;
+        });
+
+        popup.show();
     }
 }

--- a/app/src/tempus/java/com/eddyizm/tempus/ui/fragment/ToolbarFragment.java
+++ b/app/src/tempus/java/com/eddyizm/tempus/ui/fragment/ToolbarFragment.java
@@ -17,6 +17,8 @@ import androidx.media3.common.util.UnstableApi;
 
 import com.eddyizm.tempus.R;
 import com.eddyizm.tempus.databinding.FragmentToolbarBinding;
+import com.eddyizm.tempus.model.Server;
+import com.eddyizm.tempus.repository.ServerRepository;
 import com.eddyizm.tempus.subsonic.models.MusicFolder;
 import com.eddyizm.tempus.ui.activity.MainActivity;
 import com.eddyizm.tempus.util.MusicFolderUtil;
@@ -42,6 +44,8 @@ public class ToolbarFragment extends Fragment {
     private MainViewModel mainViewModel;
 
     private final List<MusicFolder> musicFolders = new ArrayList<>();
+
+    private String serverName;
 
     public ToolbarFragment() {
         // Required empty public constructor
@@ -120,6 +124,21 @@ public class ToolbarFragment extends Fragment {
         });
 
         mainViewModel.getActiveMusicFolderId().observe(getViewLifecycleOwner(), musicFolderId -> updateMusicLibraryIndicator());
+
+        // The name lives in the server table, not in Preferences, so it takes a read of every
+        // row and a match on the stored id.
+        new ServerRepository().getLiveServer().observe(getViewLifecycleOwner(), servers -> {
+            String serverId = Preferences.getServerId();
+
+            serverName = null;
+            if (servers != null && serverId != null) {
+                for (Server server : servers) {
+                    if (serverId.equals(server.getServerId())) serverName = server.getServerName();
+                }
+            }
+
+            updateMusicLibraryIndicator();
+        });
     }
 
     /**
@@ -160,8 +179,19 @@ public class ToolbarFragment extends Fragment {
         boolean canChoose = musicFolders.size() > 1 || Preferences.getActiveMusicFolderId() != null;
         boolean visible = canChoose && isLibraryScopedScreen() && isLibraryScopedTab();
 
+        // Podcast and Radio are the tabs the library never reaches, so the line carries the
+        // server instead of nothing. No caret there, since nothing is tappable.
+        boolean showServerName = !visible && serverName != null && isLibraryScopedScreen() && !isLibraryScopedTab();
+
         bind.toolbarTitleContainer.setClickable(visible);
-        bind.toolbarMusicLibraryTextView.setVisibility(visible ? View.VISIBLE : View.GONE);
+        bind.toolbarMusicLibraryTextView.setVisibility(visible || showServerName ? View.VISIBLE : View.GONE);
+        bind.toolbarMusicLibraryTextView.setCompoundDrawablesRelativeWithIntrinsicBounds(
+                0, 0, visible ? R.drawable.ic_expand_more_small : 0, 0);
+
+        if (showServerName) {
+            bind.toolbarMusicLibraryTextView.setText(serverName);
+            return;
+        }
 
         if (!visible) return;
 

--- a/app/src/test/java/com/eddyizm/tempus/util/MusicFolderUtilTest.java
+++ b/app/src/test/java/com/eddyizm/tempus/util/MusicFolderUtilTest.java
@@ -1,0 +1,54 @@
+package com.eddyizm.tempus.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+import com.eddyizm.tempus.subsonic.models.MusicFolder;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(JUnit4.class)
+public class MusicFolderUtilTest {
+
+    private static final List<MusicFolder> TWO_LIBRARIES = Arrays.asList(
+            new MusicFolder("1", "Music Library"),
+            new MusicFolder("2", "Test Library")
+    );
+
+    @Test
+    public void noSelectionMeansEveryLibrary() {
+        assertNull(MusicFolderUtil.resolveMusicFolderName(TWO_LIBRARIES, null));
+    }
+
+    @Test
+    public void selectedLibraryIsNamed() {
+        assertEquals("Test Library", MusicFolderUtil.resolveMusicFolderName(TWO_LIBRARIES, "2"));
+    }
+
+    @Test
+    public void libraryWithNoNameFallsBackToItsId() {
+        List<MusicFolder> folders = Collections.singletonList(new MusicFolder("7", null));
+        assertEquals("7", MusicFolderUtil.resolveMusicFolderName(folders, "7"));
+    }
+
+    @Test
+    public void staleSelectionIsNamedNotReportedAsEveryLibrary() {
+        assertEquals("99", MusicFolderUtil.resolveMusicFolderName(TWO_LIBRARIES, "99"));
+    }
+
+    @Test
+    public void selectionSurvivesAnAbsentFolderList() {
+        assertEquals("2", MusicFolderUtil.resolveMusicFolderName(null, "2"));
+    }
+
+    @Test
+    public void noSelectionAndNoFolderListMeansEveryLibrary() {
+        assertNull(MusicFolderUtil.resolveMusicFolderName(null, null));
+    }
+}


### PR DESCRIPTION
Tempus can already limit browsing and search to one music library, but the only way to pick one is to go into Settings, and once you are back in the app nothing tells you which library you are in.

#169 asked for a library switcher and it shipped in v4.24.0 the follow up ask on that issue was for a quicker way to reach it than the settings menu this is that.

This puts the choice in the toolbar on Home and on Library, when your server has more than one library, the one you are in is named under the app name. Tap the title to switch and the screen you are on updates with no restart and no trip through Settings.

Downloads is not filtered by library so the line stays off there Podcast and Radio are not filtered either, so they show your server's name in that spot instead.

### Screenshots

<table>
<tr>
<td><img src="https://github.com/user-attachments/assets/6ae6a92e-4a47-4c66-8b26-1dd13444da2e" width="260"></td>
<td><img src="https://github.com/user-attachments/assets/880d9152-26d7-4bd9-8b06-3ff87bd40561" width="260"></td>
<td><img src="https://github.com/user-attachments/assets/d0c3f891-3af0-45b7-9cc7-0d8472b1a144" width="260"></td>
</tr>
<tr>
<td>Home, with no library picked</td>
<td>The chooser, opened from the title</td>
<td>The same screen after switching, no restart</td>
</tr>
</table>

### Tested

An emulator against a server with two libraries, and a phone. Switching library from the toolbar on Home changed the albums on screen with no restart, and switching back to all libraries brought the full set back. There are six unit tests over the name lookup.

