### PR TITLE
fix: view swaps from callbacks crash the app when activity is suspended

### DIFF
--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/PlayerBottomSheetFragment.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/PlayerBottomSheetFragment.java
@@ -295,11 +295,13 @@ public class PlayerBottomSheetFragment extends Fragment {
     }
 
     public void goBackToFirstPage() {
+        if (getContext() == null || !isAdded() || getView() == null) return;
         bind.playerBodyLayout.playerBodyBottomSheetViewPager.setCurrentItem(0, false);
         goToControllerPage();
     }
 
     public void goToControllerPage() {
+        if (getContext() == null || !isAdded() || getView() == null) return;
         PlayerControllerVerticalPager playerControllerVerticalPager = (PlayerControllerVerticalPager) bind.playerBodyLayout.playerBodyBottomSheetViewPager.getAdapter();
         if (playerControllerVerticalPager != null) {
             PlayerControllerFragment playerControllerFragment = (PlayerControllerFragment) playerControllerVerticalPager.getRegisteredFragment(0);
@@ -310,6 +312,7 @@ public class PlayerBottomSheetFragment extends Fragment {
     }
 
     public void goToLyricsPage() {
+        if (getContext() == null || !isAdded() || getView() == null) return;
         PlayerControllerVerticalPager playerControllerVerticalPager = (PlayerControllerVerticalPager) bind.playerBodyLayout.playerBodyBottomSheetViewPager.getAdapter();
         if (playerControllerVerticalPager != null) {
             PlayerControllerFragment playerControllerFragment = (PlayerControllerFragment) playerControllerVerticalPager.getRegisteredFragment(0);
@@ -320,6 +323,7 @@ public class PlayerBottomSheetFragment extends Fragment {
     }
 
     public void goToQueuePage() {
+        if (getContext() == null || !isAdded() || getView() == null) return;
         bind.playerBodyLayout.playerBodyBottomSheetViewPager.setCurrentItem(1, true);
     }
 


### PR DESCRIPTION
Resolves #1044 

There was a callback waking up the suspended activity. Suspended activities have null bindings, so trying to change something in the XML crashes the app if not checking it is correctly attached.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation stability by preventing actions when the player interface is not fully attached or available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->