### PR TITLE
fix: tell the user a playlist is empty instead of a dead Play button

### DIFF
--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/PlaylistPageFragment.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/PlaylistPageFragment.java
@@ -272,8 +272,8 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
                         .observe(getViewLifecycleOwner(), songs -> {
                             if (songs != null) {
 
-                                bind.playlistPagePlayButton.setEnabled(true);
-                                bind.playlistPageShuffleButton.setEnabled(true);
+                                bind.playlistPagePlayButton.setEnabled(!songs.isEmpty());
+                                bind.playlistPageShuffleButton.setEnabled(!songs.isEmpty());
 
                                 if (bind.songRecyclerViewPlaceholder != null) {
                                     bind.songRecyclerViewPlaceholder.setVisibility(View.GONE);
@@ -455,6 +455,7 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
         playlistPageViewModel.getPlaylistSongLiveList().observe(getViewLifecycleOwner(), songs -> {
             songHorizontalAdapter.setItems(songs);
             if (songs != null) {
+                bind.emptyPlaylistLabel.setVisibility(songs.isEmpty() ? View.VISIBLE : View.GONE);
                 bind.playlistSongCountLabel.setText(getString(R.string.playlist_song_count, songs.size()));
                 long totalDuration = songs.stream().mapToLong(s -> s.getDuration() != null ? s.getDuration() : 0).sum();
                 bind.playlistDurationLabel.setText(getString(R.string.playlist_duration, MusicUtil.getReadableDurationString(totalDuration, false)));

--- a/app/src/main/res/layout-land/fragment_playlist_page.xml
+++ b/app/src/main/res/layout-land/fragment_playlist_page.xml
@@ -161,7 +161,8 @@
                             android:textAllCaps="false"
                             app:icon="@drawable/ic_play"
                             app:iconGravity="textStart"
-                            app:iconPadding="18dp" />
+                            app:iconPadding="18dp"
+                            android:enabled="false" />
 
                         <Button
                             android:id="@+id/playlist_page_shuffle_button"
@@ -175,7 +176,8 @@
                             android:textAllCaps="false"
                             app:icon="@drawable/ic_shuffle"
                             app:iconGravity="textStart"
-                            app:iconPadding="18dp" />
+                            app:iconPadding="18dp"
+                            android:enabled="false" />
                     </LinearLayout>
 
                     <TextView
@@ -212,14 +214,28 @@
             </com.google.android.material.appbar.AppBarLayout>
         </androidx.core.widget.NestedScrollView>
 
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/song_recycler_view"
+        <FrameLayout
             android:layout_width="0dp"
             android:layout_height="match_parent"
-            android:layout_weight="1.2"
-            android:clipToPadding="false"
-            android:paddingTop="8dp"
-            android:paddingBottom="75dp" />
+            android:layout_weight="1.2">
+
+            <androidx.recyclerview.widget.RecyclerView
+                android:id="@+id/song_recycler_view"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:clipToPadding="false"
+                android:paddingTop="8dp"
+                android:paddingBottom="75dp" />
+
+            <TextView
+                android:id="@+id/empty_playlist_label"
+                style="@style/LabelSmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:text="@string/playlist_page_empty"
+                android:visibility="gone" />
+        </FrameLayout>
 
     </LinearLayout>
 </LinearLayout>

--- a/app/src/main/res/layout/fragment_playlist_page.xml
+++ b/app/src/main/res/layout/fragment_playlist_page.xml
@@ -200,6 +200,17 @@
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
                 android:layout_gravity="center_horizontal"/>
+
+            <TextView
+                android:id="@+id/empty_playlist_label"
+                style="@style/LabelSmall"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_horizontal"
+                android:paddingTop="8dp"
+                android:paddingBottom="8dp"
+                android:text="@string/playlist_page_empty"
+                android:visibility="gone" />
         </com.google.android.material.appbar.AppBarLayout>
 
         <androidx.recyclerview.widget.RecyclerView

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -341,6 +341,7 @@
     <string name="playlist_editor_dialog_action_delete_failure">Failed to delete playlist</string>
     <string name="playlist_editor_dialog_action_save_success">Playlist saved</string>
     <string name="playlist_editor_dialog_action_save_failure">Failed to save playlist</string>
+    <string name="playlist_page_empty">No songs in this playlist</string>
     <string name="playlist_page_play_button">Play</string>
     <string name="playlist_page_shuffle_button">Shuffle</string>
     <string name="playlist_song_count">Playlist  •  %1$d songs</string>


### PR DESCRIPTION
A playlist with no songs opened with both Play and Shuffle switched on, and
pressing Play started an empty queue and put an empty player bar at the bottom
of the screen. If music was already playing it stopped, and the queue it came
from was emptied.

The page showed the playlist name, a count of zero and a length of zero, with an
empty song list and nothing to say why.

Both buttons were switched on the moment the song list arrived, with nothing
checking whether the list held anything, and they are now switched on only when
the playlist comes back with at least one song. Each layout also sets whether
the buttons start switched on, before any songs arrive: portrait already starts
with both buttons switched off, and landscape started with them switched on, so
landscape now starts with them switched off too.

The page now says "No songs in this playlist" when the playlist comes back with
no songs. In portrait the message sits under the two buttons, and in landscape
it is centered in the column the songs would fill. A search inside the playlist
that matches nothing leaves the song list looking empty as well, and there the
message does not appear and both buttons stay switched on.

I tested the change against a running server, using the same empty playlist
before and after. Before, with eighteen songs queued and one of them playing,
pressing Play on the empty playlist stopped the music and emptied the queue;
after, both buttons were switched off and the message was shown in portrait and
in landscape, and a playlist with songs still listed them with both buttons
switched on.