### PR TITLE
Repeat one restarts a transcoded track from the start after a seek

### DIFF
--- a/app/src/main/java/com/eddyizm/tempus/util/TranscodingMediaSource.kt
+++ b/app/src/main/java/com/eddyizm/tempus/util/TranscodingMediaSource.kt
@@ -26,10 +26,15 @@ class TranscodingMediaSource(
         private val mediaItem: MediaItem,
         private val dataSourceFactory: DataSource.Factory,
         private val progressiveMediaSourceFactory: ProgressiveMediaSource.Factory
-) : CompositeMediaSource<Void>() {
+) : CompositeMediaSource<Int>() {
 
     private var durationUs: Long = C.TIME_UNSET
-    private var currentSource: MediaSource? = null
+
+    // One child for the whole track, prepared once and kept until the source is released. Every
+    // period starts from it, so a repeat one loop never starts from a seeked stream. A seek gets
+    // its own child, owned by the period that seeked. See #383.
+    private var baseSource: MediaSource? = null
+    private var nextSeekChildId = BASE_CHILD_ID + 1
 
     init {
         val extras = mediaItem.mediaMetadata.extras
@@ -43,24 +48,32 @@ class TranscodingMediaSource(
                 durationUs = Util.msToUs(seconds * 1000L)
             }
         }
-
-        currentSource = progressiveMediaSourceFactory.createMediaSource(mediaItem)
     }
 
     override fun getMediaItem() = mediaItem
 
     override fun prepareSourceInternal(mediaTransferListener: TransferListener?) {
         super.prepareSourceInternal(mediaTransferListener)
-        val initialSource = progressiveMediaSourceFactory.createMediaSource(mediaItem)
-        currentSource = initialSource
-        prepareChildSource(null, initialSource)
+        val source = progressiveMediaSourceFactory.createMediaSource(mediaItem)
+        // Assigned before the child is prepared, because the first timeline refresh can call
+        // createPeriod through the player's masking source before this method returns.
+        baseSource = source
+        prepareChildSource(BASE_CHILD_ID, source)
+    }
+
+    override fun releaseSourceInternal() {
+        super.releaseSourceInternal()
+        baseSource = null
     }
 
     override fun onChildSourceInfoRefreshed(
-            childSourceId: Void?,
+            childSourceId: Int?,
             mediaSource: MediaSource,
             newTimeline: Timeline
     ) {
+        // A seek child streams from an offset, so its window is only the remainder of the track.
+        // Only the base child describes the whole track.
+        if (childSourceId != BASE_CHILD_ID) return
         val timeline =
                 if (durationUs != C.TIME_UNSET) {
                     DurationOverridingTimeline(newTimeline, durationUs)
@@ -75,25 +88,17 @@ class TranscodingMediaSource(
             allocator: Allocator,
             startPositionUs: Long
     ): MediaPeriod {
-        val source = currentSource ?: throw IllegalStateException("Source not ready")
+        val source = baseSource ?: throw IllegalStateException("Source not ready")
         val childPeriod = source.createPeriod(id, allocator, startPositionUs)
         return TranscodingMediaPeriod(childPeriod, source, id, allocator)
     }
 
     override fun releasePeriod(mediaPeriod: MediaPeriod) {
-        val transcodingPeriod = mediaPeriod as TranscodingMediaPeriod
-        transcodingPeriod.release()
-        
-        if (transcodingPeriod.currentOffsetUs > 0) {
-            releaseChildSource(null)
-            val initialSource = progressiveMediaSourceFactory.createMediaSource(mediaItem)
-            currentSource = initialSource
-            prepareChildSource(null, initialSource)
-        }
+        (mediaPeriod as TranscodingMediaPeriod).release()
     }
 
     override fun getMediaPeriodIdForChildMediaPeriodId(
-            childSourceId: Void?,
+            childSourceId: Int?,
             mediaPeriodId: MediaSource.MediaPeriodId
     ) = mediaPeriodId
 
@@ -107,6 +112,7 @@ class TranscodingMediaSource(
         private var localCallback: MediaPeriod.Callback? = null
         internal var currentOffsetUs: Long = 0
         private var isReloading = false
+        private var seekChildId: Int? = null
 
         private var lastSelections: Array<out ExoTrackSelection?>? = null
         private var lastMayRetainStreamFlags: BooleanArray? = null
@@ -114,6 +120,8 @@ class TranscodingMediaSource(
 
         fun release() {
             source.releasePeriod(currentPeriod)
+            seekChildId?.let { releaseChildSource(it) }
+            seekChildId = null
         }
 
         override fun prepare(callback: MediaPeriod.Callback, positionUs: Long) {
@@ -254,7 +262,7 @@ class TranscodingMediaSource(
             activeWrappers.forEach { it?.childStream = null }
 
             source.releasePeriod(currentPeriod)
-            releaseChildSource(null)
+            seekChildId?.let { releaseChildSource(it) }
 
             val seconds = Util.usToMs(positionUs) / 1000
             val newUri = MusicUtil.getStreamUri(mediaItem.mediaId, seconds.toInt())
@@ -262,9 +270,10 @@ class TranscodingMediaSource(
 
             val newSource = progressiveMediaSourceFactory.createMediaSource(newMediaItem)
 
+            val childId = nextSeekChildId++
+            seekChildId = childId
             source = newSource
-            currentSource = newSource
-            prepareChildSource(null, newSource)
+            prepareChildSource(childId, newSource)
 
             val newPeriod = newSource.createPeriod(id, allocator, 0)
             currentPeriod = newPeriod
@@ -337,5 +346,9 @@ class TranscodingMediaSource(
             period.durationUs = durationUs
             return period
         }
+    }
+
+    private companion object {
+        const val BASE_CHILD_ID = 0
     }
 }

--- a/app/src/test/java/com/eddyizm/tempus/util/TranscodingMediaSourceTest.kt
+++ b/app/src/test/java/com/eddyizm/tempus/util/TranscodingMediaSourceTest.kt
@@ -1,0 +1,103 @@
+package com.eddyizm.tempus.util
+
+import android.net.Uri
+import android.os.Handler
+import android.os.Looper
+import androidx.media3.common.MediaItem
+import androidx.media3.datasource.DataSource
+import androidx.media3.exoplayer.SeekParameters
+import androidx.media3.exoplayer.analytics.PlayerId
+import androidx.media3.exoplayer.source.MediaPeriod
+import androidx.media3.exoplayer.source.MediaSource
+import androidx.media3.exoplayer.source.ProgressiveMediaSource
+import androidx.media3.exoplayer.upstream.Allocator
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.mockito.Mockito.mockConstruction
+import org.mockito.Mockito.mockStatic
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.times
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+/**
+ * The fix for #383 is an invariant about which source a period is built from. Looping exposes it,
+ * because the player builds the next loop before it releases the finishing one.
+ */
+class TranscodingMediaSourceTest {
+
+    private val allocator = mock<Allocator>()
+    private val periodId = MediaSource.MediaPeriodId(Any())
+
+    private class Child(val source: ProgressiveMediaSource, val period: MediaPeriod)
+
+    private class Factory {
+        val children = mutableListOf<Child>()
+
+        val mock: ProgressiveMediaSource.Factory = mock<ProgressiveMediaSource.Factory>().also {
+            whenever(it.createMediaSource(any())).thenAnswer {
+                val source = mock<ProgressiveMediaSource>()
+                val period = mock<MediaPeriod>()
+                whenever(source.createPeriod(any(), any(), any())).thenReturn(period)
+                children.add(Child(source, period))
+                source
+            }
+        }
+
+        val base get() = children[0]
+        val seekChild get() = children[1]
+    }
+
+    private fun prepared(factory: Factory): TranscodingMediaSource {
+        val item = MediaItem.Builder().setMediaId("song-1").build()
+        val source = TranscodingMediaSource(item, mock<DataSource.Factory>(), factory.mock)
+        source.prepareSource(mock<MediaSource.MediaSourceCaller>(), null, PlayerId.UNSET)
+        return source
+    }
+
+    /** The composite base class reaches for these while the source is prepared. */
+    private fun withAndroidLooper(body: () -> Unit) {
+        mockStatic(Looper::class.java).use { looper ->
+            looper.`when`<Looper> { Looper.myLooper() }.thenReturn(mock<Looper>())
+            mockConstruction(Handler::class.java).use { body() }
+        }
+    }
+
+    // A transcode the player cannot seek reports an adjusted position of zero, which forces reload.
+    private fun seek(period: MediaPeriod, factory: Factory) {
+        whenever(factory.base.period.getAdjustedSeekPositionUs(any(), any<SeekParameters>()))
+                .thenReturn(0L)
+        mockStatic(MusicUtil::class.java).use { music ->
+            music.`when`<Uri> { MusicUtil.getStreamUri(any(), any()) }.thenReturn(mock<Uri>())
+            period.seekToUs(6_000_000L)
+        }
+    }
+
+    @Test
+    fun everyLoopIsBuiltFromTheOneBaseSource() = withAndroidLooper {
+        val factory = Factory()
+        val source = prepared(factory)
+
+        source.createPeriod(periodId, allocator, 0)
+        source.createPeriod(periodId, allocator, 0)
+
+        assertEquals(1, factory.children.size)
+        verify(factory.base.source, times(2)).createPeriod(any(), any(), any())
+    }
+
+    @Test
+    fun aLoopBuiltAfterASeekStillComesFromTheBaseSource() = withAndroidLooper {
+        val factory = Factory()
+        val source = prepared(factory)
+
+        seek(source.createPeriod(periodId, allocator, 0), factory)
+        source.createPeriod(periodId, allocator, 0)
+
+        assertEquals(2, factory.children.size)
+        // The base served the first playthrough and the loop; before the fix the loop came off
+        // the seek source instead.
+        verify(factory.base.source, times(2)).createPeriod(any(), any(), any())
+        verify(factory.seekChild.source, times(1)).createPeriod(any(), any(), any())
+    }
+}


### PR DESCRIPTION
Fixes #383.

When the server is transcoding and the app asked for the format, the stream cannot be seeked, so a seek asks the server for the song again from the chosen second. With repeat one, or repeat all and one song in the queue, loops after such a seek played audio from the seek point while the timebar sat at 0:00.

This change keeps a stream that is never seeked and builds every loop from it, so nothing is swapped underneath a loop that is already playing. A seek gets its own stream that goes away with the playthrough it belongs to.

Tested on an emulator against a server behind a proxy that hides the headers which would let the player seek on its own, with the app asking for opus at 64 kbps and repeat one on. On the current release, one seek was followed by seven requests still asking for the seek offset. On this branch the same seek was followed by exactly one, and every loop after it asked for the song from the start.

This only changes playback the server transcodes on request, on servers that support seeking a transcode. It covers songs and podcast episodes, and downloads only when the app asked for a format. Direct play, plain downloads, files in a download folder and playback that leaves the format to the server do not.

