### PR TITLE
fix: stop the player holding itself open after the app is closed

### DIFF
--- a/app/src/main/java/com/eddyizm/tempus/service/BaseMediaService.kt
+++ b/app/src/main/java/com/eddyizm/tempus/service/BaseMediaService.kt
@@ -3,7 +3,6 @@ package com.eddyizm.tempus.service
 import android.app.PendingIntent.FLAG_IMMUTABLE
 import android.app.PendingIntent.FLAG_UPDATE_CURRENT
 import android.app.TaskStackBuilder
-import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.net.ConnectivityManager
@@ -55,7 +54,7 @@ import kotlin.random.Random
 private const val TAG = "BaseMediaService"
 
 @UnstableApi
-open class BaseMediaService : MediaLibraryService() {
+open class BaseMediaService : MediaLibraryService(), MediaManager.QueueTarget {
     companion object {
         const val ACTION_BIND_EQUALIZER = "com.eddyizm.tempus.service.BIND_EQUALIZER"
         const val ACTION_EQUALIZER_UPDATED = "com.eddyizm.tempus.service.EQUALIZER_UPDATED"
@@ -174,13 +173,17 @@ open class BaseMediaService : MediaLibraryService() {
         }, MoreExecutors.directExecutor())
     }
 
-    // "Play next" under shuffle: the UI inserts items at current+1 on the timeline and asks
-    // the service to splice them into shuffle position current+1. Inserts land asynchronously,
+    // MediaManager.QueueTarget: null once the service is destroyed, so a queue edit that
+    // arrives after that is dropped instead of reaching a released player.
+    override fun livePlayer(): Player? = if (serviceDestroyed) null else mediaLibrarySession.player
+
+    // "Play next" under shuffle: items are inserted at current+1 on the timeline, and the
+    // service splices them into shuffle position current+1. Inserts land asynchronously,
     // so requests are queued and applied from onTimelineChanged once each target count is visible.
     private data class PlayNextRequest(val insertPos: Int, val count: Int, val target: Int)
     private val playNextQueue = ArrayDeque<PlayNextRequest>()
 
-    fun requestPlayNextFixup(insertPos: Int, count: Int, target: Int) {
+    override fun requestPlayNextFixup(insertPos: Int, count: Int, target: Int) {
         if (insertPos < 0 || count <= 0 || target < 0) return
         playNextQueue.addLast(PlayNextRequest(insertPos, count, target))
         tryApplyPlayNextFixup()
@@ -380,18 +383,13 @@ open class BaseMediaService : MediaLibraryService() {
                     if (item.mediaMetadata.extras != null)
                         MediaManager.scrobble(item, false)
 
-                    val browserFuture = MediaBrowser.Builder(
-                        this@BaseMediaService,
-                        SessionToken(this@BaseMediaService, ComponentName(this@BaseMediaService, this@BaseMediaService::class.java))
-                    ).buildAsync()
-
                     val handled = MediaServiceExtensionRegistry.handler
-                        ?.handle(player, currentMediaItem, browserFuture)
+                        ?.handle(player, currentMediaItem, this@BaseMediaService)
                         ?: false
 
                     if (player.nextMediaItemIndex == C.INDEX_UNSET) {
                         if (!handled && Preferences.isContinuousPlayEnabled()) {
-                            MediaManager.continuousPlay(currentMediaItem, browserFuture)
+                            MediaManager.continuousPlay(currentMediaItem, this@BaseMediaService)
                         }
                     }
                 }
@@ -632,18 +630,14 @@ open class BaseMediaService : MediaLibraryService() {
         val currentMediaItem = player.currentMediaItem
         val currentIndex = player.currentMediaItemIndex
         val lastIndex = player.mediaItemCount - 1
-        val browserFuture = MediaBrowser.Builder(
-            this@BaseMediaService,
-            SessionToken(this@BaseMediaService, ComponentName(this@BaseMediaService, this@BaseMediaService::class.java))
-        ).buildAsync()
 
         if (currentIndex in 0 until lastIndex) {
             Log.d(TAG, "onInstantMix: remove range from $currentIndex to $lastIndex")
-            MediaManager.removeRange(browserFuture, currentIndex + 1, lastIndex + 1)
+            MediaManager.removeRange(this, currentIndex + 1, lastIndex + 1)
         }
 
         Log.d(TAG, "onInstantMix: start Continuous Play with $currentMediaItem")
-        MediaManager.continuousPlay(currentMediaItem, browserFuture) {
+        MediaManager.continuousPlay(currentMediaItem, this) {
             Handler(Looper.getMainLooper()).post { onComplete?.run() }
         }
     }
@@ -696,6 +690,8 @@ open class BaseMediaService : MediaLibraryService() {
     override fun onDestroy() {
         QueuePreloader.cancel()
         serviceDestroyed = true
+        // Process scoped, so it outlives the service unless it is cleared here.
+        MediaServiceExtensionRegistry.handler = null
         releaseNetworkCallback()
         equalizerManager.release(exoplayer.audioSessionId)
         ReplayGainUtil.release()

--- a/app/src/main/java/com/eddyizm/tempus/service/MediaManager.java
+++ b/app/src/main/java/com/eddyizm/tempus/service/MediaManager.java
@@ -43,7 +43,6 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-import java.util.Objects;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -57,6 +56,53 @@ public class MediaManager {
     public static AtomicBoolean continuousPlayIsRunning = new AtomicBoolean(false);
 
     private static final ExecutorService backgroundExecutor = Executors.newSingleThreadExecutor();
+
+    /**
+     * Where a queue edit is applied: the service's own player, or a session controller.
+     * The service returns null from livePlayer() once it is destroyed, so an edit that
+     * arrives after that is dropped instead of reaching a released player; the check and the
+     * edit both run on the app's main thread, which is also where the service is destroyed.
+     * A controller always returns itself, which leaves the browser paths exactly as they
+     * were: nothing on them was ever guarded by a release check.
+     */
+    public interface QueueTarget {
+        @Nullable
+        Player livePlayer();
+
+        void requestPlayNextFixup(int insertPos, int count, int targetCount);
+    }
+
+    private static QueueTarget queueTargetFor(MediaBrowser browser) {
+        return new QueueTarget() {
+            @Override
+            public Player livePlayer() {
+                return browser;
+            }
+
+            @Override
+            public void requestPlayNextFixup(int insertPos, int count, int targetCount) {
+                Bundle args = new Bundle();
+                args.putInt(Constants.PLAY_NEXT_INSERT_POS, insertPos);
+                args.putInt(Constants.PLAY_NEXT_COUNT, count);
+                args.putInt(Constants.PLAY_NEXT_TARGET_COUNT, targetCount);
+                ListenableFuture<SessionResult> fixup = browser.sendCustomCommand(
+                        new SessionCommand(Constants.CUSTOM_COMMAND_PLAY_NEXT, Bundle.EMPTY), args);
+                Futures.addCallback(fixup, new FutureCallback<SessionResult>() {
+                    @Override
+                    public void onSuccess(SessionResult result) {
+                        if (result.resultCode != SessionResult.RESULT_SUCCESS) {
+                            Log.e(TAG, "insertPlayNext: play-next fixup rejected with code " + result.resultCode);
+                        }
+                    }
+
+                    @Override
+                    public void onFailure(Throwable t) {
+                        Log.e(TAG, "insertPlayNext: play-next fixup command failed", t);
+                    }
+                }, MoreExecutors.directExecutor());
+            }
+        };
+    }
 
     public static void registerPlaybackObserver(
             ListenableFuture<MediaBrowser> browserFuture,
@@ -330,21 +376,30 @@ public class MediaManager {
             mediaBrowserListenableFuture.addListener(() -> {
                 try {
                     if (mediaBrowserListenableFuture.isDone()) {
-                        Log.d(TAG, "enqueue");
-                        MediaBrowser browser = mediaBrowserListenableFuture.get();
-                        int current = browser.getCurrentMediaItemIndex();
-                        if (playImmediatelyAfter && current != C.INDEX_UNSET) {
-                            enqueueDatabase(media, false, current + 1);
-                            insertPlayNext(browser, MappingUtil.mapMediaItems(media));
-                        } else {
-                            enqueueDatabase(media, false, mediaBrowserListenableFuture.get().getMediaItemCount());
-                            mediaBrowserListenableFuture.get().addMediaItems(MappingUtil.mapMediaItems(media));
-                        }
+                        enqueue(queueTargetFor(mediaBrowserListenableFuture.get()), media, playImmediatelyAfter);
                     }
                 } catch (ExecutionException | InterruptedException e) {
                     e.printStackTrace();
                 }
             }, MoreExecutors.directExecutor());
+        }
+    }
+
+    public static void enqueue(QueueTarget queueTarget, List<Child> media, boolean playImmediatelyAfter) {
+        Player player = queueTarget.livePlayer();
+        if (player == null) {
+            Log.d(TAG, "enqueue: queue target gone, dropping " + media.size() + " items");
+            return;
+        }
+
+        Log.d(TAG, "enqueue");
+        int current = player.getCurrentMediaItemIndex();
+        if (playImmediatelyAfter && current != C.INDEX_UNSET) {
+            enqueueDatabase(media, false, current + 1);
+            insertPlayNext(queueTarget, player, MappingUtil.mapMediaItems(media));
+        } else {
+            enqueueDatabase(media, false, player.getMediaItemCount());
+            player.addMediaItems(MappingUtil.mapMediaItems(media));
         }
     }
 
@@ -358,7 +413,7 @@ public class MediaManager {
                         int current = browser.getCurrentMediaItemIndex();
                         if (playImmediatelyAfter && current != C.INDEX_UNSET) {
                             enqueueDatabase(media, false, current + 1);
-                            insertPlayNext(browser, Collections.singletonList(MappingUtil.mapMediaItem(media)));
+                            insertPlayNext(queueTargetFor(browser), browser, Collections.singletonList(MappingUtil.mapMediaItem(media)));
                         } else {
                             enqueueDatabase(media, false, mediaBrowserListenableFuture.get().getMediaItemCount());
                             mediaBrowserListenableFuture.get().addMediaItem(MappingUtil.mapMediaItem(media));
@@ -373,41 +428,19 @@ public class MediaManager {
 
     // "Play next": insert the items right after the current item on the timeline, then —
     // once the insert has actually applied — ask the service to move them next in the
-    // ExoPlayer shuffle order too. The timeline insert keeps URI/large-list handling on the
-    // normal onAddMediaItems path; the shuffle-order fixup must run on the service (only it
-    // can setShuffleOrder). addMediaItems and a custom command are NOT ordered relative to
-    // each other, so we send the fixup from a one-shot timeline listener once the insert is
-    // visible (same pattern startQueue uses), otherwise the fixup would be clobbered by
-    // addMediaItems' own internal shuffle insert. The fixup is a no-op when shuffle is off.
-    private static void insertPlayNext(MediaBrowser browser, List<MediaItem> items) {
+    // ExoPlayer shuffle order too. The shuffle order fixup must run on the service (only it
+    // can setShuffleOrder), and it cannot run until the insert is visible on the timeline
+    // (from a controller, addMediaItems updates the controller optimistically before the
+    // session's async onAddMediaItems even runs), so the service stashes the request and
+    // applies it from its own onTimelineChanged once the target count is reached, otherwise
+    // the fixup would be clobbered by addMediaItems' own internal shuffle insert. The fixup
+    // is a no-op when shuffle is off.
+    private static void insertPlayNext(QueueTarget queueTarget, Player player, List<MediaItem> items) {
         if (items.isEmpty()) return;
-        int insertPos = browser.getCurrentMediaItemIndex() + 1;
-        int targetCount = browser.getMediaItemCount() + items.size();
-        // Send the fixup request and do the timeline insert. These two are NOT ordered
-        // relative to each other (and addMediaItems updates the controller optimistically
-        // before the session's async onAddMediaItems even runs), so the service stashes the
-        // request and applies it from its own onTimelineChanged once the insert is visible.
-        Bundle args = new Bundle();
-        args.putInt(Constants.PLAY_NEXT_INSERT_POS, insertPos);
-        args.putInt(Constants.PLAY_NEXT_COUNT, items.size());
-        args.putInt(Constants.PLAY_NEXT_TARGET_COUNT, targetCount);
-        ListenableFuture<SessionResult> fixup =
-                browser.sendCustomCommand(
-                        new SessionCommand(Constants.CUSTOM_COMMAND_PLAY_NEXT, Bundle.EMPTY), args);
-        Futures.addCallback(fixup, new FutureCallback<SessionResult>() {
-            @Override
-            public void onSuccess(SessionResult result) {
-                if (result.resultCode != SessionResult.RESULT_SUCCESS) {
-                    Log.e(TAG, "insertPlayNext: play-next fixup rejected with code " + result.resultCode);
-                }
-            }
-
-            @Override
-            public void onFailure(Throwable t) {
-                Log.e(TAG, "insertPlayNext: play-next fixup command failed", t);
-            }
-        }, MoreExecutors.directExecutor());
-        browser.addMediaItems(insertPos, items);
+        int insertPos = player.getCurrentMediaItemIndex() + 1;
+        int targetCount = player.getMediaItemCount() + items.size();
+        queueTarget.requestPlayNextFixup(insertPos, items.size(), targetCount);
+        player.addMediaItems(insertPos, items);
     }
 
     public static void shuffle(ListenableFuture<MediaBrowser> mediaBrowserListenableFuture, List<Child> media, int startIndex, int endIndex) {
@@ -488,19 +521,15 @@ public class MediaManager {
         }
     }
 
-    public static void removeRange(ListenableFuture<MediaBrowser> mediaBrowserListenableFuture, int fromItem, int toItem) {
-        if (mediaBrowserListenableFuture != null) {
-            mediaBrowserListenableFuture.addListener(() -> {
-                try {
-                    if (mediaBrowserListenableFuture.isDone()) {
-                        mediaBrowserListenableFuture.get().removeMediaItems(fromItem, toItem);
-                        getQueueRepository().deleteRange(fromItem, toItem);
-                    }
-                } catch (ExecutionException | InterruptedException e) {
-                    e.printStackTrace();
-                }
-            }, MoreExecutors.directExecutor());
+    public static void removeRange(QueueTarget queueTarget, int fromItem, int toItem) {
+        Player player = queueTarget.livePlayer();
+        if (player == null) {
+            Log.d(TAG, "removeRange: queue target gone");
+            return;
         }
+
+        player.removeMediaItems(fromItem, toItem);
+        getQueueRepository().deleteRange(fromItem, toItem);
     }
 
     public static void getCurrentIndex(ListenableFuture<MediaBrowser> mediaBrowserListenableFuture, MediaIndexCallback callback) {
@@ -540,15 +569,21 @@ public class MediaManager {
 
     @OptIn(markerClass = UnstableApi.class)
     public static void continuousPlay(MediaItem mediaItem,
-                                      ListenableFuture<MediaBrowser> existingBrowserFuture) {
-        continuousPlay(mediaItem, existingBrowserFuture, null);
+                                      QueueTarget queueTarget) {
+        continuousPlay(mediaItem, queueTarget, null);
     }
     @OptIn(markerClass = UnstableApi.class)
     public static void continuousPlay(MediaItem mediaItem,
-                                      ListenableFuture<MediaBrowser> existingBrowserFuture,
+                                      QueueTarget queueTarget,
                                       @Nullable Runnable onComplete) {
         if (continuousPlayIsRunning.get() || !Preferences.isInstantMixUsable()) {
             Log.d(TAG, "Continuous Play: already running");
+            if (onComplete != null) onComplete.run();
+            return;
+        }
+        Player player = queueTarget.livePlayer();
+        if (player == null) {
+            Log.d(TAG, "Continuous Play: queue target gone");
             if (onComplete != null) onComplete.run();
             return;
         }
@@ -559,24 +594,13 @@ public class MediaManager {
 
         // keep only NUMBER_TRACKS_KEEP_IN_QUEUE items in queue before starting continuous play
         int numberOfTracksKeepInQueue = Preferences.getNumberOfTracksKeepInQueue();
-        if (existingBrowserFuture != null) {
-            existingBrowserFuture.addListener(() -> {
-                try {
-                    if (existingBrowserFuture.isDone()) {
-                        MediaBrowser browser = existingBrowserFuture.get();
-                        int currentIndex = browser.getCurrentMediaItem() != null
-                                ? browser.getCurrentMediaItemIndex()
-                                : 0;
-                        int firstToKeep = Math.max(0, currentIndex - numberOfTracksKeepInQueue);
-                        if (firstToKeep > 0) {
-                            Log.d(TAG, "Continuous Play: purging " + firstToKeep + " old items from queue");
-                            removeRange(existingBrowserFuture, 0, firstToKeep);
-                        }
-                    }
-                } catch (ExecutionException | InterruptedException e) {
-                    Log.e(TAG, "Continuous Play: purge failed", e);
-                }
-            }, MoreExecutors.directExecutor());
+        int currentIndex = player.getCurrentMediaItem() != null
+                ? player.getCurrentMediaItemIndex()
+                : 0;
+        int firstToKeep = Math.max(0, currentIndex - numberOfTracksKeepInQueue);
+        if (firstToKeep > 0) {
+            Log.d(TAG, "Continuous Play: purging " + firstToKeep + " old items from queue");
+            removeRange(queueTarget, 0, firstToKeep);
         }
         String trackId = mediaItem.mediaId;
         String artistId = mediaItem.mediaMetadata.extras != null
@@ -595,10 +619,10 @@ public class MediaManager {
                 // getSimilarSongs2 doesn't know what's already queued, so it may
                 // return tracks we already have. Filter first, then decide.
                 if (media != null && !media.isEmpty()) {
-                    List<Child> filtered = dedupAgainstQueue(media, existingBrowserFuture);
+                    List<Child> filtered = dedupAgainstQueue(media, queueTarget);
                     if (!filtered.isEmpty()) {
                         Log.d(TAG, "Continuous Play: adding " + filtered.size() + " similar tracks");
-                        enqueue(existingBrowserFuture, filtered, true);
+                        enqueue(queueTarget, filtered, true);
                         continuousPlayIsRunning.set(false);
                         return;
                     }
@@ -612,10 +636,10 @@ public class MediaManager {
                         public void onChanged(List<Child> random) {
                             randomSongs.removeObserver(this);
                             if (random != null && !random.isEmpty()) {
-                                List<Child> filtered = dedupAgainstQueue(random, existingBrowserFuture);
+                                List<Child> filtered = dedupAgainstQueue(random, queueTarget);
                                 if (!filtered.isEmpty()) {
                                     Log.d(TAG, "Continuous Play: adding " + filtered.size() + " random tracks");
-                                    enqueue(existingBrowserFuture, filtered, true);
+                                    enqueue(queueTarget, filtered, true);
                                 } else {
                                     Log.w(TAG, "Continuous Play: random tracks already in queue");
                                 }
@@ -634,19 +658,13 @@ public class MediaManager {
     }
 
     private static List<Child> dedupAgainstQueue(List<Child> candidates,
-                                                  ListenableFuture<MediaBrowser> existingBrowserFuture) {
-        if (existingBrowserFuture == null) return new ArrayList<>(candidates);
-
-        final MediaBrowser browser;
-        try {
-            browser = existingBrowserFuture.get();
-        } catch (ExecutionException | InterruptedException e) {
-            return new ArrayList<>(candidates);
-        }
+                                                  QueueTarget queueTarget) {
+        Player player = queueTarget.livePlayer();
+        if (player == null) return new ArrayList<>(candidates);
 
         Set<String> currentIds = new HashSet<>();
-        for (int i = 0; i < Objects.requireNonNull(browser).getMediaItemCount(); i++) {
-            currentIds.add(browser.getMediaItemAt(i).mediaId);
+        for (int i = 0; i < player.getMediaItemCount(); i++) {
+            currentIds.add(player.getMediaItemAt(i).mediaId);
         }
 
         return candidates.stream()

--- a/app/src/main/java/com/eddyizm/tempus/service/MediaServiceExtension.kt
+++ b/app/src/main/java/com/eddyizm/tempus/service/MediaServiceExtension.kt
@@ -2,14 +2,12 @@ package com.eddyizm.tempus.service
 
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
-import androidx.media3.session.MediaBrowser
-import com.google.common.util.concurrent.ListenableFuture
 
 interface MediaServiceExtension {
     fun handle(
         player: Player,
         item: MediaItem,
-        browserFuture: ListenableFuture<MediaBrowser>
+        queueTarget: MediaManager.QueueTarget
     ): Boolean
 }
 

--- a/app/src/tempus/java/com/eddyizm/tempus/repository/InstantMixBuilder.java
+++ b/app/src/tempus/java/com/eddyizm/tempus/repository/InstantMixBuilder.java
@@ -5,13 +5,12 @@ import static com.eddyizm.tempus.service.MediaManager.enqueue;
 import androidx.annotation.NonNull;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.session.MediaBrowser;
 
 import com.eddyizm.tempus.App;
+import com.eddyizm.tempus.service.MediaManager;
 import com.eddyizm.tempus.subsonic.base.ApiResponse;
 import com.eddyizm.tempus.subsonic.models.AlbumID3;
 import com.eddyizm.tempus.subsonic.models.Child;
-import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -43,13 +42,13 @@ public class InstantMixBuilder {
      * @param artistId      The artist ID extracted from parent_id
      * @param usedTrackId   The ID of the first track already playing, to avoid duplicate
      * @param count         Total number of tracks to add (INSTANT_MIX_MAX_TRACKS - 1)
-     * @param browserFuture The MediaBrowser future to enqueue into
+     * @param queueTarget   Where the finished mix is added to the queue
      */
     public void buildAndEnqueue(
             String artistId,
             String usedTrackId,
             int count,
-            ListenableFuture<MediaBrowser> browserFuture) {
+            MediaManager.QueueTarget queueTarget) {
 
         if (!isRunning.compareAndSet(false, true)) {
             Log.d(TAG, "Build already running, skipping");
@@ -79,7 +78,7 @@ public class InstantMixBuilder {
 
                             Random random = new Random();
 
-                            fetchNextTrack(albums, 0, mixTracks, usedTrackIds, random, count, browserFuture);
+                            fetchNextTrack(albums, 0, mixTracks, usedTrackIds, random, count, queueTarget);
 
                             isRunning.set(false);
                         } else {
@@ -112,7 +111,7 @@ public class InstantMixBuilder {
      * @param usedTrackIds  Set of already used track IDs to avoid duplicates
      * @param random        Shared Random instance for shuffling and track picking
      * @param maxTracks     Target number of tracks
-     * @param browserFuture Future to enqueue into when the mix is complete
+     * @param queueTarget   Where the finished mix is added to the queue
      */
     private void fetchNextTrack(
             List<AlbumID3> albums,
@@ -121,12 +120,12 @@ public class InstantMixBuilder {
             Set<String> usedTrackIds,
             Random random,
             int maxTracks,
-            ListenableFuture<MediaBrowser> browserFuture) {
+            MediaManager.QueueTarget queueTarget) {
 
         if (mixTracks.size() >= maxTracks) {
             Log.d(TAG, "Mix complete with " + mixTracks.size() + " tracks, enqueuing");
             repository.setChildrenMetadata(mixTracks);
-            enqueue(browserFuture, mixTracks, true);
+            enqueue(queueTarget, mixTracks, true);
             return;
         }
 
@@ -166,14 +165,14 @@ public class InstantMixBuilder {
                         }
 
                         int nextIndex = (albumIndex == 0) ? 1 : 0;
-                        fetchNextTrack(albums, nextIndex, mixTracks, usedTrackIds, random, maxTracks, browserFuture);
+                        fetchNextTrack(albums, nextIndex, mixTracks, usedTrackIds, random, maxTracks, queueTarget);
                     }
 
                     @Override
                     public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
                         Log.e(TAG, "Failed to load album " + album.getName() + ": " + t.getMessage());
                         int nextIndex = (albumIndex == 0) ? 1 : 0;
-                        fetchNextTrack(albums, nextIndex, mixTracks, usedTrackIds, random, maxTracks, browserFuture);
+                        fetchNextTrack(albums, nextIndex, mixTracks, usedTrackIds, random, maxTracks, queueTarget);
                     }
                 });
     }

--- a/app/src/tempus/java/com/eddyizm/tempus/repository/MadeForYouBuilder.java
+++ b/app/src/tempus/java/com/eddyizm/tempus/repository/MadeForYouBuilder.java
@@ -7,12 +7,12 @@ import androidx.annotation.NonNull;
 import androidx.lifecycle.Observer;
 import androidx.media3.common.util.Log;
 import androidx.media3.common.util.UnstableApi;
-import androidx.media3.session.MediaBrowser;
 
 import com.eddyizm.tempus.App;
 import com.eddyizm.tempus.database.AppDatabase;
 import com.eddyizm.tempus.database.dao.ChronologyDao;
 import com.eddyizm.tempus.model.Chronology;
+import com.eddyizm.tempus.service.MediaManager;
 import com.eddyizm.tempus.subsonic.base.ApiResponse;
 import com.eddyizm.tempus.subsonic.models.AlbumID3;
 import com.eddyizm.tempus.subsonic.models.ArtistID3;
@@ -60,13 +60,13 @@ public class MadeForYouBuilder {
      * @param mixType       AA_QUICKMIX_ID, AA_MYMIX_ID or AA_DISCOVERYMIX_ID
      * @param usedTrackId   The ID of the first track already playing, to avoid duplicate
      * @param count         Total number of tracks to add (INSTANT_MIX_MAX_TRACKS - 1)
-     * @param browserFuture The MediaBrowser future to enqueue into
+     * @param queueTarget   Where the finished mix is added to the queue
      */
     public void buildAndEnqueue(
             String mixType,
             String usedTrackId,
             int count,
-            ListenableFuture<MediaBrowser> browserFuture) {
+            MediaManager.QueueTarget queueTarget) {
 
         if (!isRunning.compareAndSet(false, true)) {
             Log.d(TAG, mixType + " Build already running, skipping");
@@ -102,10 +102,10 @@ public class MadeForYouBuilder {
                                         recentAlbums, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
                                         0, 0, 0, 0,
                                         new ArrayList<>(), usedTrackIds,
-                                        count, mixType, Collections.emptySet(), browserFuture);
+                                        count, mixType, Collections.emptySet(), queueTarget);
                             } else {
                                 Log.w(TAG, mixType + " recent albums failed");
-                                fallbackToRandomSongs(count, usedTrackId, browserFuture);
+                                fallbackToRandomSongs(count, usedTrackId, queueTarget);
                             }
                         }
                         @Override
@@ -206,7 +206,7 @@ public class MadeForYouBuilder {
 
             if (recentAlbums.isEmpty() && starredAlbums.isEmpty() && starredArtists.isEmpty()) {
                 Log.w(TAG, mixType + " No context available, falling back to random songs");
-                fallbackToRandomSongs(count, usedTrackId, browserFuture);
+                fallbackToRandomSongs(count, usedTrackId, queueTarget);
                 return null;
             }
 
@@ -223,7 +223,7 @@ public class MadeForYouBuilder {
                     recentAlbums, starredAlbums, starredArtists, starredTracks,
                     0, 0, 0, 0,
                     new ArrayList<>(), usedTrackIds,
-                    count, mixType, recentTracks, browserFuture);
+                    count, mixType, recentTracks, queueTarget);
 
             return null;
         }, MoreExecutors.directExecutor());
@@ -287,7 +287,7 @@ public class MadeForYouBuilder {
 
     /**
      * Recursively builds the MadeForYou mix by cycling through steps based on the selected mode.
-     * When complete, enqueues directly via browserFuture.
+     * When complete, adds the mix to the queue.
 
      * Recursion depth is bounded by count.
      */
@@ -301,16 +301,16 @@ public class MadeForYouBuilder {
             List<Child> mixTracks, Set<String> usedTrackIds,
             int count, String mixType,
             Set<String> recentTrackIds,
-            ListenableFuture<MediaBrowser> browserFuture) {
+            MediaManager.QueueTarget queueTarget) {
 
         if (mixTracks.size() >= count) {
-            enqueueMix(mixTracks, mixType, browserFuture);
+            enqueueMix(mixTracks, mixType, queueTarget);
             return;
         }
 
         if (cycleIndex > MAX_CYCLES) {
             Log.w(TAG, mixType + " Safety break reached, finalizing with " + mixTracks.size() + " tracks");
-            enqueueMix(mixTracks, mixType, browserFuture);
+            enqueueMix(mixTracks, mixType, queueTarget);
             return;
         }
 
@@ -326,14 +326,14 @@ public class MadeForYouBuilder {
                             recentAlbums, starredAlbums, starredArtists, starredTracks,
                             recentIdx + 1, starredAlbumIdx, starredArtistIdx, starredTracksIdx,
                             mixTracks, usedTrackIds, count, mixType,
-                            recentTrackIds, browserFuture);
+                            recentTrackIds, queueTarget);
                 } else {
                     Log.d(TAG, mixType + " Step RECENT: no recent albums, skipping");
                     runMixStep(cycleIndex + 1,
                             recentAlbums, starredAlbums, starredArtists, starredTracks, starredTracksIdx,
                             recentIdx, starredAlbumIdx, starredArtistIdx,
                             mixTracks, usedTrackIds, count, mixType,
-                            recentTrackIds, browserFuture);
+                            recentTrackIds, queueTarget);
                 }
                 break;
 
@@ -346,14 +346,14 @@ public class MadeForYouBuilder {
                             recentAlbums, starredAlbums, starredArtists, starredTracks,
                             recentIdx, starredAlbumIdx + 1, starredArtistIdx, starredTracksIdx,
                             mixTracks, usedTrackIds, count, mixType,
-                            recentTrackIds, browserFuture);
+                            recentTrackIds, queueTarget);
                 } else {
                     Log.d(TAG, mixType + " Step STARRED_ALBUM: no starred albums, skipping");
                     runMixStep(cycleIndex + 1,
                             recentAlbums, starredAlbums, starredArtists, starredTracks,
                             recentIdx, starredAlbumIdx, starredArtistIdx, starredTracksIdx,
                             mixTracks, usedTrackIds, count, mixType,
-                            recentTrackIds, browserFuture);
+                            recentTrackIds, queueTarget);
                 }
                 break;
 
@@ -380,14 +380,14 @@ public class MadeForYouBuilder {
                                                 recentAlbums, starredAlbums, starredArtists, starredTracks,
                                                 recentIdx, starredAlbumIdx, starredArtistIdx + 1, starredTracksIdx,
                                                 mixTracks, usedTrackIds, count, mixType,
-                                                recentTrackIds, browserFuture);
+                                                recentTrackIds, queueTarget);
                                     } else {
                                         Log.w(TAG, mixType + " Artist " + artist.getName() + " returned no albums, skipping");
                                         runMixStep(cycleIndex + 1,
                                                 recentAlbums, starredAlbums, starredArtists, starredTracks,
                                                 recentIdx, starredAlbumIdx, starredArtistIdx + 1, starredTracksIdx,
                                                 mixTracks, usedTrackIds, count, mixType,
-                                                recentTrackIds, browserFuture);
+                                                recentTrackIds, queueTarget);
                                     }
                                 }
                                 @Override
@@ -397,7 +397,7 @@ public class MadeForYouBuilder {
                                             recentAlbums, starredAlbums, starredArtists, starredTracks,
                                             recentIdx, starredAlbumIdx, starredArtistIdx + 1, starredTracksIdx,
                                             mixTracks, usedTrackIds, count, mixType,
-                                            recentTrackIds, browserFuture);
+                                            recentTrackIds, queueTarget);
                                 }
                             });
                 } else {
@@ -406,7 +406,7 @@ public class MadeForYouBuilder {
                             recentAlbums, starredAlbums, starredArtists, starredTracks,
                             recentIdx, starredAlbumIdx, starredArtistIdx, starredTracksIdx,
                             mixTracks, usedTrackIds, count, mixType,
-                            recentTrackIds, browserFuture);
+                            recentTrackIds, queueTarget);
                 }
                 break;
 
@@ -419,14 +419,14 @@ public class MadeForYouBuilder {
                             recentAlbums, starredAlbums, starredArtists, starredTracks,
                             recentIdx, starredAlbumIdx, starredArtistIdx, starredTracksIdx + 1,
                             mixTracks, usedTrackIds, count, mixType,
-                            recentTrackIds, browserFuture);
+                            recentTrackIds, queueTarget);
                 } else {
                     Log.d(TAG, mixType + " Step STARRED_TRACKS: no starred tracks, skipping");
                     runMixStep(cycleIndex + 1,
                             recentAlbums, starredAlbums, starredArtists, starredTracks,
                             recentIdx, starredAlbumIdx, starredArtistIdx, starredTracksIdx,
                             mixTracks, usedTrackIds, count, mixType,
-                            recentTrackIds, browserFuture);
+                            recentTrackIds, queueTarget);
                 }
                 break;
         }
@@ -452,7 +452,7 @@ public class MadeForYouBuilder {
             List<Child> mixTracks, Set<String> usedTrackIds,
             int count, String mixType,
             Set<String> recentTrackIds,
-            ListenableFuture<MediaBrowser> browserFuture) {
+            MediaManager.QueueTarget queueTarget) {
 
         App.getSubsonicClientInstance(false)
                 .getBrowsingClient()
@@ -485,7 +485,7 @@ public class MadeForYouBuilder {
                         }
 
                         if (mixTracks.size() >= count) {
-                            enqueueMix(mixTracks, mixType, browserFuture);
+                            enqueueMix(mixTracks, mixType, queueTarget);
                             return;
                         }
 
@@ -495,7 +495,7 @@ public class MadeForYouBuilder {
                                 recentAlbums, starredAlbums, starredArtists, starredTracks,
                                 recentIdx, starredAlbumIdx, starredArtistIdx, starredTracksIdx,
                                 mixTracks, usedTrackIds, count, mixType,
-                                recentTrackIds, browserFuture);
+                                recentTrackIds, queueTarget);
                     }
 
                     @Override
@@ -505,7 +505,7 @@ public class MadeForYouBuilder {
                                 recentAlbums, starredAlbums, starredArtists, starredTracks,
                                 recentIdx, starredAlbumIdx, starredArtistIdx, starredTracksIdx,
                                 mixTracks, usedTrackIds, count, mixType,
-                                recentTrackIds, browserFuture);
+                                recentTrackIds, queueTarget);
                     }
                 });
     }
@@ -528,7 +528,7 @@ public class MadeForYouBuilder {
             List<Child> mixTracks, Set<String> usedTrackIds,
             int count, String mixType,
             Set<String> recentTrackIds,
-            ListenableFuture<MediaBrowser> browserFuture) {
+            MediaManager.QueueTarget queueTarget) {
 
         String songIdForSimilar = null;
 
@@ -543,7 +543,7 @@ public class MadeForYouBuilder {
         }
 
         if (mixTracks.size() >= count) {
-            enqueueMix(mixTracks, mixType, browserFuture);
+            enqueueMix(mixTracks, mixType, queueTarget);
             return;
         }
 
@@ -553,7 +553,7 @@ public class MadeForYouBuilder {
                 recentAlbums, starredAlbums, starredArtists, starredTracks,
                 recentIdx, starredAlbumIdx, starredArtistIdx, starredTracksIdx,
                 mixTracks, usedTrackIds, count, mixType,
-                recentTrackIds, browserFuture);
+                recentTrackIds, queueTarget);
     }
 
     /**
@@ -574,14 +574,14 @@ public class MadeForYouBuilder {
             List<Child> mixTracks, Set<String> usedTrackIds,
             int count, String mixType,
             Set<String> recentTrackIds,
-            ListenableFuture<MediaBrowser> browserFuture) {
+            MediaManager.QueueTarget queueTarget) {
 
         if (!mixType.equals(ConstantsAA.DISCOVERYMIX_ID) || songIdForSimilar == null) {
             runMixStep(cycleIndex,
                     recentAlbums, starredAlbums, starredArtists, starredTracks,
                     recentIdx, starredAlbumIdx, starredArtistIdx, starredTracksIdx,
                     mixTracks, usedTrackIds, count, mixType,
-                    recentTrackIds, browserFuture);
+                    recentTrackIds, queueTarget);
             return;
         }
 
@@ -615,7 +615,7 @@ public class MadeForYouBuilder {
                         }
 
                         if (mixTracks.size() >= count) {
-                            enqueueMix(mixTracks, mixType, browserFuture);
+                            enqueueMix(mixTracks, mixType, queueTarget);
                             return;
                         }
 
@@ -623,7 +623,7 @@ public class MadeForYouBuilder {
                                 recentAlbums, starredAlbums, starredArtists, starredTracks,
                                 recentIdx, starredAlbumIdx, starredArtistIdx, starredTracksIdx,
                                 mixTracks, usedTrackIds, count, mixType,
-                                recentTrackIds, browserFuture);
+                                recentTrackIds, queueTarget);
                     }
 
                     @Override
@@ -633,7 +633,7 @@ public class MadeForYouBuilder {
                                 recentAlbums, starredAlbums, starredArtists, starredTracks,
                                 recentIdx, starredAlbumIdx, starredArtistIdx, starredTracksIdx,
                                 mixTracks, usedTrackIds, count, mixType,
-                                recentTrackIds, browserFuture);
+                                recentTrackIds, queueTarget);
                     }
                 });
     }
@@ -644,7 +644,7 @@ public class MadeForYouBuilder {
     private void fallbackToRandomSongs(
             int count,
             String usedTrackId,
-            ListenableFuture<MediaBrowser> browserFuture) {
+            MediaManager.QueueTarget queueTarget) {
 
         App.getSubsonicClientInstance(false)
                 .getAlbumSongListClient()
@@ -663,7 +663,7 @@ public class MadeForYouBuilder {
 
                             Log.d(TAG, "Fallback random songs: " + songs.size());
                             repository.setChildrenMetadata(songs);
-                            enqueue(browserFuture, songs, true);
+                            enqueue(queueTarget, songs, true);
                         } else {
                             Log.w(TAG, "Fallback random songs failed");
                         }
@@ -684,14 +684,14 @@ public class MadeForYouBuilder {
     private void enqueueMix(
             List<Child> mixTracks,
             String mixType,
-            ListenableFuture<MediaBrowser> browserFuture) {
+            MediaManager.QueueTarget queueTarget) {
         Log.d(TAG, mixType + " complete with " + mixTracks.size() + " tracks, enqueuing");
 
         if(mixType.equals(ConstantsAA.DISCOVERYMIX_ID))
             Collections.shuffle(mixTracks);
 
         repository.setChildrenMetadata(mixTracks);
-        enqueue(browserFuture, mixTracks, true);
+        enqueue(queueTarget, mixTracks, true);
 
         isRunning.set(false);
     }

--- a/app/src/tempus/java/com/eddyizm/tempus/service/TracksChangedExtension.kt
+++ b/app/src/tempus/java/com/eddyizm/tempus/service/TracksChangedExtension.kt
@@ -5,11 +5,9 @@ import androidx.annotation.OptIn
 import androidx.media3.common.MediaItem
 import androidx.media3.common.Player
 import androidx.media3.common.util.UnstableApi
-import androidx.media3.session.MediaBrowser
 import com.eddyizm.tempus.repository.AutomotiveRepository
 import com.eddyizm.tempus.util.ConstantsAA
 import com.eddyizm.tempus.util.Preferences
-import com.google.common.util.concurrent.ListenableFuture
 import kotlin.text.removePrefix
 
 private const val TAG = "TracksChangedExtension"
@@ -22,7 +20,7 @@ class TracksChangedExtension(
     override fun handle(
         player: Player,
         item: MediaItem,
-        browserFuture: ListenableFuture<MediaBrowser>
+        queueTarget: MediaManager.QueueTarget
     ): Boolean {
 
         if (player.mediaItemCount > 1) {
@@ -49,7 +47,7 @@ class TracksChangedExtension(
                 artistId,
                 item.mediaId,
                 (count-1),
-                browserFuture
+                queueTarget
             )
             return true
         }
@@ -71,7 +69,7 @@ class TracksChangedExtension(
                 mixType,
                 item.mediaId,
                 (count-1),
-                browserFuture
+                queueTarget
             )
             return true
         }


### PR DESCRIPTION
Closing Tempus from the recents screen while playback is paused is supposed to shut the player down and take its notification away. It does not: the notification stays, and the player is still running behind it.

The part of the app that plays in the background opens connections to itself as tracks change and when it starts a mix, and never closes them. They build up for as long as playback continues, and Android will not shut something down while anything is connected to it, so the app's request to close on exit does nothing. On a phone running a released build, Android was listing over 200 of them in an earlier session.

This change stops the background player opening those connections.

Tested on an emulator running Android 16, on the build with Google services, with the change and without it. The counts below are the entries Android lists as connected to the background player. Over 5 track changes with the app closed, the count went from 3 to 33 without the change and stayed at 0 with it. Closing while paused, 5 tries each way, left the player and its notification in place without the change and removed both with it.

Continuous play was run to the end of a queue, with the number of tracks to keep in queue set low so older tracks would be dropped as well as new ones added: it did both, and a track it added played. Pressing the instant mix button on the notification shortened the queue and refilled it, and one of the new tracks played. The mixes Android Auto can start were not run at all.

One thing changes for users on the build without Google services. When a track the background player adds has no artist, the address it plays from used to appear where the artist goes. Now the notification and the player screen leave that line out, and the home screen widget shows its own placeholder text. A track you queue yourself is unaffected.
