### PR TITLE
fix: make saving a playlist edit replace its contents instead of appending

### DIFF
--- a/app/src/main/java/com/eddyizm/tempus/interfaces/PlaylistCallback.java
+++ b/app/src/main/java/com/eddyizm/tempus/interfaces/PlaylistCallback.java
@@ -5,4 +5,6 @@ import androidx.annotation.Keep;
 @Keep
 public interface PlaylistCallback {
     default void onDismiss() {}
+
+    default void onRenamed(String name) {}
 }

--- a/app/src/main/java/com/eddyizm/tempus/repository/PlaylistRepository.java
+++ b/app/src/main/java/com/eddyizm/tempus/repository/PlaylistRepository.java
@@ -22,6 +22,7 @@ import com.eddyizm.tempus.model.PlaylistSong;
 import com.eddyizm.tempus.subsonic.base.ApiResponse;
 import com.eddyizm.tempus.subsonic.models.Child;
 import com.eddyizm.tempus.subsonic.models.Playlist;
+import com.eddyizm.tempus.subsonic.models.ResponseStatus;
 import com.eddyizm.tempus.subsonic.models.SubsonicResponse;
 
 import java.util.ArrayList;
@@ -164,6 +165,16 @@ public class PlaylistRepository {
     }
 
     public MutableLiveData<List<Child>> getPlaylistSongs(String id) {
+        return getPlaylistSongs(id, true);
+    }
+
+    /**
+     * @param allowCache whether a locally cached copy may stand in when the server cannot be
+     *                   reached. A caller that writes the list back must pass false, the cache is a
+     *                   snapshot, and saving it would delete whatever has been added since it was
+     *                   written.
+     */
+    public MutableLiveData<List<Child>> getPlaylistSongs(String id, boolean allowCache) {
         MutableLiveData<List<Child>> listLivePlaylistSongs = new MutableLiveData<>();
 
         App.getSubsonicClientInstance(false)
@@ -195,7 +206,11 @@ public class PlaylistRepository {
 
                     @Override
                     public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
-                        fetchCachedPlaylistSongs(id, listLivePlaylistSongs);
+                        if (allowCache) {
+                            fetchCachedPlaylistSongs(id, listLivePlaylistSongs);
+                        } else {
+                            listLivePlaylistSongs.setValue(null);
+                        }
                     }
                 });
 
@@ -392,36 +407,20 @@ public class PlaylistRepository {
         App.getSubsonicClientInstance(false)
                 .getPlaylistClient()
                 .createPlaylist(playlistId, name, songsId)
-                .enqueue(new Callback<ApiResponse>() {
-                    @Override
-                    public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
-                        if (response.isSuccessful()) {
-                            notifyPlaylistChanged();
-                            if (callback != null) callback.onSuccess();
-                        } else {
-                            if (callback != null) callback.onFailure();
-                        }
-                    }
-
-                    @Override
-                    public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
-                        if (callback != null) callback.onFailure();
-                    }
-                });
+                .enqueue(resultHandler(callback));
     }
 
     public void updatePlaylist(String playlistId, String name, ArrayList<String> songsId, PlaylistActionCallback callback) {
         new Thread(() -> {
             App.getSubsonicClientInstance(false)
                     .getPlaylistClient()
-                    .updatePlaylist(playlistId, name, visibilityToSend(playlistId), songsId, null)
+                    .updatePlaylist(playlistId, name, visibilityToSend(playlistId), null, null)
                     .enqueue(new Callback<ApiResponse>() {
                         @Override
                         public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
-                            if (response.isSuccessful()) {
+                            if (isAccepted(response)) {
                                 updateLocalPlaylistName(playlistId, name);
-                                notifyPlaylistChanged();
-                                if (callback != null) callback.onSuccess();
+                                replacePlaylistSongs(playlistId, songsId, callback);
                             } else {
                                 if (callback != null) callback.onFailure();
                             }
@@ -433,6 +432,60 @@ public class PlaylistRepository {
                         }
                     });
         }).start();
+    }
+
+    /**
+     * Subsonic reports a refusal as HTTP 200 carrying a failed status, so the status line on its own
+     * reads a refusal as a success.
+     */
+    static boolean isAccepted(Response<ApiResponse> response) {
+        if (!response.isSuccessful() || response.body() == null) return false;
+
+        SubsonicResponse subsonicResponse = response.body().getSubsonicResponse();
+
+        return subsonicResponse != null && ResponseStatus.OK.equals(subsonicResponse.getStatus());
+    }
+
+    private Callback<ApiResponse> resultHandler(PlaylistActionCallback callback) {
+        return new Callback<ApiResponse>() {
+            @Override
+            public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
+                if (isAccepted(response)) {
+                    notifyPlaylistChanged();
+                    if (callback != null) callback.onSuccess();
+                } else {
+                    if (callback != null) callback.onFailure();
+                }
+            }
+
+            @Override
+            public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
+                if (callback != null) callback.onFailure();
+            }
+        };
+    }
+
+    /**
+     * Known limitation: the rename runs first and is not undone when the contents fail, so such a
+     * save leaves the playlist renamed while reporting failure. The rename also writes the new
+     * name to the local database, so the app's own playlist lists show the new name while the
+     * open page still shows the old one.
+     *
+     * The failure path deliberately does not refresh, a reload through the server that just failed
+     * can itself come back as an HTTP error, which this app reports as the playlist being gone and
+     * closes the page. The success paths do refresh.
+     */
+    private void replacePlaylistSongs(String playlistId, ArrayList<String> songsId, PlaylistActionCallback callback) {
+        if (songsId == null || songsId.isEmpty()) {
+            notifyPlaylistChanged();
+            if (callback != null) callback.onSuccess();
+            return;
+        }
+
+        App.getSubsonicClientInstance(false)
+                .getPlaylistClient()
+                .createPlaylist(playlistId, null, songsId)
+                .enqueue(resultHandler(callback));
     }
 
     @OptIn(markerClass = UnstableApi.class)
@@ -466,6 +519,10 @@ public class PlaylistRepository {
     public interface PlaylistActionCallback {
         void onSuccess();
         void onFailure();
+
+        default void onEmptied() {
+            onFailure();
+        }
     }
 
     public void deletePlaylist(String playlistId, PlaylistActionCallback callback) {

--- a/app/src/main/java/com/eddyizm/tempus/ui/dialog/PlaylistEditorDialog.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/dialog/PlaylistEditorDialog.java
@@ -10,8 +10,10 @@ import android.view.View;
 import android.widget.Toast;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.OptIn;
 import androidx.fragment.app.DialogFragment;
 import androidx.lifecycle.ViewModelProvider;
+import androidx.media3.common.util.UnstableApi;
 import androidx.recyclerview.widget.ItemTouchHelper;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
@@ -99,6 +101,9 @@ public class PlaylistEditorDialog extends DialogFragment {
                         if (isAdded() && getContext() != null) {
                             requireActivity().runOnUiThread(() -> {
                                 Toast.makeText(getContext(), R.string.playlist_editor_dialog_action_save_success, Toast.LENGTH_SHORT).show();
+                                if (playlistCallback != null && playlistEditorViewModel.getPlaylistToEdit() != null) {
+                                    playlistCallback.onRenamed(playlistName);
+                                }
                                 dialogDismiss();
                             });
                         }
@@ -109,6 +114,16 @@ public class PlaylistEditorDialog extends DialogFragment {
                         if (isAdded() && getContext() != null) {
                             requireActivity().runOnUiThread(() -> {
                                 Toast.makeText(getContext(), R.string.playlist_editor_dialog_action_save_failure, Toast.LENGTH_SHORT).show();
+                            });
+                        }
+                    }
+
+                    @Override
+                    @OptIn(markerClass = UnstableApi.class)
+                    public void onEmptied() {
+                        if (isAdded() && getContext() != null) {
+                            requireActivity().runOnUiThread(() -> {
+                                Toast.makeText(getContext(), R.string.playlist_editor_dialog_action_save_empty, Toast.LENGTH_SHORT).show();
                             });
                         }
                     }

--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/PlaylistPageFragment.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/PlaylistPageFragment.java
@@ -215,8 +215,13 @@ public class PlaylistPageFragment extends Fragment implements ClickCallback {
             bundle.putParcelable(Constants.PLAYLIST_OBJECT, playlistPageViewModel.getPlaylist());
             PlaylistEditorDialog dialog = new PlaylistEditorDialog(new PlaylistCallback() {
                 @Override
-                public void onDismiss() {
-                    // Refresh?
+                public void onRenamed(String name) {
+                    playlistPageViewModel.getPlaylist().setName(name);
+
+                    if (bind != null) {
+                        bind.animToolbar.setTitle(name);
+                        bind.playlistNameLabel.setText(name);
+                    }
                 }
             });
             dialog.setArguments(bundle);

--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/PlaylistEditorViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/PlaylistEditorViewModel.java
@@ -3,9 +3,12 @@ package com.eddyizm.tempus.viewmodel;
 import android.app.Application;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.OptIn;
 import androidx.lifecycle.AndroidViewModel;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
+import androidx.lifecycle.Observer;
+import androidx.media3.common.util.UnstableApi;
 
 import com.eddyizm.tempus.repository.PlaylistRepository;
 import com.eddyizm.tempus.repository.SharingRepository;
@@ -30,6 +33,9 @@ public class PlaylistEditorViewModel extends AndroidViewModel {
 
     private MutableLiveData<List<Child>> songLiveList = new MutableLiveData<>();
 
+    private Integer loadedSongCount;
+    private Observer<List<Child>> loadedCountObserver;
+
     public PlaylistEditorViewModel(@NonNull Application application) {
         super(application);
 
@@ -42,7 +48,19 @@ public class PlaylistEditorViewModel extends AndroidViewModel {
     }
 
     public void updatePlaylist(String name, PlaylistRepository.PlaylistActionCallback callback) {
-        playlistRepository.updatePlaylist(toEdit.getId(), name, getPlaylistSongIds(), callback);
+        ArrayList<String> songsId = getPlaylistSongIds();
+
+        if (songsId == null) {
+            if (callback != null) callback.onFailure();
+            return;
+        }
+
+        if (songsId.isEmpty() && loadedSongCount != null && loadedSongCount > 0) {
+            if (callback != null) callback.onEmptied();
+            return;
+        }
+
+        playlistRepository.updatePlaylist(toEdit.getId(), name, songsId, callback);
     }
 
     public void deletePlaylist(PlaylistRepository.PlaylistActionCallback callback) {
@@ -61,14 +79,43 @@ public class PlaylistEditorViewModel extends AndroidViewModel {
         return toEdit;
     }
 
+    @OptIn(markerClass = UnstableApi.class)
     public void setPlaylistToEdit(Playlist playlist) {
         this.toEdit = playlist;
 
+        // Detach before reassigning, while songLiveList still points at the list being observed.
+        detachLoadedCountObserver();
+        loadedSongCount = null;
+
         if (playlist != null) {
-            this.songLiveList = playlistRepository.getPlaylistSongs(toEdit.getId());
+            this.songLiveList = playlistRepository.getPlaylistSongs(toEdit.getId(), false);
+            attachLoadedCountObserver();
         } else {
             this.songLiveList = new MutableLiveData<>();
         }
+    }
+
+    private void attachLoadedCountObserver() {
+        loadedCountObserver = songs -> {
+            if (songs == null) return;
+
+            loadedSongCount = songs.size();
+            detachLoadedCountObserver();
+        };
+
+        songLiveList.observeForever(loadedCountObserver);
+    }
+
+    private void detachLoadedCountObserver() {
+        if (loadedCountObserver == null) return;
+
+        songLiveList.removeObserver(loadedCountObserver);
+        loadedCountObserver = null;
+    }
+
+    @Override
+    protected void onCleared() {
+        detachLoadedCountObserver();
     }
 
     public LiveData<List<Child>> getPlaylistSongLiveList() {
@@ -85,14 +132,21 @@ public class PlaylistEditorViewModel extends AndroidViewModel {
         songLiveList.postValue(songs);
     }
 
+    /**
+     * The ids of the tracks the user has arranged, or null when the list is not known. A null
+     * list means the load has not finished or has failed, and a save is refused because the
+     * editor is not showing the playlist. An empty list means nothing is on screen, which is a
+     * removal only if the editor loaded tracks in the first place.
+     */
     private ArrayList<String> getPlaylistSongIds() {
         List<Child> songs = songLiveList.getValue();
+
+        if (songs == null) return null;
+
         ArrayList<String> ids = new ArrayList<>();
 
-        if (songs != null && !songs.isEmpty()) {
-            for (Child song : songs) {
-                ids.add(song.getId());
-            }
+        for (Child song : songs) {
+            ids.add(song.getId());
         }
 
         return ids;

--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/PlaylistPageViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/PlaylistPageViewModel.java
@@ -82,8 +82,11 @@ public class PlaylistPageViewModel extends AndroidViewModel {
     }
 
     public void setPlaylist(Playlist playlist) {
-        if (this.playlist == null || !this.playlist.getId().equals(playlist.getId())) {
-            this.playlist = playlist;
+        boolean isDifferentPlaylist = this.playlist == null || !this.playlist.getId().equals(playlist.getId());
+
+        this.playlist = playlist;
+
+        if (isDifferentPlaylist) {
             this.songLiveList.setValue(null); // Clear old data immediately
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -341,6 +341,7 @@
     <string name="playlist_editor_dialog_action_delete_failure">Failed to delete playlist</string>
     <string name="playlist_editor_dialog_action_save_success">Playlist saved</string>
     <string name="playlist_editor_dialog_action_save_failure">Failed to save playlist</string>
+    <string name="playlist_editor_dialog_action_save_empty">A playlist has to keep at least one track</string>
     <string name="playlist_page_empty">No songs in this playlist</string>
     <string name="playlist_page_play_button">Play</string>
     <string name="playlist_page_shuffle_button">Shuffle</string>

--- a/app/src/test/java/com/eddyizm/tempus/repository/PlaylistRepositoryTest.java
+++ b/app/src/test/java/com/eddyizm/tempus/repository/PlaylistRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.eddyizm.tempus.repository;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.eddyizm.tempus.subsonic.base.ApiResponse;
+import com.eddyizm.tempus.subsonic.models.ResponseStatus;
+import com.eddyizm.tempus.subsonic.models.SubsonicResponse;
+
+import org.junit.Test;
+
+import okhttp3.MediaType;
+import okhttp3.ResponseBody;
+import retrofit2.Response;
+
+public class PlaylistRepositoryTest {
+
+    private static Response<ApiResponse> responseWith(String status) {
+        SubsonicResponse subsonicResponse = new SubsonicResponse();
+        subsonicResponse.setStatus(status);
+
+        ApiResponse body = new ApiResponse();
+        body.setSubsonicResponse(subsonicResponse);
+
+        return Response.success(body);
+    }
+
+    @Test
+    public void okIsAccepted() {
+        assertTrue(PlaylistRepository.isAccepted(responseWith(ResponseStatus.OK)));
+    }
+
+    @Test
+    public void failedInsideHttp200IsRefused() {
+        assertFalse("a refusal carried by a 200 must not read as a save",
+                PlaylistRepository.isAccepted(responseWith(ResponseStatus.FAILED)));
+    }
+
+    @Test
+    public void missingStatusIsRefused() {
+        assertFalse(PlaylistRepository.isAccepted(responseWith(null)));
+    }
+
+    @Test
+    public void httpErrorIsRefused() {
+        Response<ApiResponse> error = Response.error(500,
+                ResponseBody.create("{}", MediaType.get("application/json")));
+
+        assertFalse(PlaylistRepository.isAccepted(error));
+    }
+}


### PR DESCRIPTION
Fixes #800

Saving an edit to a playlist added its songs all over again instead of replacing them.

Everything the editor showed went to the server as songs to add, never as songs to remove, though the same call takes both. A playlist saved without changing anything came back with every song in it twice. A reordered list arrived as a second block after the songs already there, and removing a song was worse still, the one you removed stayed and everything else doubled.

Saving now renames the playlist first, and only if that rename works does it send the songs you left on screen as the new contents, through a different call that writes to the same playlist and keeps the order you arranged.

A save that removes every song is refused, and the editor says a save has to keep at least one song. Servers do not agree on what an empty list means, some clear the playlist and some do nothing. Emptying a playlist belongs in its own change.

Saving is refused while the app does not know what is in the playlist. The editor also no longer falls back on an offline copy when the server cannot be reached, because writing a stale copy back would now delete anything added since it was stored. A refusal that arrives inside a successful reply now counts as a failure, both here and when creating a playlist.

The playlist page now shows the new name instead of the old one.

There are three limits. The save writes the list on screen without reading the server first, so a song added elsewhere after the editor loaded the playlist is dropped. If the name lands and the songs then fail, the new name stays on the server and in the app's lists, not on the page. And a failed save does not refresh the playlist page, because reloading through a server that has just failed can close the page.

I tested the editing and saving paths against a running server, reading the playlist back and checking what the app sent.
