### PR TITLE
Keep the favorite heart in step across every screen

### DIFF
--- a/app/src/main/java/com/eddyizm/tempus/interfaces/StarCallback.java
+++ b/app/src/main/java/com/eddyizm/tempus/interfaces/StarCallback.java
@@ -6,4 +6,6 @@ import androidx.annotation.Keep;
 public interface StarCallback {
     default void onError() {}
     default void onSuccess() {}
+
+    default void onRefused() {}
 }

--- a/app/src/main/java/com/eddyizm/tempus/model/SessionMediaItem.kt
+++ b/app/src/main/java/com/eddyizm/tempus/model/SessionMediaItem.kt
@@ -24,6 +24,7 @@ import com.eddyizm.tempus.util.Constants
 import com.eddyizm.tempus.util.MusicUtil
 import com.eddyizm.tempus.util.Preferences.getImageSize
 import com.eddyizm.tempus.util.ReplayGainBundleUtil
+import com.eddyizm.tempus.util.FavoriteRegistry
 import java.util.Date
 
 @UnstableApi
@@ -263,7 +264,7 @@ class SessionMediaItem() {
                     .setAlbumTitle(album)
                     .setArtist(artist)
                     .setArtworkUri(artworkUri)
-                    .setUserRating(HeartRating(starred != null))
+                    .setUserRating(HeartRating(if (type == Constants.MEDIA_TYPE_MUSIC) FavoriteRegistry.resolve(FavoriteRegistry.Kind.SONG, id, starred != null) else starred != null))
                     .setSupportedCommands(
                         listOf(
                             Constants.CUSTOM_COMMAND_TOGGLE_HEART_ON,

--- a/app/src/main/java/com/eddyizm/tempus/repository/FavoriteRepository.java
+++ b/app/src/main/java/com/eddyizm/tempus/repository/FavoriteRepository.java
@@ -8,6 +8,8 @@ import com.eddyizm.tempus.database.dao.FavoriteDao;
 import com.eddyizm.tempus.interfaces.StarCallback;
 import com.eddyizm.tempus.model.Favorite;
 import com.eddyizm.tempus.subsonic.base.ApiResponse;
+import com.eddyizm.tempus.util.FavoriteRegistry;
+import com.eddyizm.tempus.subsonic.models.ResponseStatus;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,44 +21,84 @@ import retrofit2.Response;
 public class FavoriteRepository {
     private final FavoriteDao favoriteDao = AppDatabase.getInstance().favoriteDao();
 
+    // Exactly one of the three ids is set on any call, so the caller's intent is recorded against
+    // whichever one that is, under the kind that id belongs to.
+    private static FavoriteRegistry.Record remember(String id, String albumId, String artistId, boolean isStarred) {
+        FavoriteRegistry.Record song = FavoriteRegistry.set(FavoriteRegistry.Kind.SONG, id, isStarred);
+        FavoriteRegistry.Record album = FavoriteRegistry.set(FavoriteRegistry.Kind.ALBUM, albumId, isStarred);
+        FavoriteRegistry.Record artist = FavoriteRegistry.set(FavoriteRegistry.Kind.ARTIST, artistId, isStarred);
+        return song != null ? song : album != null ? album : artist;
+    }
+
+    // A non 2xx lands here too, since a proxy's 401 or 429 is answered by trying again later, not by
+    // dropping the decision.
+    private static void retryOrWithdraw(FavoriteRegistry.Record record, StarCallback starCallback) {
+        if (FavoriteRegistry.isCurrent(record)) starCallback.onError();
+        else FavoriteRegistry.withdraw(record);
+    }
+
+    // Subsonic reports a refusal as a 200 whose body says failed, so the status line alone cannot
+    // tell a stored star from a rejected one.
+    private static boolean serverRefused(Response<ApiResponse> response) {
+        return response.body() != null
+                && response.body().getSubsonicResponse() != null
+                && ResponseStatus.FAILED.equals(response.body().getSubsonicResponse().getStatus());
+    }
+
+    // Timestamps are the queue table's key, so two rows in one millisecond would silently drop the
+    // second.
+    private static long lastQueuedAt;
+
     public void star(String id, String albumId, String artistId, StarCallback starCallback) {
+        FavoriteRegistry.Record record = remember(id, albumId, artistId, true);
+
         App.getSubsonicClientInstance(false)
                 .getMediaAnnotationClient()
                 .star(id, albumId, artistId)
                 .enqueue(new Callback<ApiResponse>() {
                     @Override
                     public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
-                        if (response.isSuccessful()) {
+                        if (response.isSuccessful() && !serverRefused(response)) {
+                            FavoriteRegistry.accept(record);
                             starCallback.onSuccess();
+                        } else if (serverRefused(response)) {
+                            FavoriteRegistry.strike(record);
+                            starCallback.onRefused();
                         } else {
-                            starCallback.onError();
+                            retryOrWithdraw(record, starCallback);
                         }
                     }
 
                     @Override
                     public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
-                        starCallback.onError();
+                        retryOrWithdraw(record, starCallback);
                     }
                 });
     }
 
     public void unstar(String id, String albumId, String artistId, StarCallback starCallback) {
+        FavoriteRegistry.Record record = remember(id, albumId, artistId, false);
+
         App.getSubsonicClientInstance(false)
                 .getMediaAnnotationClient()
                 .unstar(id, albumId, artistId)
                 .enqueue(new Callback<ApiResponse>() {
                     @Override
                     public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
-                        if (response.isSuccessful()) {
+                        if (response.isSuccessful() && !serverRefused(response)) {
+                            FavoriteRegistry.accept(record);
                             starCallback.onSuccess();
+                        } else if (serverRefused(response)) {
+                            FavoriteRegistry.strike(record);
+                            starCallback.onRefused();
                         } else {
-                            starCallback.onError();
+                            retryOrWithdraw(record, starCallback);
                         }
                     }
 
                     @Override
                     public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
-                        starCallback.onError();
+                        retryOrWithdraw(record, starCallback);
                     }
                 });
     }
@@ -97,7 +139,13 @@ public class FavoriteRepository {
     }
 
     public void starLater(String id, String albumId, String artistId, boolean toStar) {
-        InsertThreadSafe insert = new InsertThreadSafe(favoriteDao, new Favorite(System.currentTimeMillis(), id, albumId, artistId, toStar));
+        FavoriteRegistry.supersede(FavoriteRegistry.Kind.SONG, id, toStar);
+        FavoriteRegistry.supersede(FavoriteRegistry.Kind.ALBUM, albumId, toStar);
+        FavoriteRegistry.supersede(FavoriteRegistry.Kind.ARTIST, artistId, toStar);
+        remember(id, albumId, artistId, toStar);
+        lastQueuedAt = Math.max(System.currentTimeMillis(), lastQueuedAt + 1);
+
+        InsertThreadSafe insert = new InsertThreadSafe(favoriteDao, new Favorite(lastQueuedAt, id, albumId, artistId, toStar));
         Thread thread = new Thread(insert);
         thread.start();
     }

--- a/app/src/main/java/com/eddyizm/tempus/service/BaseSessionCallback.kt
+++ b/app/src/main/java/com/eddyizm/tempus/service/BaseSessionCallback.kt
@@ -21,8 +21,10 @@ import androidx.media3.session.SessionResult
 import com.eddyizm.tempus.App
 import com.eddyizm.tempus.R
 import com.eddyizm.tempus.subsonic.base.ApiResponse
+import com.eddyizm.tempus.subsonic.models.ResponseStatus
 import com.eddyizm.tempus.util.Constants
 import com.eddyizm.tempus.util.Preferences
+import com.eddyizm.tempus.util.FavoriteRegistry
 import com.google.common.collect.ImmutableList
 import com.google.common.util.concurrent.Futures
 import com.google.common.util.concurrent.ListenableFuture
@@ -345,6 +347,11 @@ open class BaseSessionCallback(
         rating: Rating
     ): ListenableFuture<SessionResult> {
         val isStarring = (rating as HeartRating).isHeart
+        val record = (0 until session.player.mediaItemCount)
+            .map { session.player.getMediaItemAt(it) }
+            .firstOrNull { it.mediaId == mediaId }
+            ?.takeIf { it.mediaMetadata.extras?.getString("type") == Constants.MEDIA_TYPE_MUSIC }
+            ?.let { FavoriteRegistry.set(FavoriteRegistry.Kind.SONG, mediaId, isStarring) }
 
         val networkCall = if (isStarring)
             App.getSubsonicClientInstance(false)
@@ -360,7 +367,11 @@ open class BaseSessionCallback(
         networkCall.enqueue(object : Callback<ApiResponse?> {
             @OptIn(UnstableApi::class)
             override fun onResponse(call: Call<ApiResponse?>, response: Response<ApiResponse?>) {
-                if (response.isSuccessful) {
+                val refused = response.body()?.subsonicResponse?.status == ResponseStatus.FAILED
+
+                if (response.isSuccessful && !refused) {
+                    FavoriteRegistry.accept(record)
+
                     for (i in 0 until session.player.mediaItemCount) {
                         val mediaItem = session.player.getMediaItemAt(i)
                         if (mediaItem.mediaId == mediaId) {
@@ -375,13 +386,15 @@ open class BaseSessionCallback(
                     updateMediaNotificationCustomLayout(session)
                     future.set(SessionResult(SessionResult.RESULT_SUCCESS))
                 } else {
+                    if (refused) FavoriteRegistry.strike(record) else FavoriteRegistry.withdraw(record)
                     updateMediaNotificationCustomLayout(session)
-                    future.set(SessionResult(SessionError(response.code(), response.message())))
+                    future.set(SessionResult(if (refused) SessionError(SessionError.ERROR_UNKNOWN, "The server refused the change") else SessionError(response.code(), response.message())))
                 }
             }
 
             @OptIn(UnstableApi::class)
             override fun onFailure(call: Call<ApiResponse?>, t: Throwable) {
+                FavoriteRegistry.withdraw(record)
                 updateMediaNotificationCustomLayout(session)
                 future.set(SessionResult(SessionError(SessionError.ERROR_UNKNOWN, "An error has occurred")))
             }

--- a/app/src/main/java/com/eddyizm/tempus/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/activity/MainActivity.java
@@ -64,6 +64,7 @@ import com.eddyizm.tempus.util.AlbumArtistBackfill;
 import com.eddyizm.tempus.util.DownloadRepair;
 import com.eddyizm.tempus.util.Preferences;
 import com.eddyizm.tempus.viewmodel.MainViewModel;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.google.android.material.bottomsheet.BottomSheetBehavior;
 import com.google.android.material.navigation.NavigationView;
@@ -503,6 +504,8 @@ public class MainActivity extends BaseActivity {
     }
 
     private void resetUserSession() {
+        FavoriteRegistry.clear();
+
         Preferences.setServerId(null);
         Preferences.setSalt(null);
         Preferences.setToken(null);

--- a/app/src/main/java/com/eddyizm/tempus/ui/adapter/PlayerSongQueueAdapter.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/adapter/PlayerSongQueueAdapter.java
@@ -26,6 +26,7 @@ import com.eddyizm.tempus.util.Constants;
 import com.eddyizm.tempus.util.ExternalAudioReader;
 import com.eddyizm.tempus.util.MusicUtil;
 import com.eddyizm.tempus.util.Preferences;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.MoreExecutors;
 
@@ -116,11 +117,10 @@ public class PlayerSongQueueAdapter extends RecyclerView.Adapter<PlayerSongQueue
         }
 
         if (Preferences.showItemRating()) {
-            if (song.getStarred() == null && song.getUserRating() == null) {
-                holder.item.ratingIndicatorImageView.setVisibility(View.GONE);
-            }
+            boolean isStarred = FavoriteRegistry.resolve(FavoriteRegistry.Kind.SONG, song.getId(), song.getStarred() != null);
+            holder.item.ratingIndicatorImageView.setVisibility(isStarred || song.getUserRating() != null ? View.VISIBLE : View.GONE);
 
-            holder.item.preferredIcon.setVisibility(song.getStarred() != null ? View.VISIBLE : View.GONE);
+            holder.item.preferredIcon.setVisibility(isStarred ? View.VISIBLE : View.GONE);
             holder.item.ratingBarLayout.setVisibility(song.getUserRating() != null ? View.VISIBLE : View.GONE);
 
             if (song.getUserRating() != null) {

--- a/app/src/main/java/com/eddyizm/tempus/ui/adapter/SongHorizontalAdapter.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/adapter/SongHorizontalAdapter.java
@@ -31,6 +31,7 @@ import com.eddyizm.tempus.util.ExternalAudioReader;
 import com.eddyizm.tempus.util.MappingUtil;
 import com.eddyizm.tempus.util.MusicUtil;
 import com.eddyizm.tempus.util.Preferences;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.ArrayList;
@@ -207,11 +208,10 @@ public class SongHorizontalAdapter extends RecyclerView.Adapter<SongHorizontalAd
         }
 
         if (Preferences.showItemRating()) {
-            if (song.getStarred() == null && song.getUserRating() == null) {
-                holder.item.ratingIndicatorImageView.setVisibility(View.GONE);
-            }
+            boolean isStarred = FavoriteRegistry.resolve(FavoriteRegistry.Kind.SONG, song.getId(), song.getStarred() != null);
+            holder.item.ratingIndicatorImageView.setVisibility(isStarred || song.getUserRating() != null ? View.VISIBLE : View.GONE);
 
-            holder.item.preferredIcon.setVisibility(song.getStarred() != null ? View.VISIBLE : View.GONE);
+            holder.item.preferredIcon.setVisibility(isStarred ? View.VISIBLE : View.GONE);
             holder.item.ratingBarLayout.setVisibility(song.getUserRating() != null ? View.VISIBLE : View.GONE);
 
             if (song.getUserRating() != null) {

--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/AlbumPageFragment.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/AlbumPageFragment.java
@@ -47,6 +47,7 @@ import com.eddyizm.tempus.util.ExternalAudioWriter;
 import com.eddyizm.tempus.util.Preferences;
 import com.eddyizm.tempus.viewmodel.AlbumPageViewModel;
 import com.eddyizm.tempus.viewmodel.PlaybackViewModel;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.ArrayList;
@@ -182,14 +183,14 @@ public class AlbumPageFragment extends Fragment implements ClickCallback {
     private void init(View view, AlbumID3 albumArg) {
         albumPageViewModel.setAlbum(getViewLifecycleOwner(), albumArg);
         ToggleButton favoriteToggle = view.findViewById(R.id.button_favorite);
-        favoriteToggle.setChecked(albumArg.getStarred() != null);
+        favoriteToggle.setChecked(FavoriteRegistry.resolve(FavoriteRegistry.Kind.ALBUM, albumArg.getId(), albumArg.getStarred() != null));
 
         favoriteToggle.setOnClickListener(v -> {
             albumPageViewModel.setFavorite();
         });
         albumPageViewModel.getAlbum().observe(getViewLifecycleOwner(), album -> {
             if (album != null) {
-                favoriteToggle.setChecked(album.getStarred() != null);
+                favoriteToggle.setChecked(FavoriteRegistry.resolve(FavoriteRegistry.Kind.ALBUM, album.getId(), album.getStarred() != null));
             }
         });
     }

--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/ArtistPageFragment.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/ArtistPageFragment.java
@@ -48,6 +48,7 @@ import com.eddyizm.tempus.util.Preferences;
 import com.eddyizm.tempus.util.TileSizeManager;
 import com.eddyizm.tempus.viewmodel.ArtistPageViewModel;
 import com.eddyizm.tempus.viewmodel.PlaybackViewModel;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import java.util.ArrayList;
@@ -144,7 +145,7 @@ public class ArtistPageFragment extends Fragment implements ClickCallback {
         });
 
         ToggleButton favoriteToggle = view.findViewById(R.id.button_favorite);
-        favoriteToggle.setChecked(artistPageViewModel.getArtist().getStarred() != null);
+        favoriteToggle.setChecked(FavoriteRegistry.resolve(FavoriteRegistry.Kind.ARTIST, artistPageViewModel.getArtist().getId(), artistPageViewModel.getArtist().getStarred() != null));
         favoriteToggle.setOnClickListener(v -> artistPageViewModel.setFavorite(requireContext()));
 
         Button bioToggle = view.findViewById(R.id.button_toggle_bio);

--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/PlayerControllerFragment.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/PlayerControllerFragment.java
@@ -64,6 +64,7 @@ import com.eddyizm.tempus.util.MusicUtil;
 import com.eddyizm.tempus.util.Preferences;
 import com.eddyizm.tempus.viewmodel.PlayerBottomSheetViewModel;
 import com.eddyizm.tempus.viewmodel.RatingViewModel;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 import com.google.android.material.chip.Chip;
 import com.google.android.material.chip.ChipGroup;
 import com.google.android.material.elevation.SurfaceColors;
@@ -778,7 +779,7 @@ public class PlayerControllerFragment extends Fragment {
         playerBottomSheetViewModel.getLiveMedia().observe(getViewLifecycleOwner(), media -> {
             if (media != null) {
                 ratingViewModel.setSong(media);
-                buttonFavorite.setChecked(media.getStarred() != null);
+                buttonFavorite.setChecked(FavoriteRegistry.resolve(FavoriteRegistry.Kind.SONG, media.getId(), media.getStarred() != null));
                 buttonFavorite.setOnClickListener(v -> playerBottomSheetViewModel.setFavorite(requireContext(), media));
                 buttonFavorite.setOnLongClickListener(v -> {
                     Bundle bundle = new Bundle();

--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/bottomsheetdialog/AlbumBottomSheetDialog.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/bottomsheetdialog/AlbumBottomSheetDialog.java
@@ -41,6 +41,7 @@ import com.eddyizm.tempus.util.ExternalAudioWriter;
 import com.eddyizm.tempus.util.ExternalAudioReader;
 import com.eddyizm.tempus.viewmodel.AlbumBottomSheetViewModel;
 import com.eddyizm.tempus.viewmodel.HomeViewModel;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -114,7 +115,7 @@ public class AlbumBottomSheetDialog extends BottomSheetDialogFragment implements
         artistAlbum.setText(albumBottomSheetViewModel.getAlbum().getArtist());
 
         ToggleButton favoriteToggle = view.findViewById(R.id.button_favorite);
-        favoriteToggle.setChecked(albumBottomSheetViewModel.getAlbum().getStarred() != null);
+        favoriteToggle.setChecked(FavoriteRegistry.resolve(FavoriteRegistry.Kind.ALBUM, albumBottomSheetViewModel.getAlbum().getId(), albumBottomSheetViewModel.getAlbum().getStarred() != null));
         favoriteToggle.setOnClickListener(v -> albumBottomSheetViewModel.setFavorite(requireContext()));
 
         TextView playRadio = view.findViewById(R.id.play_radio_text_view);

--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/bottomsheetdialog/ArtistBottomSheetDialog.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/bottomsheetdialog/ArtistBottomSheetDialog.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import com.eddyizm.tempus.util.Constants;
 import com.eddyizm.tempus.util.MusicUtil;
 import com.eddyizm.tempus.viewmodel.ArtistBottomSheetViewModel;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 import com.google.android.material.bottomsheet.BottomSheetDialogFragment;
 import com.google.common.util.concurrent.ListenableFuture;
 
@@ -89,7 +90,7 @@ public class ArtistBottomSheetDialog extends BottomSheetDialogFragment implement
         nameArtist.setSelected(true);
 
         ToggleButton favoriteToggle = view.findViewById(R.id.button_favorite);
-        favoriteToggle.setChecked(artistBottomSheetViewModel.getArtist().getStarred() != null);
+        favoriteToggle.setChecked(FavoriteRegistry.resolve(FavoriteRegistry.Kind.ARTIST, artistBottomSheetViewModel.getArtist().getId(), artistBottomSheetViewModel.getArtist().getStarred() != null));
         favoriteToggle.setOnClickListener(v -> {
             artistBottomSheetViewModel.setFavorite(requireContext());
         });

--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/bottomsheetdialog/SongBottomSheetDialog.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/bottomsheetdialog/SongBottomSheetDialog.java
@@ -49,6 +49,7 @@ import com.google.android.material.snackbar.Snackbar;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import com.eddyizm.tempus.util.ExternalAudioWriter;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -129,7 +130,7 @@ public class SongBottomSheetDialog extends BottomSheetDialogFragment implements 
         bindAssetLinkView(artistSong, currentArtistLink != null ? currentArtistLink : currentSongLink);
 
         ToggleButton favoriteToggle = view.findViewById(R.id.button_favorite);
-        favoriteToggle.setChecked(songBottomSheetViewModel.getSong().getStarred() != null);
+        favoriteToggle.setChecked(FavoriteRegistry.resolve(FavoriteRegistry.Kind.SONG, songBottomSheetViewModel.getSong().getId(), songBottomSheetViewModel.getSong().getStarred() != null));
         favoriteToggle.setOnClickListener(v -> {
             songBottomSheetViewModel.setFavorite(requireContext());
         });

--- a/app/src/main/java/com/eddyizm/tempus/util/FavoriteRegistry.java
+++ b/app/src/main/java/com/eddyizm/tempus/util/FavoriteRegistry.java
@@ -1,0 +1,89 @@
+package com.eddyizm.tempus.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public final class FavoriteRegistry {
+    public enum Kind {SONG, ALBUM, ARTIST}
+
+    // One request's decision and the one before it. A refusal strikes its own record and, skipping
+    // records already struck, the unaccepted records beneath it that carry the same decision, since
+    // those are earlier attempts at the same decision. Any other failed request is withdrawn alone
+    // unless the retry queue takes over its decision, and a decision handed to that queue strikes the
+    // pending records above the newest accepted one that say the opposite. Resolve reads past struck
+    // records. A record the server accepted is never struck, and accepting one lifts a strike it
+    // took while its request was still open.
+    public static final class Record {
+        private final String key;
+        private final boolean starred;
+        private final Record previous;
+        private boolean accepted;
+        private boolean struck;
+
+        private Record(String key, boolean starred, Record previous) {
+            this.key = key;
+            this.starred = starred;
+            this.previous = previous;
+        }
+    }
+
+    private static final Map<String, Record> records = new HashMap<>();
+
+    private FavoriteRegistry() {
+    }
+
+    public static synchronized Record set(Kind kind, String id, boolean isStarred) {
+        if (id == null) return null;
+        String key = key(kind, id);
+        Record record = new Record(key, isStarred, records.get(key));
+        records.put(key, record);
+        return record;
+    }
+
+    public static synchronized boolean resolve(Kind kind, String id, boolean serverSaysStarred) {
+        Record live = id != null ? surviving(records.get(key(kind, id))) : null;
+        return live != null ? live.starred : serverSaysStarred;
+    }
+
+    public static synchronized boolean isCurrent(Record record) {
+        return record != null && surviving(records.get(record.key)) == record;
+    }
+
+    public static synchronized void accept(Record record) {
+        if (record == null) return;
+        record.accepted = true;
+        record.struck = false;
+    }
+
+    public static synchronized void strike(Record record) {
+        for (Record r = record; r != null; r = r.previous) {
+            if (r.struck) continue;
+            if (r.accepted || r.starred != record.starred) break;
+            r.struck = true;
+        }
+    }
+
+    public static synchronized void withdraw(Record record) {
+        if (record != null && !record.accepted) record.struck = true;
+    }
+
+    public static synchronized void supersede(Kind kind, String id, boolean isStarred) {
+        if (id == null) return;
+        for (Record r = records.get(key(kind, id)); r != null && !r.accepted; r = r.previous) {
+            if (r.starred != isStarred) r.struck = true;
+        }
+    }
+
+    public static synchronized void clear() {
+        records.clear();
+    }
+
+    private static Record surviving(Record record) {
+        while (record != null && record.struck) record = record.previous;
+        return record;
+    }
+
+    private static String key(Kind kind, String id) {
+        return kind.name() + ":" + id;
+    }
+}

--- a/app/src/main/java/com/eddyizm/tempus/util/MappingUtil.java
+++ b/app/src/main/java/com/eddyizm/tempus/util/MappingUtil.java
@@ -23,6 +23,7 @@ import com.eddyizm.tempus.repository.DownloadRepository;
 import com.eddyizm.tempus.subsonic.models.Child;
 import com.eddyizm.tempus.subsonic.models.InternetRadioStation;
 import com.eddyizm.tempus.subsonic.models.PodcastEpisode;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 import com.google.common.collect.ImmutableList;
 
 import java.io.File;
@@ -146,7 +147,7 @@ public class MappingUtil {
                                     .setAlbumTitle(media.getAlbum())
                                     .setArtist(media.getArtist())
                                     .setArtworkUri(artworkUri)
-                                    .setUserRating(new HeartRating(media.getStarred() != null && media.getStarred().getTime() > 0))
+                                    .setUserRating(new HeartRating(FavoriteRegistry.resolve(FavoriteRegistry.Kind.SONG, media.getId(), media.getStarred() != null && media.getStarred().getTime() > 0)))
                                     .setSupportedCommands(
                                         ImmutableList.of(
                                                 Constants.CUSTOM_COMMAND_TOGGLE_HEART_ON,

--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/AlbumBottomSheetViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/AlbumBottomSheetViewModel.java
@@ -26,6 +26,7 @@ import com.eddyizm.tempus.util.DownloadUtil;
 import com.eddyizm.tempus.util.MappingUtil;
 import com.eddyizm.tempus.util.NetworkUtil;
 import com.eddyizm.tempus.util.Preferences;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 
 import java.util.Collections;
 import java.util.Date;
@@ -66,7 +67,7 @@ public class AlbumBottomSheetViewModel extends AndroidViewModel {
     }
 
     public void setFavorite(Context context) {
-        if (album.getStarred() != null) {
+        if (FavoriteRegistry.resolve(FavoriteRegistry.Kind.ALBUM, album.getId(), album.getStarred() != null)) {
             if (NetworkUtil.isOffline()) {
                 removeFavoriteOffline();
             } else {

--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/AlbumPageViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/AlbumPageViewModel.java
@@ -17,6 +17,7 @@ import com.eddyizm.tempus.subsonic.models.AlbumInfo;
 import com.eddyizm.tempus.subsonic.models.ArtistID3;
 import com.eddyizm.tempus.subsonic.models.Child;
 import com.eddyizm.tempus.util.NetworkUtil;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 
 import java.util.Date;
 import java.util.List;
@@ -59,7 +60,7 @@ public class AlbumPageViewModel extends AndroidViewModel {
         AlbumID3 currentAlbum = album.getValue();
         if (currentAlbum == null) return;
         
-        if (currentAlbum.getStarred() != null) {
+        if (FavoriteRegistry.resolve(FavoriteRegistry.Kind.ALBUM, currentAlbum.getId(), currentAlbum.getStarred() != null)) {
             if (NetworkUtil.isOffline()) {
                 removeFavoriteOffline(currentAlbum);
             } else {

--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/ArtistBottomSheetViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/ArtistBottomSheetViewModel.java
@@ -21,6 +21,7 @@ import com.eddyizm.tempus.util.NetworkUtil;
 import com.eddyizm.tempus.util.DownloadUtil;
 import com.eddyizm.tempus.util.MappingUtil;
 import com.eddyizm.tempus.util.Preferences;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 
 import java.util.Collections;
 import java.util.Date;
@@ -63,7 +64,7 @@ public class ArtistBottomSheetViewModel extends AndroidViewModel {
     }
 
     public void setFavorite(Context context) {
-        if (artist.getStarred() != null) {
+        if (FavoriteRegistry.resolve(FavoriteRegistry.Kind.ARTIST, artist.getId(), artist.getStarred() != null)) {
             if (NetworkUtil.isOffline()) {
                 removeFavoriteOffline();
             } else {

--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/ArtistPageViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/ArtistPageViewModel.java
@@ -26,6 +26,7 @@ import com.eddyizm.tempus.util.DownloadUtil;
 import com.eddyizm.tempus.util.MappingUtil;
 import com.eddyizm.tempus.util.NetworkUtil;
 import com.eddyizm.tempus.util.Preferences;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 
 import java.util.Collections;
 import java.util.Comparator;
@@ -144,7 +145,7 @@ public class ArtistPageViewModel extends AndroidViewModel {
     }
 
     public void setFavorite(Context context) {
-        if (artist.getStarred() != null) {
+        if (FavoriteRegistry.resolve(FavoriteRegistry.Kind.ARTIST, artist.getId(), artist.getStarred() != null)) {
             if (NetworkUtil.isOffline()) {
                 removeFavoriteOffline();
             } else {

--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/HomeViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/HomeViewModel.java
@@ -513,53 +513,37 @@ public class HomeViewModel extends AndroidViewModel {
         }
     }
 
+    private StarCallback dropWhenAnswered(Favorite favorite) {
+        return new StarCallback() {
+            @Override
+            public void onSuccess() {
+                favoriteRepository.delete(favorite);
+            }
+
+            @Override
+            public void onRefused() {
+                favoriteRepository.delete(favorite);
+            }
+        };
+    }
+
     private void favoriteToStar(Favorite favorite) {
         if (favorite.getSongId() != null) {
-            favoriteRepository.star(favorite.getSongId(), null, null, new StarCallback() {
-                @Override
-                public void onSuccess() {
-                    favoriteRepository.delete(favorite);
-                }
-            });
+            favoriteRepository.star(favorite.getSongId(), null, null, dropWhenAnswered(favorite));
         } else if (favorite.getAlbumId() != null) {
-            favoriteRepository.star(null, favorite.getAlbumId(), null, new StarCallback() {
-                @Override
-                public void onSuccess() {
-                    favoriteRepository.delete(favorite);
-                }
-            });
+            favoriteRepository.star(null, favorite.getAlbumId(), null, dropWhenAnswered(favorite));
         } else if (favorite.getArtistId() != null) {
-            favoriteRepository.star(null, null, favorite.getArtistId(), new StarCallback() {
-                @Override
-                public void onSuccess() {
-                    favoriteRepository.delete(favorite);
-                }
-            });
+            favoriteRepository.star(null, null, favorite.getArtistId(), dropWhenAnswered(favorite));
         }
     }
 
     private void favoriteToUnstar(Favorite favorite) {
         if (favorite.getSongId() != null) {
-            favoriteRepository.unstar(favorite.getSongId(), null, null, new StarCallback() {
-                @Override
-                public void onSuccess() {
-                    favoriteRepository.delete(favorite);
-                }
-            });
+            favoriteRepository.unstar(favorite.getSongId(), null, null, dropWhenAnswered(favorite));
         } else if (favorite.getAlbumId() != null) {
-            favoriteRepository.unstar(null, favorite.getAlbumId(), null, new StarCallback() {
-                @Override
-                public void onSuccess() {
-                    favoriteRepository.delete(favorite);
-                }
-            });
+            favoriteRepository.unstar(null, favorite.getAlbumId(), null, dropWhenAnswered(favorite));
         } else if (favorite.getArtistId() != null) {
-            favoriteRepository.unstar(null, null, favorite.getArtistId(), new StarCallback() {
-                @Override
-                public void onSuccess() {
-                    favoriteRepository.delete(favorite);
-                }
-            });
+            favoriteRepository.unstar(null, null, favorite.getArtistId(), dropWhenAnswered(favorite));
         }
     }
 }

--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/PlayerBottomSheetViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/PlayerBottomSheetViewModel.java
@@ -36,6 +36,7 @@ import com.eddyizm.tempus.util.MappingUtil;
 import com.eddyizm.tempus.util.NetworkUtil;
 import com.eddyizm.tempus.util.OpenSubsonicExtensionsUtil;
 import com.eddyizm.tempus.util.Preferences;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 import com.google.gson.Gson;
 
 import java.util.Collections;
@@ -87,7 +88,7 @@ public class PlayerBottomSheetViewModel extends AndroidViewModel {
 
     public void setFavorite(Context context, Child media) {
         if (media != null) {
-            if (media.getStarred() != null) {
+            if (FavoriteRegistry.resolve(FavoriteRegistry.Kind.SONG, media.getId(), media.getStarred() != null)) {
                 if (NetworkUtil.isOffline()) {
                     removeFavoriteOffline(media);
                 } else {
@@ -112,7 +113,6 @@ public class PlayerBottomSheetViewModel extends AndroidViewModel {
         favoriteRepository.unstar(media.getId(), null, null, new StarCallback() {
             @Override
             public void onError() {
-                // media.setStarred(new Date());
                 favoriteRepository.starLater(media.getId(), null, null, false);
             }
         });
@@ -128,7 +128,6 @@ public class PlayerBottomSheetViewModel extends AndroidViewModel {
         favoriteRepository.star(media.getId(), null, null, new StarCallback() {
             @Override
             public void onError() {
-                // media.setStarred(null);
                 favoriteRepository.starLater(media.getId(), null, null, true);
             }
         });

--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/SongBottomSheetViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/SongBottomSheetViewModel.java
@@ -27,6 +27,7 @@ import com.eddyizm.tempus.util.DownloadUtil;
 import com.eddyizm.tempus.util.MappingUtil;
 import com.eddyizm.tempus.util.NetworkUtil;
 import com.eddyizm.tempus.util.Preferences;
+import com.eddyizm.tempus.util.FavoriteRegistry;
 
 import java.util.Collections;
 import java.util.Date;
@@ -63,7 +64,7 @@ public class SongBottomSheetViewModel extends AndroidViewModel {
     }
 
     public void setFavorite(Context context) {
-        if (song.getStarred() != null) {
+        if (FavoriteRegistry.resolve(FavoriteRegistry.Kind.SONG, song.getId(), song.getStarred() != null)) {
             if (NetworkUtil.isOffline()) {
                 removeFavoriteOffline(song);
             } else {
@@ -87,7 +88,6 @@ public class SongBottomSheetViewModel extends AndroidViewModel {
         favoriteRepository.unstar(media.getId(), null, null, new StarCallback() {
             @Override
             public void onError() {
-                // media.setStarred(new Date());
                 favoriteRepository.starLater(media.getId(), null, null, false);
             }
         });
@@ -104,7 +104,6 @@ public class SongBottomSheetViewModel extends AndroidViewModel {
         favoriteRepository.star(media.getId(), null, null, new StarCallback() {
             @Override
             public void onError() {
-                // media.setStarred(null);
                 favoriteRepository.starLater(media.getId(), null, null, true);
             }
         });

--- a/app/src/test/java/com/eddyizm/tempus/util/FavoriteRegistryTest.java
+++ b/app/src/test/java/com/eddyizm/tempus/util/FavoriteRegistryTest.java
@@ -1,0 +1,294 @@
+package com.eddyizm.tempus.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import com.eddyizm.tempus.util.FavoriteRegistry.Kind;
+
+import org.junit.Before;
+import org.junit.Test;
+
+public class FavoriteRegistryTest {
+
+    @Before
+    public void reset() {
+        FavoriteRegistry.clear();
+    }
+
+    @Test
+    public void untouchedItemFollowsTheServer() {
+        assertTrue(FavoriteRegistry.resolve(Kind.ALBUM, "1", true));
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void starringWinsOverAServerThatDoesNotSayStarred() {
+        FavoriteRegistry.set(Kind.ALBUM, "1", true);
+
+        assertTrue(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void unstarringWinsOverAServerStillSayingStarred() {
+        FavoriteRegistry.set(Kind.ALBUM, "1", false);
+
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "1", true));
+    }
+
+    @Test
+    public void onlyTheItemThatWasTouchedIsAffected() {
+        FavoriteRegistry.set(Kind.ALBUM, "1", true);
+
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "2", false));
+    }
+
+    @Test
+    public void theSameIdUnderADifferentKindIsADifferentItem() {
+        FavoriteRegistry.set(Kind.SONG, "1234", true);
+
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "1234", false));
+        assertFalse(FavoriteRegistry.resolve(Kind.ARTIST, "1234", false));
+        assertTrue(FavoriteRegistry.resolve(Kind.SONG, "1234", false));
+    }
+
+    @Test
+    public void aNullIdFallsBackToTheServer() {
+        FavoriteRegistry.set(Kind.SONG, null, true);
+
+        assertFalse(FavoriteRegistry.resolve(Kind.SONG, null, false));
+        assertTrue(FavoriteRegistry.resolve(Kind.SONG, null, true));
+    }
+
+    @Test
+    public void aRefusedChangeLeavesTheEarlierDecisionStanding() {
+        FavoriteRegistry.set(Kind.ALBUM, "1", false);
+        FavoriteRegistry.Record record = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.strike(record);
+
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "1", true));
+    }
+
+    @Test
+    public void aRefusedFirstChangeFallsBackToTheServer() {
+        FavoriteRegistry.Record record = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.strike(record);
+
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+        assertTrue(FavoriteRegistry.resolve(Kind.ALBUM, "1", true));
+    }
+
+    @Test
+    public void aLateRefusalLeavesALaterDecisionAlone() {
+        FavoriteRegistry.Record record = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.set(Kind.ALBUM, "1", false);
+        FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.strike(record);
+
+        assertTrue(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void twoRefusalsFallBackToTheServerInEitherOrder() {
+        FavoriteRegistry.Record first = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.Record second = FavoriteRegistry.set(Kind.ALBUM, "1", false);
+        FavoriteRegistry.strike(first);
+        FavoriteRegistry.strike(second);
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+
+        FavoriteRegistry.clear();
+        first = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        second = FavoriteRegistry.set(Kind.ALBUM, "1", false);
+        FavoriteRegistry.strike(second);
+        FavoriteRegistry.strike(first);
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void aRefusedRetryVoidsTheQueuedDecisionToo() {
+        FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.Record retry = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.strike(retry);
+
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void aRefusedRetryStopsAtAnAcceptedDecisionBeneathIt() {
+        FavoriteRegistry.accept(FavoriteRegistry.set(Kind.ALBUM, "1", true));
+        FavoriteRegistry.Record retry = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.strike(retry);
+
+        assertTrue(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void aRefusedRetryStopsAtTheOtherDecisionBeneathIt() {
+        FavoriteRegistry.set(Kind.ALBUM, "1", false);
+        FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.Record retry = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.strike(retry);
+
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "1", true));
+    }
+
+    @Test
+    public void aRefusalDoesNotReachAnAcceptedDecisionAboveIt() {
+        FavoriteRegistry.Record first = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.accept(FavoriteRegistry.set(Kind.ALBUM, "1", true));
+        FavoriteRegistry.strike(first);
+
+        assertTrue(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void anAcceptedDecisionCannotBeStruck() {
+        FavoriteRegistry.Record record = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.accept(record);
+        FavoriteRegistry.strike(record);
+
+        assertTrue(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void aLateAcceptanceRevivesAStruckRecord() {
+        FavoriteRegistry.Record record = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.strike(record);
+        FavoriteRegistry.accept(record);
+
+        assertTrue(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void aRecordBuriedByACascadeRevivesWhenItsOwnRequestIsAccepted() {
+        FavoriteRegistry.Record first = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.Record second = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.strike(second);
+        FavoriteRegistry.accept(first);
+
+        assertTrue(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void aRefusalSkipsAStruckRecordOfTheOtherDecision() {
+        FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.Record unstar = FavoriteRegistry.set(Kind.ALBUM, "1", false);
+        FavoriteRegistry.strike(unstar);
+        FavoriteRegistry.Record star = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.strike(star);
+
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void aRecordIsCurrentUntilANewerDecisionReplacesIt() {
+        FavoriteRegistry.Record star = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        assertTrue(FavoriteRegistry.isCurrent(star));
+
+        FavoriteRegistry.set(Kind.ALBUM, "1", false);
+        assertFalse(FavoriteRegistry.isCurrent(star));
+    }
+
+    @Test
+    public void aRecordIsStillCurrentBeneathAStruckNewerOne() {
+        FavoriteRegistry.Record star = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.strike(FavoriteRegistry.set(Kind.ALBUM, "1", false));
+
+        assertTrue(FavoriteRegistry.isCurrent(star));
+    }
+
+    @Test
+    public void nothingIsCurrentAfterClearing() {
+        FavoriteRegistry.Record star = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.clear();
+
+        assertFalse(FavoriteRegistry.isCurrent(star));
+    }
+
+    @Test
+    public void aWithdrawnRecordIsNotCurrent() {
+        FavoriteRegistry.Record star = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.withdraw(star);
+
+        assertFalse(FavoriteRegistry.isCurrent(star));
+    }
+
+    @Test
+    public void aRefusalPassesThroughAStruckRecordOfTheSameDecision() {
+        FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.withdraw(FavoriteRegistry.set(Kind.ALBUM, "1", true));
+        FavoriteRegistry.strike(FavoriteRegistry.set(Kind.ALBUM, "1", true));
+
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void aQueuedDecisionReplacesAPendingOppositeOne() {
+        FavoriteRegistry.set(Kind.ALBUM, "1", false);
+        FavoriteRegistry.supersede(Kind.ALBUM, "1", true);
+
+        assertTrue(FavoriteRegistry.resolve(Kind.ALBUM, "1", true));
+    }
+
+    @Test
+    public void aQueuedDecisionLeavesAnAcceptedOppositeOneAlone() {
+        FavoriteRegistry.accept(FavoriteRegistry.set(Kind.ALBUM, "1", false));
+        FavoriteRegistry.supersede(Kind.ALBUM, "1", true);
+
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "1", true));
+    }
+
+    @Test
+    public void aSupersededDecisionRevivesWhenTheServerAcceptsIt() {
+        FavoriteRegistry.Record unstar = FavoriteRegistry.set(Kind.ALBUM, "1", false);
+        FavoriteRegistry.supersede(Kind.ALBUM, "1", true);
+        FavoriteRegistry.accept(unstar);
+
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "1", true));
+    }
+
+    @Test
+    public void anAcceptedDecisionCannotBeWithdrawn() {
+        FavoriteRegistry.Record star = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.accept(star);
+        FavoriteRegistry.withdraw(star);
+
+        assertTrue(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void withdrawingTouchesOnlyItsOwnRecord() {
+        FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.Record retry = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.withdraw(retry);
+
+        assertTrue(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void aMissingRecordIsIgnored() {
+        FavoriteRegistry.withdraw(null);
+        assertFalse(FavoriteRegistry.isCurrent(null));
+        FavoriteRegistry.strike(null);
+        FavoriteRegistry.accept(null);
+
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void aStrikeAfterClearingLeavesTheNewSessionAlone() {
+        FavoriteRegistry.Record stale = FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.clear();
+        FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.strike(stale);
+
+        assertTrue(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+
+    @Test
+    public void clearingForgetsEverything() {
+        FavoriteRegistry.set(Kind.ALBUM, "1", true);
+        FavoriteRegistry.clear();
+
+        assertFalse(FavoriteRegistry.resolve(Kind.ALBUM, "1", false));
+    }
+}


### PR DESCRIPTION
### What is broken

On Home, open the three dot sheet on an album and tap the heart. It fills. Open that album and the heart there is filled too. Go back, open the same sheet again, and the heart is empty. The star did land and the server reports the album as starred, so only the app disagrees with itself. The artist sheet does the same.

Nothing in the app holds one answer for what is starred, every screen reads the flag off whatever copy it is holding, and no two hold the same one. A sheet reads its copy once and never asks again, so starring updates that copy and nothing else, and the next sheet is built from the stale list behind it.

The app now remembers what you starred and unstarred and draws every heart from that, on the album page, the artist page, all three long press sheets, the player, the song rows and the queue badges. When the server refuses a star, the notification heart no longer fills.

### Tested

The three taps above, before and after, on an emulator against a real server and against a proxy that refuses every star, every star and unstar checked in its log. Ten surfaces checked.
