### PR TITLE
fix: crash when login fails

### DIFF
--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/LoginFragment.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/LoginFragment.java
@@ -1,5 +1,6 @@
 package com.eddyizm.tempus.ui.fragment;
 
+import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
 import android.view.LayoutInflater;
@@ -154,8 +155,10 @@ public class LoginFragment extends Fragment implements ClickCallback {
             public void onError(Exception exception) {
                 Preferences.switchInUseServerAddress();
                 resetServerPreference();
-                if (requireContext() != null) { // Swapping activities does not ensure non-null
-                    Toast.makeText(requireContext(), exception.getMessage(), Toast.LENGTH_SHORT).show();
+
+                Context context = getContext();
+                if (context != null && isAdded()) {
+                    Toast.makeText(context, exception.getMessage(), Toast.LENGTH_SHORT).show();
                 }
             }
 


### PR DESCRIPTION
Resolves #1077

The previous check was wrong because it returns `IllegalStateException` rather than `null`.