### PR TITLE
Improve Android Auto album track lists

### DIFF
--- a/app/src/main/java/com/eddyizm/tempus/util/Preferences.kt
+++ b/app/src/main/java/com/eddyizm/tempus/util/Preferences.kt
@@ -128,6 +128,7 @@ object Preferences {
     private const val AA_SHUFFLE_STARRED_TRACKS = "androidauto_shuffle_starred_tracks"
     private const val AA_SHUFFLE_PLAYLISTS = "androidauto_shuffle_playlists"
     private const val AA_SHUFFLE_DOWNLOADED_TRACKS = "androidauto_shuffle_downloaded_tracks"
+    private const val AA_TRACK_NUMBERS = "androidauto_track_numbers"
     private const val ACTIVE_MUSIC_FOLDER_ID = "active_music_folder_id"
 
     const val MUSIC_FOLDER_ALL = "default"
@@ -1075,6 +1076,11 @@ object Preferences {
     @JvmStatic
     fun getAndroidAutoStarredForMadeForYou(): Int {
         return App.getInstance().preferences.getString(AA_STARRED_FOR_MADE_FOR_YOU, "0")!!.toInt()
+    }
+
+    @JvmStatic
+    fun isAndroidAutoTrackNumbersEnabled(): Boolean {
+        return App.getInstance().preferences.getBoolean(AA_TRACK_NUMBERS, false)
     }
 
     @JvmStatic

--- a/app/src/main/res/values-b+es+419/strings.xml
+++ b/app/src/main/res/values-b+es+419/strings.xml
@@ -456,6 +456,7 @@
     <string name="settings_androidauto_shuffle_genre_songs_summary">Reproduce canciones aleatorias cuando seleccionas un género</string>
     <string name="settings_androidauto_artists_view">Los artistas se muestran por álbum</string>
     <string name="settings_androidauto_starred_for_made_for_you">Mix de tus canciones favoritas hecho para ti</string>
+    <string name="settings_androidauto_track_numbers">Mostrar números de pista en la vista de álbum</string>
     <string name="settings_audio_quality">Mostrar calidad de audio</string>
     <string name="settings_audio_quality_summary">La tasa de bits y el formato de audio se mostrará en cada canción que reproduzcas</string>
     <string name="settings_song_rating">Mostrar valoración</string>

--- a/app/src/main/res/values-ca/strings.xml
+++ b/app/src/main/res/values-ca/strings.xml
@@ -456,6 +456,7 @@
     <string name="settings_androidauto_shuffle_genre_songs_summary">Reprodueix cançons aleatòries en seleccionar un gènere</string>
     <string name="settings_androidauto_artists_view">Els artistes es mostren per àlbum</string>
     <string name="settings_androidauto_starred_for_made_for_you">Estrelles per a la mescla personal</string>
+    <string name="settings_androidauto_track_numbers">Mostra els números de pista a la vista d\'àlbum</string>
     <string name="settings_audio_quality">Mostra la qualitat de l\'àudio</string>
     <string name="settings_audio_quality_summary">Es mostraran la taxa de bits i el format d\'àudio per a cada pista d\'àudio.</string>
     <string name="settings_song_rating">Mostra la valoració amb estrelles de les cançons</string>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -419,6 +419,7 @@
 	<string name="settings_androidauto_fourth_tab">Viertes Tab</string>
     <string name="settings_androidauto_shuffle_genre_songs">Zufallslieder aus Genres</string>
     <string name="settings_androidauto_shuffle_genre_songs_summary">Bei Auswahl eines Genres werden Lieder daraus zufällig gewählt</string>
+    <string name="settings_androidauto_track_numbers">Titelnummern in der Albumansicht anzeigen</string>
     <string name="settings_audio_quality">Audioqualität zeigen</string>
     <string name="settings_audio_quality_summary">Zeigt Audioformat und Bitrate des aktuellen Titels</string>
     <string name="settings_song_rating">Sternbewertung von Liedern zeigen</string>

--- a/app/src/main/res/values-es-rES/strings.xml
+++ b/app/src/main/res/values-es-rES/strings.xml
@@ -369,6 +369,7 @@
     <string name="settings_playlist_sort">Ordenar listas de reproducción</string>
     <string name="settings_androidauto_fourth_tab">Vista de la cuarta pestaña</string>
     <string name="settings_androidauto_starred_for_made_for_you">Favoritos en el mix \"Para ti\"</string>
+    <string name="settings_androidauto_track_numbers">Mostrar números de pista en la vista de álbum</string>
     <string name="settings_audio_quality">Mostrar calidad de audio</string>
     <string name="settings_audio_quality_summary">La tasa de bits y el formato de audio se mostrarán para cada pista de audio.</string>
     <string name="settings_song_rating_summary">Si se habilita, muestra la valoración de la pista como barra de 5 estrellas en la página del control de reproducción.\n\n*Requiere reiniciar la aplicación</string>

--- a/app/src/main/res/values-eu/strings.xml
+++ b/app/src/main/res/values-eu/strings.xml
@@ -24,7 +24,6 @@
     <string name="aa_quick_mix">Nahasketa azkarra</string>
     <string name="aa_my_mix">Nire nahasketa</string>
     <string name="aa_discovery_mix">Aurkikuntza-nahasketa</string>
-
     <string name="activity_battery_optimizations_conclusion">Arazorik izanez gero, bisitatu https://dontkillmyapp.com. Aplikazioaren errendimenduari eragin diezaioketen energia-aurrezteko eginbideak desgaitzeko argibide zehatzak eskaintzen ditu.</string>
     <string name="activity_battery_optimizations_summary">Mesedez, desgaitu bateria-optimizazioak pantaila itzalita dagoenean multimedia erreproduzitzeko.</string>
     <string name="activity_battery_optimizations_title">Bateria-optimizazioak</string>
@@ -470,6 +469,7 @@
     <string name="settings_androidauto_shuffle_genre_songs_summary">Erreproduzitu ausazko abestiak genero bat hautatzean</string>
     <string name="settings_androidauto_artists_view">Artistak diskaka bistaratzen dira</string>
     <string name="settings_androidauto_starred_for_made_for_you">Gogokoak "Zuretzat egina" nahasketarako</string>
+    <string name="settings_androidauto_track_numbers">Erakutsi pista-zenbakiak albumaren ikuspegian</string>
     <string name="settings_audio_quality">Audio-kalitatea erakutsi</string>
     <string name="settings_audio_quality_summary">Bit-emaria eta audio-formatua erakutsiko dira abesti bakoitzean.</string>
     <string name="settings_song_rating">Abestien izar-balorazioa erakutsi</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -24,7 +24,6 @@
     <string name="aa_quick_mix">Mix rapide</string>
     <string name="aa_my_mix">Mon mix</string>
     <string name="aa_discovery_mix">Mix découverte</string>
-
     <string name="activity_battery_optimizations_conclusion">Si vous rencontrez un problème, visitez https://dontkillmyapp.com. Des instructions pour désactiver les fonctions de sauvegarde d\'énergie qui pourrait affecter les performance de l\'app y sont disponibles.</string>
     <string name="activity_battery_optimizations_summary">Veuillez désactiver les optimisations de la batterie pour permettre la lecture des médias lorsque l\'écran est éteint.</string>
     <string name="activity_battery_optimizations_title">Optimisations de la batterie</string>
@@ -454,6 +453,7 @@
     <string name="settings_androidauto_shuffle_genre_songs_summary">Lire les titres aléatoirement à la sélection d\'un genre</string>
     <string name="settings_androidauto_artists_view">Les artistes sont affichés par album</string>
     <string name="settings_androidauto_starred_for_made_for_you">Sélectionnés pour le mix Pour vous</string>
+    <string name="settings_androidauto_track_numbers">Afficher les numéros de piste dans la vue album</string>
 	<string name="settings_audio_quality">Afficher la qualité audio</string>
     <string name="settings_audio_quality_summary">Le débit binaire et le format audio seront affichés pour chaque piste.</string>
     <string name="settings_song_rating">Afficher la note de la piste</string>

--- a/app/src/main/res/values-it/strings.xml
+++ b/app/src/main/res/values-it/strings.xml
@@ -348,6 +348,7 @@
     <string name="settings_music_directory_summary">Se abilitato, mostra la sezione delle directory musicali. Nota che per la navigazione nelle cartelle è necessario che il server supporti questa funzionalità.</string>
     <string name="settings_podcast">Mostra podcast</string>
     <string name="settings_podcast_summary">Se abilitato, mostra la sezione podcast. Riavvia l\'app per rendere effettive le modifiche.</string>
+    <string name="settings_androidauto_track_numbers">Mostra i numeri delle tracce nella vista album</string>
     <string name="settings_audio_quality">Mostra qualità audio</string>
     <string name="settings_audio_quality_summary">Il bitrate e il formato audio saranno mostrati per ogni traccia.</string>
     <string name="settings_song_rating">Mostra valutazione della canzone</string>

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -489,6 +489,7 @@
     <string name="settings_androidauto_shuffle_genre_songs_summary">ジャンル選択時にランダムな曲を再生します</string>
     <string name="settings_androidauto_artists_view">アーティストをアルバム別に表示</string>
     <string name="settings_androidauto_starred_for_made_for_you">「あなたへのおすすめ」ミックス用のお気に入り</string>
+    <string name="settings_androidauto_track_numbers">アルバム表示でトラック番号を表示</string>
     <string name="settings_audio_quality">音質情報を表示</string>
     <string name="settings_audio_quality_summary">各トラックのビットレートと音声形式が表示されます。</string>
     <string name="settings_song_rating">曲の星評価を表示</string>

--- a/app/src/main/res/values-ko/strings.xml
+++ b/app/src/main/res/values-ko/strings.xml
@@ -394,6 +394,7 @@
     <string name="menu_sort_least_recently_starred">즐겨찾기 오래된순</string>
     <string name="menu_pin_button">홈화면에 추가</string>
     <string name="album_page_release_date_label">%1$s에 발매됨</string>
+    <string name="settings_androidauto_track_numbers">앨범 보기에서 트랙 번호 표시</string>
     <string name="settings_audio_quality">오디오 품질 표시하기</string>
     <string name="settings_audio_quality_summary">오디오 트랙에 비트레이트와 포맷이 표시됩니다.</string>
     <string name="settings_song_rating">음악 별점 표시하기</string>

--- a/app/src/main/res/values-pl/strings.xml
+++ b/app/src/main/res/values-pl/strings.xml
@@ -514,6 +514,7 @@
     <string name="settings_androidauto_shuffle_genre_songs_summary">Odtwórz losowe piosenki po wybraniu gatunku</string>
 	<string name="settings_androidauto_artists_view">Wykonawcy są wyświetlani według albumu</string>
 	<string name="settings_androidauto_starred_for_made_for_you">Oznaczone gwiazdką do mixu stworzonego dla ciebie</string>
+    <string name="settings_androidauto_track_numbers">Pokazuj numery utworów w widoku albumu</string>
     <string name="settings_audio_quality">Pokaż jakość audio</string>
     <string name="settings_audio_quality_summary">Bitrate i format audio będzie pokazywany dla każdego utworu.</string>
     <string name="settings_song_rating">Pokaż ocenę piosenek w gwiazdkach</string>

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -262,6 +262,7 @@
     <string name="settings_music_directory_summary">Se ativado, mostrará a seção do diretório de música. Observe que, para que a navegação na pasta funcione corretamente, o servidor deve oferecer suporte a esse recurso.</string>
     <string name="settings_podcast">Mostrar podcast</string>
     <string name="settings_podcast_summary">Se ativado, mostrará a seção de podcasts. Reinicie o aplicativo para que as mudanças tenham efeito.</string>
+    <string name="settings_androidauto_track_numbers">Mostrar números das faixas na vista de álbum</string>
     <string name="settings_queue_syncing_countdown">Temporizador de sincronização</string>
     <string name="settings_queue_syncing_summary">Se ativado, o usuário poderá salvar sua fila de reprodução e carregar o estado ao abrir o aplicativo.</string>
     <string name="settings_queue_syncing_title">Sincronizar a fila de reprodução para este usuário</string>

--- a/app/src/main/res/values-ro/strings.xml
+++ b/app/src/main/res/values-ro/strings.xml
@@ -358,6 +358,7 @@
     <string name="settings_music_directory_summary">Dacă este activat, afișează secțiunea directorului de muzică. Vă rugăm să rețineți că pentru ca navigarea folderului să funcționeze corect, serverul trebuie să suporte această funcție.</string>
     <string name="settings_podcast">Arătați podcast</string>
     <string name="settings_podcast_summary">Dacă este activat, afișează secțiunea podcast. Reporniți aplicația pentru ca aceasta să aibă efect complet.</string>
+    <string name="settings_androidauto_track_numbers">Afișează numerele pieselor în vizualizarea albumului</string>
     <string name="settings_audio_quality">Arătați calitate audio</string>
     <string name="settings_audio_quality_summary">Bitrate-ul și formatul audio vor fi afișate pentru fiecare pistă audio.</string>
     <string name="settings_song_rating">Arătați evaluarea cu stele a cântecului</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -408,6 +408,7 @@
     <string name="settings_androidauto_fourth_tab">Fourth tab display</string>
     <string name="settings_androidauto_shuffle_genre_songs">Перемешивать треки по жанру</string>
     <string name="settings_androidauto_shuffle_genre_songs_summary">Воспроизводить случайные треки при выборе жанра</string>
+    <string name="settings_androidauto_track_numbers">Показывать номера треков в представлении альбома</string>
     <string name="settings_audio_quality">Показывать качество аудио</string>
     <string name="settings_audio_quality_summary">Битрейт и формат аудио будут отображаться для каждого трека.</string>
     <string name="settings_song_rating">Показывать рейтинг трека</string>

--- a/app/src/main/res/values-tr/strings.xml
+++ b/app/src/main/res/values-tr/strings.xml
@@ -309,6 +309,7 @@
     <string name="settings_music_directory_summary">Etkinleştirildiğinde müzik dizini bölümü görüntülenir. Klasörlerde gezinmenin doğru çalışması için sunucunun bu özelliği desteklemesi gerekir.</string>
     <string name="settings_podcast">Podcast’i göster</string>
     <string name="settings_podcast_summary">Etkinleştirildiğinde podcast bölümü görüntülenir. Tam etkili olması için uygulamayı yeniden başlatın.</string>
+    <string name="settings_androidauto_track_numbers">Albüm görünümünde parça numaralarını göster</string>
     <string name="settings_audio_quality">Ses kalitesini göster</string>
     <string name="settings_audio_quality_summary">Her ses parçası için bit hızı ve ses formatı gösterilecektir.</string>
     <string name="settings_song_rating_summary">" "</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -392,6 +392,7 @@
     <string name="settings_music_directory_summary">啟用後則顯示音樂目錄部分。 請注意，要使資料夾導航正常工作，伺服器必須支援此功能。</string>
     <string name="settings_podcast">顯示播客</string>
     <string name="settings_podcast_summary">啟用後則顯示播客部分。</string>
+    <string name="settings_androidauto_track_numbers">在專輯檢視中顯示曲目編號</string>
     <string name="settings_queue_syncing_countdown">同步定時器</string>
     <string name="settings_queue_syncing_summary">啟用後將允許當前使用者儲存其播放序列，並能夠在開啟應用程式時載入儲存狀態。</string>
     <string name="settings_queue_syncing_title">同步當前使用者的播放序列</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -346,6 +346,7 @@
     <string name="settings_app_equalizer_summary">打开内置均衡器</string>
     <string name="settings_artist_sort_by_album_count">按专辑数量排序艺术家</string>
     <string name="settings_artist_sort_by_album_count_summary">启用后按专辑数量排序；关闭则按名称排序。</string>
+    <string name="settings_androidauto_track_numbers">在专辑视图中显示曲目编号</string>
     <string name="settings_audio_quality">显示音频质量</string>
     <string name="settings_audio_quality_summary">显示歌曲的码率和音频格式。</string>
     <string name="settings_audio_transcode_download_format">转码格式</string>
@@ -392,6 +393,7 @@
     <string name="settings_music_directory_summary">启用后则显示音乐目录部分。 请注意，要使文件夹导航正常工作，服务器必须支持此功能。</string>
     <string name="settings_podcast">显示播客</string>
     <string name="settings_podcast_summary">启用后则显示播客部分。</string>
+
     <string name="settings_queue_syncing_countdown">同步定时器</string>
     <string name="settings_queue_syncing_summary">启用后将允许当前用户保存其播放队列，并能够在打开应用程序时加载保存状态。</string>
     <string name="settings_queue_syncing_title">同步当前用户的播放队列</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -508,6 +508,7 @@
     <string name="settings_androidauto_shuffle_genre_songs_summary">Play random songs when selecting a genre</string>
     <string name="settings_androidauto_artists_view">Artists are displayed by album</string>
     <string name="settings_androidauto_starred_for_made_for_you">Starred for Made For You mix</string>
+    <string name="settings_androidauto_track_numbers">Show track numbers in album view</string>
     <string name="settings_audio_quality">Show audio quality</string>
     <string name="settings_audio_quality_summary">The bitrate and audio format will be shown for each audio track.</string>
     <string name="settings_song_rating">Show song star rating</string>

--- a/app/src/main/res/xml/global_preferences.xml
+++ b/app/src/main/res/xml/global_preferences.xml
@@ -616,6 +616,11 @@
             android:defaultValue="false"
             android:key="androidauto_shuffle_downloaded_tracks" />
 
+        <SwitchPreference
+            android:title="@string/settings_androidauto_track_numbers"
+            android:defaultValue="false"
+            android:key="androidauto_track_numbers" />
+
         <ListPreference
             app:defaultValue="0"
             app:dialogTitle="@string/settings_androidauto_starred_for_made_for_you"

--- a/app/src/tempus/java/com/eddyizm/tempus/repository/AutomotiveRepository.java
+++ b/app/src/tempus/java/com/eddyizm/tempus/repository/AutomotiveRepository.java
@@ -1,5 +1,6 @@
 package com.eddyizm.tempus.repository;
 
+import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
 
@@ -27,10 +28,12 @@ import com.eddyizm.tempus.model.SessionMediaItem;
 import com.eddyizm.tempus.provider.AlbumArtContentProvider;
 import com.eddyizm.tempus.subsonic.base.ApiResponse;
 import com.eddyizm.tempus.subsonic.models.AlbumID3;
+import com.eddyizm.tempus.subsonic.models.AlbumWithSongsID3;
 import com.eddyizm.tempus.subsonic.models.Artist;
 import com.eddyizm.tempus.subsonic.models.ArtistID3;
 import com.eddyizm.tempus.subsonic.models.Child;
 import com.eddyizm.tempus.subsonic.models.Directory;
+import com.eddyizm.tempus.subsonic.models.DiscTitle;
 import com.eddyizm.tempus.subsonic.models.Index;
 import com.eddyizm.tempus.subsonic.models.IndexID3;
 import com.eddyizm.tempus.subsonic.models.InternetRadioStation;
@@ -50,6 +53,7 @@ import com.google.common.util.concurrent.SettableFuture;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Random;
 import java.util.stream.Collectors;
 
@@ -891,11 +895,12 @@ public class AutomotiveRepository {
                     @Override
                     public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
                         if (response.isSuccessful() && response.body() != null && response.body().getSubsonicResponse().getAlbum() != null && response.body().getSubsonicResponse().getAlbum().getSongs() != null) {
-                            List<Child> tracks = response.body().getSubsonicResponse().getAlbum().getSongs();
+                            AlbumWithSongsID3 album = response.body().getSubsonicResponse().getAlbum();
+                            List<Child> tracks = album.getSongs();
 
                             setChildrenMetadata(tracks);
 
-                            List<MediaItem> mediaItems = MappingUtil.mapMediaItems(tracks, ConstantsAA.QUEUE_CACHED_SOURCE);
+                            List<MediaItem> mediaItems = buildAlbumTrackMediaItems(album, tracks, Preferences.isAndroidAutoTrackNumbersEnabled());
 
                             LibraryResult<ImmutableList<MediaItem>> libraryResult = LibraryResult.ofItemList(ImmutableList.copyOf(mediaItems), null);
 
@@ -912,6 +917,97 @@ public class AutomotiveRepository {
                 });
 
         return listenableFuture;
+    }
+
+    private static List<MediaItem> buildAlbumTrackMediaItems(AlbumWithSongsID3 album, List<Child> tracks, boolean showTrackNumbers) {
+        List<MediaItem> mediaItems = MappingUtil.mapMediaItems(tracks, ConstantsAA.QUEUE_CACHED_SOURCE);
+
+        boolean showDiscHeaders = hasMultipleDiscs(tracks);
+
+        if (!showDiscHeaders && !showTrackNumbers) {
+            return mediaItems;
+        }
+
+        List<MediaItem> result = new ArrayList<>(mediaItems.size());
+
+        for (int i = 0; i < mediaItems.size(); i++) {
+            Child track = tracks.get(i);
+            MediaItem mediaItem = mediaItems.get(i);
+
+            MediaMetadata.Builder metadataBuilder = mediaItem.mediaMetadata.buildUpon();
+
+            if (showDiscHeaders) {
+                applyDiscHeader(album, track, mediaItem, metadataBuilder);
+            }
+
+            String displayTitle = getTrackDisplayTitle(track, showTrackNumbers);
+
+            if (displayTitle != null) {
+                metadataBuilder.setDisplayTitle(displayTitle);
+            }
+
+            result.add(mediaItem.buildUpon().setMediaMetadata(metadataBuilder.build()).build());
+        }
+
+        return result;
+    }
+
+    static boolean hasMultipleDiscs(List<Child> tracks) {
+        return tracks.stream()
+                .map(Child::getDiscNumber)
+                .filter(Objects::nonNull)
+                .distinct()
+                .limit(2)
+                .count() > 1;
+    }
+
+    private static void applyDiscHeader(AlbumWithSongsID3 album, Child track, MediaItem mediaItem, MediaMetadata.Builder metadataBuilder) {
+        String title = getDiscHeaderTitle(App.getContext(), album, track);
+
+        if (title == null) {
+            return;
+        }
+
+        Bundle extras = mediaItem.mediaMetadata.extras == null ? new Bundle() : new Bundle(mediaItem.mediaMetadata.extras);
+
+        extras.putString(MediaConstants.EXTRAS_KEY_CONTENT_STYLE_GROUP_TITLE, title);
+
+        metadataBuilder.setExtras(extras);
+    }
+
+    static String getDiscHeaderTitle(Context context, AlbumWithSongsID3 album, Child track) {
+        Integer discNumber = track.getDiscNumber();
+        if (discNumber == null) {
+            return null;
+        }
+
+        String discSubtitle = getDiscSubtitle(album, discNumber);
+
+        return discSubtitle == null
+                ? context.getString(R.string.disc_titleless, discNumber.toString())
+                : context.getString(R.string.disc_titlefull, discNumber.toString(), discSubtitle);
+    }
+
+    static String getDiscSubtitle(AlbumWithSongsID3 album, Integer discNumber) {
+        List<DiscTitle> titles = album.getDiscTitles();
+        if (titles == null) {
+            return null;
+        }
+
+        return titles.stream()
+                .filter(discTitle -> discNumber.equals(discTitle.getDisc()))
+                .map(DiscTitle::getTitle)
+                .filter(title -> title != null && !title.isEmpty())
+                .findFirst()
+                .orElse(null);
+    }
+
+    static String getTrackDisplayTitle(Child track, Boolean showTrackNumbers) {
+        if (!showTrackNumbers || track.getTrack() == null || track.getTitle() == null) {
+            return null;
+        }
+
+        return track.getTrack() + ". " + track.getTitle();
     }
 
     public ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> getArtistAlbum(String prefix, String id) {

--- a/app/src/testTempus/java/com/eddyizm/tempus/repository/AutomotiveRepositoryTest.java
+++ b/app/src/testTempus/java/com/eddyizm/tempus/repository/AutomotiveRepositoryTest.java
@@ -1,8 +1,17 @@
 package com.eddyizm.tempus.repository;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.content.Context;
 
 import com.eddyizm.tempus.subsonic.models.InternetRadioStation;
+import com.eddyizm.tempus.R;
+import com.eddyizm.tempus.subsonic.models.AlbumWithSongsID3;
+import com.eddyizm.tempus.subsonic.models.Child;
+import com.eddyizm.tempus.subsonic.models.DiscTitle;
 
 import org.junit.Test;
 
@@ -15,6 +24,14 @@ public class AutomotiveRepositoryTest {
 
     private static InternetRadioStation station(String name) {
         return new InternetRadioStation(null, name, null, null, null, null);
+    }
+
+    private static Child track(String id, String title, int trackNumber, int discNumber) {
+        Child track = new Child(id);
+        track.setTitle(title);
+        track.setTrack(trackNumber);
+        track.setDiscNumber(discNumber);
+        return track;
     }
 
     private static List<String> names(List<InternetRadioStation> stations) {
@@ -47,5 +64,63 @@ public class AutomotiveRepositoryTest {
                 Arrays.asList(station(null), station("a")));
 
         assertEquals(Arrays.asList(null, "a", "b"), names(result));
+    }
+
+    @Test
+    public void trackNumbersShownWhenSettingEnabled() {
+        Child track = track("1", "Track One", 1, 1);
+
+        assertEquals("1. Track One", AutomotiveRepository.getTrackDisplayTitle(track, true));
+    }
+
+    @Test
+    public void trackNumbersNotShownWhenSettingDisabled() {
+        Child track = track("1", "Track One", 1, 1);
+
+        assertNull(AutomotiveRepository.getTrackDisplayTitle(track, false));
+    }
+
+    @Test
+    public void singleDiscAlbumHasNoDiscHeader() {
+        Context context = mock(Context.class);
+        AlbumWithSongsID3 album = new AlbumWithSongsID3();
+
+        List<Child> tracks = Arrays.asList(
+                track("1", "Track One", 1, 1),
+                track("2", "Track Two", 2, 1));
+
+        assertNull(AutomotiveRepository.getDiscHeaderTitle(context, album, tracks.getFirst()));
+    }
+
+    @Test
+    public void multiDiscAlbumWithoutTitlesShowsDiscNumber() {
+        Context context = mock(Context.class);
+        AlbumWithSongsID3 album = new AlbumWithSongsID3();
+
+        List<Child> tracks = Arrays.asList(
+                track("1", "First Disc, Last Track", 14, 1),
+                track("2", "Second Disc, First Track", 1, 2));
+
+        when(context.getString(R.string.disc_titleless, "2")).thenReturn("Disc 2");
+
+        assertEquals("Disc 2", AutomotiveRepository.getDiscHeaderTitle(context, album, tracks.get(1)));
+    }
+
+    @Test
+    public void multiDiscAlbumWithTitlesShowsDiscNumberAndTitle() {
+        Context context = mock(Context.class);
+        AlbumWithSongsID3 album = new AlbumWithSongsID3();
+
+        album.setDiscTitles(Arrays.asList(
+                new DiscTitle(1, "Title of Disc 1"),
+                new DiscTitle(2, "Title of Disc 2")));
+
+        List<Child> tracks = Arrays.asList(
+                track("1", "First Disc, Last Track", 14, 1),
+                track("2", "Second Disc, First Track", 1, 2));
+
+        when(context.getString(R.string.disc_titlefull, "2", "Title of Disc 2")).thenReturn("Disc 2 - Title of Disc 2");
+
+        assertEquals("Disc 2 - Title of Disc 2", AutomotiveRepository.getDiscHeaderTitle(context, album, tracks.get(1)));
     }
 }


### PR DESCRIPTION
Adds a couple of small QoL improvements to album browsing in Android Auto:

Groups multi-disc albums by disc, including disc titles where available.
Adds an Android Auto setting to optionally show track numbers in album view.
Single-disc albums remain unchanged unless track numbers are enabled.
Adds tests covering disc grouping and the track number setting.

Screenshots show the updated multi-disc album view and track numbering.

Multidisc with title and track numbers
<img width="791" height="433" alt="Multidisc with title and track numbers" src="https://github.com/user-attachments/assets/8f16181a-e1cd-4f67-adc0-5a60bf882e26" />

Multidisc with title, no track numbers
<img width="791" height="433" alt="Multidisc with title, no track numbers" src="https://github.com/user-attachments/assets/de2c87ee-283d-444b-927a-cdf1671e459e" />

Multidisc without titles, with track numbers
<img width="791" height="423" alt="Multidisc without titles, with track numbers" src="https://github.com/user-attachments/assets/780eb16a-6697-428c-a97d-7e5337adca29" />

Single disc with track numbers
<img width="791" height="426" alt="Single disc with track numbers" src="https://github.com/user-attachments/assets/6189e882-1e3e-4acb-a0af-6a8dc9e528c2" />


