### PR TITLE
ci: add emulator tests against dockerized Subsonic servers

### DIFF
--- a/.github/workflows/emulator-tests.yml
+++ b/.github/workflows/emulator-tests.yml
@@ -1,0 +1,126 @@
+name: Emulator Tests
+
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+jobs:
+  emulator-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        server:
+          - name: navidrome
+            image: deluan/navidrome:latest
+            port: 4533:4533
+            env: -e ND_DEVAUTOCREATEADMINPASSWORD=test -e ND_MUSICFOLDER=/music -e ND_DATAFOLDER=/data
+            password: test
+          - name: gonic
+            image: sentriz/gonic:latest
+            port: 4533:4747
+            env: -e GONIC_MUSIC_PATH=/music -e GONIC_DB_PATH=/data/gonic.db -e GONIC_PLAYLISTS_PATH=/playlists -e GONIC_SCAN_AT_START_ENABLED=1 -e GONIC_LISTEN_ADDR=0.0.0.0:4747
+            password: admin
+        flavor:
+          - tempus
+          - degoogled
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Setup JDK 21
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'zulu'
+          java-version: '21'
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+        with:
+          cache-read-only: ${{ github.event.repository.fork && github.actor != github.repository_owner }}
+
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
+
+      # Generate a small test library so the app has something to render.
+      # GitHub runners don't ship ffmpeg, so install it first.
+      - name: Install ffmpeg
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y ffmpeg
+
+      - name: Seed test library
+        run: |
+          mkdir -p "test-library/Test Album"
+          ffmpeg -f lavfi -i "sine=frequency=440:duration=30" \
+            -metadata title="Test Song 1" -metadata artist="Test Artist" \
+            -metadata album="Test Album" -q:a 9 -y "test-library/Test Album/01 Test Song 1.mp3"
+          ffmpeg -f lavfi -i "sine=frequency=550:duration=30" \
+            -metadata title="Test Song 2" -metadata artist="Test Artist" \
+            -metadata album="Test Album" -q:a 9 -y "test-library/Test Album/02 Test Song 2.mp3"
+
+      # Started as a step (not a `services:` container) so the test-library
+      # folder is checked out and mountable — service containers start before
+      # checkout and cannot bind-mount repo files.
+      - name: Start ${{ matrix.server.name }}
+        run: |
+          docker run -d --name ${{ matrix.server.name }} \
+            -p ${{ matrix.server.port }} \
+            ${{ matrix.server.env }} \
+            -v "$GITHUB_WORKSPACE/test-library:/music:ro" \
+            -v ${{ matrix.server.name }}-data:/data \
+            -v ${{ matrix.server.name }}-playlists:/playlists \
+            ${{ matrix.server.image }}
+
+      - name: Wait for ${{ matrix.server.name }}
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf "http://127.0.0.1:4533/rest/ping?u=admin&p=${{ matrix.server.password }}&v=1.16.1&c=tempus&f=json" | grep -q '"ok"'; then
+              echo "${{ matrix.server.name }} ready"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "${{ matrix.server.name }} did not become ready"
+          exit 1
+
+      # The server scans the library on startup; wait until the seeded songs
+      # are indexed before running the app against it.
+      - name: Wait for library index
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf "http://127.0.0.1:4533/rest/getRandomSongs?u=admin&p=${{ matrix.server.password }}&v=1.16.1&c=tempus&f=json&size=10" | grep -q "Test Song"; then
+              echo "Library indexed"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Library not indexed"
+          exit 1
+
+      # The emulator needs /dev/kvm; the runner user can't access it by
+      # default, which silently falls back to slow software emulation.
+      - name: Enable KVM access
+        run: |
+          sudo chmod 666 /dev/kvm
+
+      - name: Run instrumented tests
+        uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 34
+          target: google_apis
+          arch: x86_64
+          script: bash scripts/run-emulator-tests.sh ${{ matrix.server.password }} ${{ matrix.flavor }}
+
+      - name: Upload Test Report Artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: emulator-test-report-${{ matrix.server.name }}-${{ matrix.flavor }}
+          path: |
+            **/build/reports/androidTests/
+            logcat.txt

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -160,6 +160,7 @@ dependencies {
 
     androidTestImplementation libs.androidx.test.ext.junit
     androidTestImplementation libs.androidx.test.runner
+    androidTestImplementation libs.androidx.test.espresso.core
 }
 
 java {

--- a/app/src/androidTest/java/com/eddyizm/tempus/AppLaunchSmokeTest.java
+++ b/app/src/androidTest/java/com/eddyizm/tempus/AppLaunchSmokeTest.java
@@ -1,0 +1,100 @@
+package com.eddyizm.tempus;
+
+import android.content.Context;
+
+import androidx.lifecycle.Lifecycle;
+import androidx.preference.PreferenceManager;
+import androidx.test.core.app.ActivityScenario;
+import androidx.test.core.app.ApplicationProvider;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+
+import com.eddyizm.tempus.ui.activity.MainActivity;
+import com.eddyizm.tempus.util.Preferences;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static androidx.test.espresso.Espresso.onView;
+import static androidx.test.espresso.action.ViewActions.scrollTo;
+import static androidx.test.espresso.assertion.ViewAssertions.matches;
+import static androidx.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static androidx.test.espresso.matcher.ViewMatchers.withText;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Proves the emulator + docker-Subsonic-server plumbing: the app installs,
+ * launches, and reaches RESUMED without crashing when pointed at a server.
+ *
+ * The server address is the emulator's alias for the host loopback
+ * (10.0.2.2), where the CI workflow publishes a Navidrome container.
+ */
+@RunWith(AndroidJUnit4.class)
+public class AppLaunchSmokeTest {
+
+    @Before
+    public void grantNotificationsPermission() {
+        // The app requests POST_NOTIFICATIONS on first launch; the resulting
+        // dialog pauses the activity and blocks it from staying RESUMED in a
+        // headless test. Grant it up front so the app reaches a usable state.
+        Context context = ApplicationProvider.getApplicationContext();
+        InstrumentationRegistry.getInstrumentation().getUiAutomation()
+                .grantRuntimePermission(context.getPackageName(),
+                        "android.permission.POST_NOTIFICATIONS");
+    }
+
+    @Test
+    public void appLaunchesAndConnects() {
+        Context context = ApplicationProvider.getApplicationContext();
+        String password = InstrumentationRegistry.getArguments()
+                .getString("serverPassword", "test");
+        PreferenceManager.getDefaultSharedPreferences(context)
+                .edit()
+                .putString("server", "http://10.0.2.2:4533")
+                .putString("user", "admin")
+                .putString("password", password)
+                // The battery-optimization warning card blocks the home content.
+                .putBoolean("battery_optimization", false)
+                .commit();
+
+        try (ActivityScenario<MainActivity> scenario = ActivityScenario.launch(MainActivity.class)) {
+            // The app is slow to reach RESUMED on a fresh software-rendered
+            // emulator (splash + heavy init), so poll past ActivityScenario's
+            // default 45s timeout.
+            long deadline = System.currentTimeMillis() + 120_000;
+            while (scenario.getState() != Lifecycle.State.RESUMED
+                    && System.currentTimeMillis() < deadline) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+            assertEquals(Lifecycle.State.RESUMED, scenario.getState());
+
+            // The app sets openSubsonic only after a successful server ping;
+            // wait for it to prove the app actually connected to Navidrome.
+            deadline = System.currentTimeMillis() + 60_000;
+            while (!Preferences.isOpenSubsonic()
+                    && System.currentTimeMillis() < deadline) {
+                try {
+                    Thread.sleep(1000);
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    break;
+                }
+            }
+            assertTrue("app did not connect to the server", Preferences.isOpenSubsonic());
+
+            // The home screen loads random songs from the seeded library;
+            // assert one of them renders to prove the library is served.
+            // The Discovery section sits below the sync cards, so scroll to it.
+            onView(withText("Test Song 1"))
+                    .perform(scrollTo())
+                    .check(matches(isDisplayed()));
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -32,6 +32,7 @@ lifecycleViewmodelKtx = "2.11.0"
 # Testing
 androidxTestExtJunit = "1.2.1"
 androidxTestRunner = "1.6.2"
+androidxTestEspresso = "3.6.1"
 
 # Compose
 composeBom = "2026.08.00"
@@ -88,6 +89,7 @@ androidx-lifecycle-viewmodel-ktx = { group = "androidx.lifecycle", name = "lifec
 
 androidx-test-ext-junit = { group = "androidx.test.ext", name = "junit", version.ref = "androidxTestExtJunit" }
 androidx-test-runner = { group = "androidx.test", name = "runner", version.ref = "androidxTestRunner" }
+androidx-test-espresso-core = { group = "androidx.test.espresso", name = "espresso-core", version.ref = "androidxTestEspresso" }
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }

--- a/scripts/run-emulator-tests.sh
+++ b/scripts/run-emulator-tests.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Runs the connected instrumented tests and dumps logcat for diagnosis.
+# Invoked from android-emulator-runner's `script:` input, which runs each
+# line as a separate `sh -c`, so all logic lives in this file.
+set +e
+flavor="$2"
+./gradlew "connected${flavor^}DebugAndroidTest" \
+  -Pandroid.testInstrumentationRunnerArguments.serverPassword="$1"
+status=$?
+adb -s emulator-5554 logcat -d > logcat.txt 2>/dev/null
+exit $status

--- a/test-library/README.md
+++ b/test-library/README.md
@@ -1,0 +1,9 @@
+# Test music library
+
+This folder is mounted into the Navidrome container in CI as its music folder
+(`ND_MUSICFOLDER`). Drop short audio files here to give the app a library to
+browse and play during emulator tests.
+
+For the resume/continue-listening tests, tracks must be > 10 minutes (the
+app's resumability threshold) — generate them in CI with ffmpeg, or seed
+bookmarks directly via the Subsonic API instead of relying on real playback.


### PR DESCRIPTION
## What this does

Adds a CI workflow that actually boots an Android emulator and runs a real instrumented test against a real Subsonic server. No more "it works on my machine" — the app now proves it can install, launch, connect to a server, and render the home screen, on every push.

## How it works

The workflow spins up a dockerized Subsonic server, seeds a tiny test library (two sine-wave MP3s generated with ffmpeg), boots an emulator with KVM, and runs a smoke test that:

1. launches the app
2. waits for it to reach a usable state
3. checks it actually connects to the server (not just that it opens)
4. scrolls to the Discovery section and asserts a seeded song shows up

## Coverage

It runs the same test across a small matrix:

| Server | Flavor |
|--------|--------|
| Navidrome | tempus |
| Navidrome | degoogled |
| gonic | tempus |
| gonic | degoogled |

So we get both server implementations and both product flavors covered for free.

## Why this matters

The existing unit tests are great, but they never touch a real server or a real device. This catches the kind of thing that only shows up when the app talks to an actual Subsonic API — wrong endpoints, auth issues, library parsing, that sort of thing. And since it runs on every push, regressions get caught early instead of at release time.

## Notes

- The smoke test is intentionally small. It proves the plumbing works (emulator + server + app + library), not every feature. Playback, downloads, bookmarks, etc. can be added as follow-ups.
- The server password is passed to the test via an instrumentation argument, so each server in the matrix logs in with its own credentials.
- gonic needed a couple of non-obvious settings to start in docker (it listens on port 80 by default and won't boot without a playlists dir) — that's all handled in the workflow.

## Testing

All four matrix jobs pass on the `ci/emulator-tests` branch.