### PR TITLE
fix: stop a playlist edit forcing the playlist public

### DIFF
--- a/app/src/main/java/com/eddyizm/tempus/database/dao/PlaylistDao.java
+++ b/app/src/main/java/com/eddyizm/tempus/database/dao/PlaylistDao.java
@@ -45,11 +45,23 @@ public interface PlaylistDao {
     @Query("SELECT coverArt FROM playlist WHERE id = :playlistId")
     String getPlaylistCoverArtId(String playlistId);
 
+    /**
+     * The visibility the server last reported for this playlist, or null when there is no cached
+     * value for it. The
+     * full playlist list refreshes this row on every load, so it is the newest value the app has
+     * without asking the server again.
+     */
+    @Query("SELECT isUniversal FROM playlist WHERE id = :playlistId")
+    Boolean isPlaylistPublic(String playlistId);
+
     @Query("UPDATE playlist SET name = :newName WHERE id = :playlistId")
     void updateName(String playlistId, String newName);
 
     @Query("UPDATE playlist SET lastPlayed = :timestamp WHERE id = :playlistId")
     void updateLastPlayed(String playlistId, long timestamp);
+
+    @Query("UPDATE playlist SET isUniversal = :isUniversal WHERE id = :playlistId")
+    void updateVisibility(String playlistId, Boolean isUniversal);
 
     /**
      * Full list query used by PlaylistCatalogueFragment.

--- a/app/src/main/java/com/eddyizm/tempus/repository/PlaylistRepository.java
+++ b/app/src/main/java/com/eddyizm/tempus/repository/PlaylistRepository.java
@@ -212,6 +212,10 @@ public class PlaylistRepository {
             // Insert before the early-return dedup checks so the row is ensured even when
             // the songs are already cached. See issue #729.
             playlistDao.insertIfAbsent(playlist);
+            // insertIfAbsent leaves an existing row alone, so this response's visibility would be
+            // thrown away whenever the row already exists. The write paths read this column, so
+            // the value this response carried is written back on its own.
+            playlistDao.updateVisibility(playlistId, playlist.isUniversal());
             List<PlaylistSong> cached = playlistSongDao.getSongsForPlaylistSync(playlistId);
             if (songs == null || songs.isEmpty()) {
                 if (cached != null && !cached.isEmpty()) {
@@ -301,14 +305,26 @@ public class PlaylistRepository {
         void onAllSkipped();
     }
 
+    /**
+     * @param playlistVisibilityIsPublic true when the user marked the playlist public with the
+     *                                   chooser switch. Anything else falls back to the playlist's
+     *                                   cached visibility. The switch marks a playlist public and
+     *                                   never sends false, because false is not a safe value to
+     *                                   send.
+     */
     public void addSongToPlaylist(String playlistId, ArrayList<String> songsId, Boolean playlistVisibilityIsPublic, AddToPlaylistCallback callback) {
         android.util.Log.d("PlaylistRepository", "addSongToPlaylist: id=" + playlistId + ", songs=" + songsId);
         if (songsId.isEmpty()) {
             if (callback != null) callback.onAllSkipped();
-        } else{
+            return;
+        }
+        new Thread(() -> {
+            Boolean isPublic = Boolean.TRUE.equals(playlistVisibilityIsPublic)
+                    ? Boolean.TRUE
+                    : visibilityToSend(playlistId);
             App.getSubsonicClientInstance(false)
                     .getPlaylistClient()
-                    .updatePlaylist(playlistId, null, playlistVisibilityIsPublic, songsId, null)
+                    .updatePlaylist(playlistId, null, isPublic, songsId, null)
                     .enqueue(new Callback<ApiResponse>() {
                         @Override
                         public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
@@ -321,30 +337,51 @@ public class PlaylistRepository {
                             if (callback != null) callback.onFailure();
                         }
                     });
-        }
+        }).start();
+    }
+
+    /**
+     * The visibility to send with a write, or null to send none at all. True only when the server
+     * has said this playlist is public.
+     * <p>
+     * Servers split two ways on an absent public parameter. One group reads the parameter's value,
+     * so leaving it out leaves the visibility alone. The other never acts on what the value says,
+     * making the playlist public whenever the parameter arrives and private when it does not. So
+     * false is never sent, and true is sent whenever the playlist is known to be public, since on
+     * the second group leaving it out would make that playlist private. A literal true published
+     * every private playlist that was edited, which is what this exists to stop.
+     * <p>
+     * The value is the one the server last reported, held in the cached playlist row, which the
+     * full playlist list refreshes on every load. Reading it here keeps the screens out of it and
+     * costs no extra request. It touches the database, so callers have to be off the main thread.
+     */
+    private Boolean visibilityToSend(String playlistId) {
+        return Boolean.TRUE.equals(playlistDao.isPlaylistPublic(playlistId)) ? Boolean.TRUE : null;
     }
 
     public void removeSongFromPlaylist(String playlistId, int index, AddToPlaylistCallback callback) {
         ArrayList<Integer> indexes = new ArrayList<>();
         indexes.add(index);
-        App.getSubsonicClientInstance(false)
-                .getPlaylistClient()
-                .updatePlaylist(playlistId, null, true, null, indexes)
-                .enqueue(new Callback<ApiResponse>() {
-                    @Override
-                    public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
-                        if (response.isSuccessful()) notifyPlaylistChanged();
-                        if (callback != null) {
-                            if (response.isSuccessful()) callback.onSuccess();
-                            else callback.onFailure();
+        new Thread(() -> {
+            App.getSubsonicClientInstance(false)
+                    .getPlaylistClient()
+                    .updatePlaylist(playlistId, null, visibilityToSend(playlistId), null, indexes)
+                    .enqueue(new Callback<ApiResponse>() {
+                        @Override
+                        public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
+                            if (response.isSuccessful()) notifyPlaylistChanged();
+                            if (callback != null) {
+                                if (response.isSuccessful()) callback.onSuccess();
+                                else callback.onFailure();
+                            }
                         }
-                    }
 
-                    @Override
-                    public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
-                        if (callback != null) callback.onFailure();
-                    }
-                });
+                        @Override
+                        public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
+                            if (callback != null) callback.onFailure();
+                        }
+                    });
+        }).start();
     }
 
     public void addSongToPlaylist(String playlistId, ArrayList<String> songsId, Boolean playlistVisibilityIsPublic) {
@@ -374,26 +411,28 @@ public class PlaylistRepository {
     }
 
     public void updatePlaylist(String playlistId, String name, ArrayList<String> songsId, PlaylistActionCallback callback) {
-        App.getSubsonicClientInstance(false)
-                .getPlaylistClient()
-                .updatePlaylist(playlistId, name, true, songsId, null)
-                .enqueue(new Callback<ApiResponse>() {
-                    @Override
-                    public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
-                        if (response.isSuccessful()) {
-                            updateLocalPlaylistName(playlistId, name);
-                            notifyPlaylistChanged();
-                            if (callback != null) callback.onSuccess();
-                        } else {
+        new Thread(() -> {
+            App.getSubsonicClientInstance(false)
+                    .getPlaylistClient()
+                    .updatePlaylist(playlistId, name, visibilityToSend(playlistId), songsId, null)
+                    .enqueue(new Callback<ApiResponse>() {
+                        @Override
+                        public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
+                            if (response.isSuccessful()) {
+                                updateLocalPlaylistName(playlistId, name);
+                                notifyPlaylistChanged();
+                                if (callback != null) callback.onSuccess();
+                            } else {
+                                if (callback != null) callback.onFailure();
+                            }
+                        }
+
+                        @Override
+                        public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
                             if (callback != null) callback.onFailure();
                         }
-                    }
-
-                    @Override
-                    public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
-                        if (callback != null) callback.onFailure();
-                    }
-                });
+                    });
+        }).start();
     }
 
     @OptIn(markerClass = UnstableApi.class)
@@ -461,8 +500,8 @@ public class PlaylistRepository {
     }
 
     @androidx.media3.common.util.UnstableApi
-    public void insert(Playlist playlist) {
-        InsertThreadSafe insert = new InsertThreadSafe(playlistDao, playlist);
+    public void insertIfAbsent(Playlist playlist) {
+        InsertIfAbsentThreadSafe insert = new InsertIfAbsentThreadSafe(playlistDao, playlist);
         Thread thread = new Thread(insert);
         thread.start();
     }
@@ -517,18 +556,23 @@ public class PlaylistRepository {
         }).start();
     }
 
-    private static class InsertThreadSafe implements Runnable {
+    /**
+     * Makes sure a playlist has a cached row without touching one that is already there. A replace
+     * would overwrite every column of an existing row, and pinning has no business rewriting a row
+     * it did not fetch.
+     */
+    private static class InsertIfAbsentThreadSafe implements Runnable {
         private final PlaylistDao playlistDao;
         private final Playlist playlist;
 
-        public InsertThreadSafe(PlaylistDao playlistDao, Playlist playlist) {
+        public InsertIfAbsentThreadSafe(PlaylistDao playlistDao, Playlist playlist) {
             this.playlistDao = playlistDao;
             this.playlist = playlist;
         }
 
         @Override
         public void run() {
-            playlistDao.insert(playlist);
+            playlistDao.insertIfAbsent(playlist);
         }
     }
 

--- a/app/src/main/java/com/eddyizm/tempus/subsonic/api/playlist/PlaylistClient.java
+++ b/app/src/main/java/com/eddyizm/tempus/subsonic/api/playlist/PlaylistClient.java
@@ -36,7 +36,7 @@ public class PlaylistClient {
         return playlistService.createPlaylist(subsonic.getParams(), playlistId, name, songsId);
     }
 
-    public Call<ApiResponse> updatePlaylist(String playlistId, String name, boolean isPublic, ArrayList<String> songIdToAdd, ArrayList<Integer> songIndexToRemove) {
+    public Call<ApiResponse> updatePlaylist(String playlistId, String name, Boolean isPublic, ArrayList<String> songIdToAdd, ArrayList<Integer> songIndexToRemove) {
         Log.d(TAG, "updatePlaylist()");
         return playlistService.updatePlaylist(subsonic.getParams(), playlistId, name, isPublic, songIdToAdd, songIndexToRemove);
     }

--- a/app/src/main/java/com/eddyizm/tempus/subsonic/api/playlist/PlaylistService.java
+++ b/app/src/main/java/com/eddyizm/tempus/subsonic/api/playlist/PlaylistService.java
@@ -20,8 +20,13 @@ public interface PlaylistService {
     @GET("createPlaylist")
     Call<ApiResponse> createPlaylist(@QueryMap Map<String, String> params, @Query("playlistId") String playlistId, @Query("name") String name, @Query("songId") ArrayList<String> songsId);
 
+    /**
+     * isPublic is boxed so a caller can decline to set a visibility at all. Retrofit leaves a query
+     * parameter out of the request when its value is null, and a primitive can never be null, which
+     * is why public used to go out on every call.
+     */
     @GET("updatePlaylist")
-    Call<ApiResponse> updatePlaylist(@QueryMap Map<String, String> params, @Query("playlistId") String playlistId, @Query("name") String name, @Query("public") boolean isPublic, @Query("songIdToAdd") ArrayList<String> songIdToAdd, @Query("songIndexToRemove") ArrayList<Integer> songIndexToRemove);
+    Call<ApiResponse> updatePlaylist(@QueryMap Map<String, String> params, @Query("playlistId") String playlistId, @Query("name") String name, @Query("public") Boolean isPublic, @Query("songIdToAdd") ArrayList<String> songIdToAdd, @Query("songIndexToRemove") ArrayList<Integer> songIndexToRemove);
 
     @GET("deletePlaylist")
     Call<ApiResponse> deletePlaylist(@QueryMap Map<String, String> params, @Query("id") String id);

--- a/app/src/main/java/com/eddyizm/tempus/ui/dialog/PlaylistChooserDialog.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/dialog/PlaylistChooserDialog.java
@@ -32,6 +32,8 @@ public class PlaylistChooserDialog extends DialogFragment implements ClickCallba
 
         playlistChooserViewModel = new ViewModelProvider(requireActivity()).get(PlaylistChooserViewModel.class);
 
+        playlistChooserViewModel.forgetVisibility();
+
         bind.playlistDialogChooserVisibilitySwitch.setOnCheckedChangeListener(
                 (buttonView,
                  isChecked) -> playlistChooserViewModel.setIsPlaylistPublic(isChecked)

--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/PlaylistChooserViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/PlaylistChooserViewModel.java
@@ -21,7 +21,9 @@ import java.util.List;
 public class PlaylistChooserViewModel extends AndroidViewModel {
     private final PlaylistRepository playlistRepository;
     private final MutableLiveData<List<Playlist>> playlists = new MutableLiveData<>(null);
-    private final MutableLiveData<Boolean> playlistIsPublic = new MutableLiveData<>(false);
+    // Null until the user touches the switch. A false default went out on the wire and changed
+    // the visibility of a playlist the user only meant to add a song to.
+    private final MutableLiveData<Boolean> playlistIsPublic = new MutableLiveData<>(null);
 
     public Boolean getIsPlaylistPublic() {
         return playlistIsPublic.getValue();
@@ -29,6 +31,15 @@ public class PlaylistChooserViewModel extends AndroidViewModel {
 
     public void setIsPlaylistPublic(boolean isPublic) {
         playlistIsPublic.setValue(isPublic);
+    }
+
+    /**
+     * Clears the visibility the user picked last time. This view model belongs to the activity, so
+     * it outlives the dialog, while the switch is inflated unchecked every time. Without this the
+     * two disagree and a later add sends a visibility the switch is not showing.
+     */
+    public void forgetVisibility() {
+        playlistIsPublic.setValue(null);
     }
 
     private ArrayList<Child> toAdd = new ArrayList<>();

--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/PlaylistPageViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/PlaylistPageViewModel.java
@@ -101,7 +101,7 @@ public class PlaylistPageViewModel extends AndroidViewModel {
 
     @OptIn(markerClass = UnstableApi.class)
     public void setPinned(boolean isNowPinned) {
-        playlistRepository.insert(playlist);
+        playlistRepository.insertIfAbsent(playlist);
 
         if (isNowPinned) {
             playlistRepository.pin(playlist.getId());

--- a/app/src/main/res/layout/dialog_playlist_chooser.xml
+++ b/app/src/main/res/layout/dialog_playlist_chooser.xml
@@ -20,7 +20,7 @@
         android:layout_height="wrap_content"
         android:paddingStart="30dp"
         android:paddingEnd="30dp"
-        android:text="@string/playlist_chooser_dialog_visibility_summary"
+        android:text="@string/playlist_chooser_dialog_visibility_summary_v2"
         android:layout_marginTop="8dp"/>
 
     <TextView

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -290,7 +290,6 @@
     <string name="playlist_chooser_dialog_visibility_public">Pública</string>
     <string name="playlist_chooser_dialog_visibility_private">Privada</string>
     <string name="playlist_chooser_dialog_visibility_switch_label">Lista de reproducción pública</string>
-    <string name="playlist_chooser_dialog_visibility_summary">El servidor actualiza la visibilidad en cada modificación. Por defecto es privado</string>
     <string name="playlist_counted_tracks">%1$d canciones •  %2$s</string>
     <string name="playlist_duration">Duración • %1$s</string>
     <string name="playlist_editor_dialog_action_delete_toast">Mantén presionado para eliminar</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -290,7 +290,6 @@
     <string name="playlist_chooser_dialog_visibility_public">Pública</string>
     <string name="playlist_chooser_dialog_visibility_private">Privada</string>
     <string name="playlist_chooser_dialog_visibility_switch_label">Marca la llista de reproducció com a pública</string>
-    <string name="playlist_chooser_dialog_visibility_summary">El servidor actualitza la visibilitat a cada sol·licitud. Per defecte, és privada.</string>
     <string name="playlist_counted_tracks">%1$d pistes •  %2$s</string>
     <string name="playlist_duration">Durada  •  %1$s</string>
     <string name="playlist_editor_dialog_action_delete_toast">Manteniu-ho premut per a suprimir-ho</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -265,7 +265,6 @@
     <string name="playlist_chooser_dialog_visibility_public">Öffentlich</string>
     <string name="playlist_chooser_dialog_visibility_private">Privat</string>
     <string name="playlist_chooser_dialog_visibility_switch_label">Wiedergabeliste als öffentlich markieren</string>
-    <string name="playlist_chooser_dialog_visibility_summary">Der Server aktualisiert die Sichtbarkeit bei jeder Anfrage. Sichtbarkeit ist standardmäßig privat.</string>
     <string name="playlist_counted_tracks">%1$d Titel •  %2$s</string>
     <string name="playlist_duration">Laufzeit  •  %1$s</string>
     <string name="playlist_editor_dialog_action_delete_toast">Halten um zu löschen</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -256,7 +256,6 @@
     <string name="playlist_chooser_dialog_visibility_public">Público</string>
     <string name="playlist_chooser_dialog_visibility_private">Privado</string>
     <string name="playlist_chooser_dialog_visibility_switch_label">Marcar la lista de reproducción como pública</string>
-    <string name="playlist_chooser_dialog_visibility_summary">El servidor actualiza la visibilidad en cada petición. Por defecto está configurada como privada.</string>
     <string name="playlist_counted_tracks">%1$d pistas •  %2$s</string>
     <string name="playlist_duration">Duración  •  %1$s</string>
     <string name="playlist_editor_dialog_action_delete_toast">Pulsación larga para eliminar</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -297,7 +297,6 @@
     <string name="playlist_chooser_dialog_visibility_public">Publikoa</string>
     <string name="playlist_chooser_dialog_visibility_private">Pribatua</string>
     <string name="playlist_chooser_dialog_visibility_switch_label">Zerrenda publiko gisa markatu</string>
-    <string name="playlist_chooser_dialog_visibility_summary">Zerbitzariak ikusgarritasuna eskaera bakoitzean eguneratzen du. Lehenespenez pribatu gisa ezartzen da.</string>
     <string name="playlist_counted_tracks">%1$d abesti •  %2$s</string>
     <string name="playlist_duration">Iraupena  •  %1$s</string>
     <string name="playlist_editor_dialog_action_delete_toast">Sakatu luze ezabatzeko</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -287,7 +287,6 @@
     <string name="playlist_chooser_dialog_visibility_public">Publique</string>
     <string name="playlist_chooser_dialog_visibility_private">Privé</string>
 	<string name="playlist_chooser_dialog_visibility_switch_label">Rendre la playlist publique</string>
-    <string name="playlist_chooser_dialog_visibility_summary">Le serveur met à jour la visibilité à chaque requête. Est défini à privé par défaut.</string>
     <string name="playlist_counted_tracks">%1$d titres •  %2$s</string>
     <string name="playlist_duration">Durée  •  %1$s</string>
     <string name="playlist_editor_dialog_action_delete_toast">Appui long pour supprimer</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -316,7 +316,6 @@
     <string name="playlist_chooser_dialog_visibility_public">公開</string>
     <string name="playlist_chooser_dialog_visibility_private">非公開</string>
     <string name="playlist_chooser_dialog_visibility_switch_label">プレイリストを公開にする</string>
-    <string name="playlist_chooser_dialog_visibility_summary">サーバーはリクエストのたびに公開設定を更新します。デフォルトでは非公開に設定されています。</string>
     <string name="playlist_counted_tracks">%1$d トラック • %2$s</string>
     <string name="playlist_duration">再生時間 • %1$s</string>
     <string name="playlist_editor_dialog_action_delete_toast">長押しで削除</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -333,7 +333,6 @@
     <string name="playlist_chooser_dialog_visibility_public">Publiczna</string>
     <string name="playlist_chooser_dialog_visibility_private">Prywatna</string>
 	<string name="playlist_chooser_dialog_visibility_switch_label">Oznacz playlistę jako publiczną</string>
-    <string name="playlist_chooser_dialog_visibility_summary">Serwer aktualizuje widoczność podczas każdego zapytania. Domyślnie jest ustawiona na prywatną.</string>
     <string name="playlist_counted_tracks">%1$d utworów •  %2$s</string>
     <string name="playlist_duration">Długość  •  %1$s</string>
     <string name="playlist_editor_dialog_action_delete_toast">Przytrzymaj aby usunąć</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -272,7 +272,6 @@
     <string name="playlist_chooser_dialog_visibility_public">Публичный</string>
     <string name="playlist_chooser_dialog_visibility_private">Приватный</string>
     <string name="playlist_chooser_dialog_visibility_switch_label">Сделать плейлист публичным</string>
-    <string name="playlist_chooser_dialog_visibility_summary">Сервер обновляет видимость при каждом запросе. По умолчанию плейлист приватный.</string>
     <string name="playlist_counted_tracks">%1$d треков • %2$s</string>
     <string name="playlist_duration">Длительность • %1$s</string>
     <string name="playlist_editor_dialog_action_delete_toast">Удерживайте для удаления</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -328,7 +328,7 @@
     <string name="playlist_chooser_dialog_visibility_public">Public</string>
     <string name="playlist_chooser_dialog_visibility_private">Private</string>
     <string name="playlist_chooser_dialog_visibility_switch_label">Mark the playlist as public</string>
-    <string name="playlist_chooser_dialog_visibility_summary">The server updates the visibility on each request. By default it is set to private.</string>
+    <string name="playlist_chooser_dialog_visibility_summary_v2">Turning this on marks the playlist public. Leaving it alone does not change the playlist visibility.</string>
     <string name="playlist_counted_tracks">%1$d tracks •  %2$s</string>
     <string name="playlist_duration">Duration  •  %1$s</string>
     <string name="playlist_editor_dialog_action_delete_toast">Long press to delete</string>


### PR DESCRIPTION
Fixes #969

Editing a playlist could silently change who can see it.

Rename a playlist, remove a song from it, or add a song to it, and the app was
also telling the server what the playlist's visibility should be, so a private
playlist could come back public and a public one could come back private.
Nothing in the interface said that would happen.

The reason is that the app had no way to stay quiet about visibility: every
playlist change carried a setting, so it always said something. Two of the three
places said "make this public" no matter what the playlist was, and the third
sent whatever the switch in the add to playlist dialog was showing, which is
never set from the playlist you pick.

Now the app only says "make this public" when it already knows the playlist is
public or when you deliberately turn the switch on, and otherwise it says
nothing about visibility so the server leaves it as it was. It knows which
playlists are public because it remembers what the server last said, and
refreshes that whenever it loads a playlist's songs.

The catch is that servers disagree about what saying nothing means: on some it
leaves the playlist alone, and on others it makes the playlist private. That is
why the app still says "make this public" for playlists it knows are public,
even on servers where it would not need to.

The switch now only marks a playlist public and cannot make one private, because
there is no value that means private on every server.

I tested every one of those actions against a running server and checked what
the app actually sent each time, on playlists that were public and playlists
that were private.
