### PR TITLE
fix: prevent startup crash on duplicate tracks in playback queue

### DIFF
--- a/app/src/main/java/com/eddyizm/tempus/ui/components/NowPlayingArtworkPager.kt
+++ b/app/src/main/java/com/eddyizm/tempus/ui/components/NowPlayingArtworkPager.kt
@@ -107,7 +107,7 @@ fun NowPlayingArtworkPager(
         pageSpacing = 16.dp,
         userScrollEnabled = !isRadio && count > 1,
         key = { page ->
-            if (isRadio) "radio" else queue.getOrNull(page)?.id ?: page
+            if (isRadio) "radio" else "${queue.getOrNull(page)?.id ?: "track"}_$page"
         }
     ) { page ->
         val pageOffset = ((pagerState.currentPage - page) + pagerState.currentPageOffsetFraction).absoluteValue


### PR DESCRIPTION
### Problem
When the playback queue contains duplicate tracks (e.g., repeated songs or looping an album/queue), `NowPlayingArtworkPager` crashes on launch with an `IllegalArgumentException` from Compose's `HorizontalPager` due to duplicate keys.

Because Tempus persists the queue across launches, this causes an unrecoverable startup crash loop where the only workaround is wiping all app data/settings.

### Solution
Append the `page` index to the item key for queued tracks:
```kotlin
key = { page ->
    if (isRadio) "radio" else "${queue.getOrNull(page)?.id ?: "track"}_$page"
}
```
This guarantees uniqueness across duplicate queue entries while keeping keys stable per page.
