### PR TITLE
Virtualize the internet-radio list to stop OOM on large station  (#308)

### DIFF
--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/HomeTabRadioFragment.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/HomeTabRadioFragment.java
@@ -102,11 +102,11 @@ public class HomeTabRadioFragment extends Fragment implements ClickCallback, Rad
         bind.internetRadioStationRecyclerView.setAdapter(internetRadioStationAdapter);
         radioViewModel.getInternetRadioStations(getViewLifecycleOwner()).observe(getViewLifecycleOwner(), internetRadioStations -> {
             if (internetRadioStations == null) {
-                if (bind != null) bind.homeRadioStationSector.setVisibility(View.GONE);
+                if (bind != null) bind.internetRadioStationRecyclerView.setVisibility(View.GONE);
                 if (bind != null) bind.emptyRadioStationLayout.setVisibility(View.GONE);
             } else {
                 if (bind != null)
-                    bind.homeRadioStationSector.setVisibility(!internetRadioStations.isEmpty() ? View.VISIBLE : View.GONE);
+                    bind.internetRadioStationRecyclerView.setVisibility(!internetRadioStations.isEmpty() ? View.VISIBLE : View.GONE);
                 if (bind != null)
                     bind.emptyRadioStationLayout.setVisibility(internetRadioStations.isEmpty() ? View.VISIBLE : View.GONE);
 

--- a/app/src/main/res/layout/fragment_home_tab_radio.xml
+++ b/app/src/main/res/layout/fragment_home_tab_radio.xml
@@ -34,31 +34,20 @@
         app:layout_constraintStart_toStartOf="parent"
         app:layout_constraintEnd_toEndOf="parent" />
 
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/home_radio_station_sector"
+    <!-- The RecyclerView is its own bounded (0dp) scroll container so it recycles views.
+         Previously it was wrap_content inside a NestedScrollView, which inflated EVERY row at
+         once and OOM-crashed on large station lists (#308). -->
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/internet_radio_station_recycler_view"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:clipToPadding="false"
+        android:paddingTop="8dp"
+        android:paddingBottom="@dimen/global_padding_bottom"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"
-        app:layout_constraintTop_toBottomOf="@id/internet_radio_station_title_text_view">
-
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical"
-            android:paddingBottom="@dimen/global_padding_bottom">
-
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/internet_radio_station_recycler_view"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                android:layout_marginBottom="8dp"
-                android:clipToPadding="false"
-                android:paddingTop="8dp"
-                android:paddingBottom="8dp" />
-        </LinearLayout>
-    </androidx.core.widget.NestedScrollView>
+        app:layout_constraintTop_toBottomOf="@id/internet_radio_station_title_text_view" />
 
     <LinearLayout
         android:id="@+id/empty_radio_station_layout"


### PR DESCRIPTION
resolves #308

pulling in @herrerad85 fix.

The radio list RecyclerView was wrap_content inside a NestedScrollView, which gives the list an unbounded height and makes it inflate every row at once instead of recycling. With a large station count (the reporter had ~21,000 from m3u radio playlists) this inflates tens of thousands of item views on the main thread, exhausts the heap, and crashes with OutOfMemoryError on app open (the Home pager creates the radio fragment eagerly).

Drop the NestedScrollView/LinearLayout wrapper and make the RecyclerView its own bounded (0dp) scroll container so it recycles. The visibility toggle moves from the removed wrapper id to the RecyclerView itself.

Verified before/after on the emulator with 20,000 injected local stations: the old layout OOM-crashes to the launcher; the new one opens fine and the Radio tab scrolls the full list with ~560 views inflated instead of 20,000.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Home radio screen so internet radio stations now appear and hide correctly based on available station data.
  * Improved the station list layout for more reliable scrolling and spacing.
  * Preserved the empty-state display when no radio stations are available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->