### PR TITLE
fix: no search result placeholder never goes away after triggered

### DIFF
--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/SearchFragment.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/SearchFragment.java
@@ -277,6 +277,8 @@ public class SearchFragment extends Fragment implements ClickCallback {
 
                 if (sectionsThatMatchedTheQuery == 0) {
                     bind.emptyResponseContainer.setVisibility(View.VISIBLE);
+                } else {
+                    bind.emptyResponseContainer.setVisibility(View.GONE);
                 }
             }
         });


### PR DESCRIPTION
Partially solves #1074, fixes a logical bug from #1035 (the placeholder lingers forever after it gets unhidden).