### PR TITLE
fix: keep a blank release type out of the artist page sections

### DIFF
--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/ArtistPageViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/ArtistPageViewModel.java
@@ -69,13 +69,7 @@ public class ArtistPageViewModel extends AndroidViewModel {
                             .collect(Collectors.toList());
                     mapOfAlbums.setValue(
                             primaryAlbums.stream()
-                                    .collect(groupingBy(a -> {
-                                        List<String> releaseTypes = a.getReleaseTypes();
-                                        if (releaseTypes != null && !releaseTypes.isEmpty() && releaseTypes.get(0) != null) {
-                                            return releaseTypes.get(0).toLowerCase();
-                                        }
-                                        return getAutoType(a);
-                                    })));
+                                    .collect(groupingBy(ArtistPageViewModel::sectionType)));
 
                 } else {
                     mapOfAlbums.setValue(Collections.emptyMap());
@@ -93,7 +87,24 @@ public class ArtistPageViewModel extends AndroidViewModel {
         });
     }
 
-    private String getAutoType(AlbumID3 album) {
+    /**
+     * The section an album is filed under, never blank: AlbumSectionsAdapter titles a
+     * section outside its own list from the first character of this value.
+     */
+    static String sectionType(AlbumID3 album) {
+        List<String> releaseTypes = album.getReleaseTypes();
+
+        if (releaseTypes != null && !releaseTypes.isEmpty() && releaseTypes.get(0) != null) {
+            String releaseType = releaseTypes.get(0).trim().toLowerCase();
+            if (!releaseType.isEmpty()) {
+                return releaseType;
+            }
+        }
+
+        return getAutoType(album);
+    }
+
+    private static String getAutoType(AlbumID3 album) {
         // Fallback to song count if releaseTypes is not available
         int songCount = album.getSongCount() != null ? album.getSongCount() : 0;
         if (songCount >= 8) {

--- a/app/src/test/java/com/eddyizm/tempus/viewmodel/ArtistPageViewModelTest.java
+++ b/app/src/test/java/com/eddyizm/tempus/viewmodel/ArtistPageViewModelTest.java
@@ -1,0 +1,45 @@
+package com.eddyizm.tempus.viewmodel;
+
+import static org.junit.Assert.assertEquals;
+
+import com.eddyizm.tempus.subsonic.models.AlbumID3;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+@RunWith(JUnit4.class)
+public class ArtistPageViewModelTest {
+
+    private static AlbumID3 album(int songCount, List<String> releaseTypes) {
+        AlbumID3 album = new AlbumID3();
+        album.setSongCount(songCount);
+        album.setReleaseTypes(releaseTypes);
+        return album;
+    }
+
+    @Test
+    public void sectionType_usesTheReportedReleaseType() {
+        assertEquals("ep", ArtistPageViewModel.sectionType(album(10, Arrays.asList("EP"))));
+        assertEquals("live", ArtistPageViewModel.sectionType(album(1, Arrays.asList("Live", "Album"))));
+    }
+
+    // gonic reports [""] rather than omitting the field. Without the blank check the group
+    // key is "" and AlbumSectionsAdapter reads the first character of it.
+    @Test
+    public void sectionType_fallsBackToTheSongCountWhenTheReleaseTypeIsBlank() {
+        assertEquals("album", ArtistPageViewModel.sectionType(album(10, Arrays.asList(""))));
+        assertEquals("single", ArtistPageViewModel.sectionType(album(2, Arrays.asList("   "))));
+    }
+
+    @Test
+    public void sectionType_fallsBackToTheSongCountWithNoReleaseTypeAtAll() {
+        assertEquals("album", ArtistPageViewModel.sectionType(album(8, null)));
+        assertEquals("ep", ArtistPageViewModel.sectionType(album(3, Collections.emptyList())));
+        assertEquals("single", ArtistPageViewModel.sectionType(album(2, Collections.singletonList(null))));
+    }
+}


### PR DESCRIPTION
Fixes #971

On gonic, opening an artist that has albums closes the app, and doing the same
on Navidrome does not.

The artist page sorts an artist's albums into sections by release type, and the
release type arrives in the same answer that lists the artist's albums. gonic
sends a release type but leaves it blank, and the app uses that blank release
type as a section name. Building the heading for a section the app does not
recognize means reading the first letter of the section name, and a blank
release type has no first letter, so the app closes as the page opens. Navidrome
instead sends no release type at all when an album has none, and the app already
covers that case by guessing the release type from how many songs the album has.

A blank release type now falls back to that same guess, so the album is filed
under albums, EPs or singles like any album that reports no release type at all.
The release type is also trimmed first, so a release type that is only spaces
falls back too, and one with spaces around it is now treated as the same release
type without them.

I tested the change against a running gonic server. Before the change the app
closed on both artists I tried, and after the change three artist pages opened
and rendered their albums. The change also adds tests on the sorting, and
putting the old behavior back fails one of them and nothing else.
