### PR TITLE
feat(android-auto): group multi-disc album tracks

### DIFF
--- a/app/src/tempus/java/com/eddyizm/tempus/repository/AutomotiveRepository.java
+++ b/app/src/tempus/java/com/eddyizm/tempus/repository/AutomotiveRepository.java
@@ -1,5 +1,6 @@
 package com.eddyizm.tempus.repository;
 
+import android.content.Context;
 import android.net.Uri;
 import android.os.Bundle;
 
@@ -27,10 +28,12 @@ import com.eddyizm.tempus.model.SessionMediaItem;
 import com.eddyizm.tempus.provider.AlbumArtContentProvider;
 import com.eddyizm.tempus.subsonic.base.ApiResponse;
 import com.eddyizm.tempus.subsonic.models.AlbumID3;
+import com.eddyizm.tempus.subsonic.models.AlbumWithSongsID3;
 import com.eddyizm.tempus.subsonic.models.Artist;
 import com.eddyizm.tempus.subsonic.models.ArtistID3;
 import com.eddyizm.tempus.subsonic.models.Child;
 import com.eddyizm.tempus.subsonic.models.Directory;
+import com.eddyizm.tempus.subsonic.models.DiscTitle;
 import com.eddyizm.tempus.subsonic.models.Index;
 import com.eddyizm.tempus.subsonic.models.IndexID3;
 import com.eddyizm.tempus.subsonic.models.InternetRadioStation;
@@ -49,7 +52,10 @@ import com.google.common.util.concurrent.SettableFuture;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.stream.Collectors;
 
@@ -891,11 +897,14 @@ public class AutomotiveRepository {
                     @Override
                     public void onResponse(@NonNull Call<ApiResponse> call, @NonNull Response<ApiResponse> response) {
                         if (response.isSuccessful() && response.body() != null && response.body().getSubsonicResponse().getAlbum() != null && response.body().getSubsonicResponse().getAlbum().getSongs() != null) {
-                            List<Child> tracks = response.body().getSubsonicResponse().getAlbum().getSongs();
+                            AlbumWithSongsID3 album = response.body().getSubsonicResponse().getAlbum();
+                            List<Child> tracks = album.getSongs();
 
                             setChildrenMetadata(tracks);
 
                             List<MediaItem> mediaItems = MappingUtil.mapMediaItems(tracks, ConstantsAA.QUEUE_CACHED_SOURCE);
+
+                            setMultiDiscTitleGrouping(App.getContext(), album.getDiscTitles(), mediaItems);
 
                             LibraryResult<ImmutableList<MediaItem>> libraryResult = LibraryResult.ofItemList(ImmutableList.copyOf(mediaItems), null);
 
@@ -912,6 +921,64 @@ public class AutomotiveRepository {
                 });
 
         return listenableFuture;
+    }
+
+    static void setMultiDiscTitleGrouping(Context context, List<DiscTitle> discTitles, List<MediaItem> mediaItems) {
+        Map<Integer, String> discTitleMap = getMultiDiscTitles(context, discTitles, mediaItems);
+
+        if (discTitleMap.isEmpty()) {
+            return;
+        }
+
+        for (int i = 0; i < mediaItems.size(); i++) {
+            var mediaItem = mediaItems.get(i);
+            var disc = mediaItem.mediaMetadata.discNumber;
+
+            if (disc == null) {
+                continue;
+            }
+
+            Bundle extras = mediaItem.mediaMetadata.extras == null ? new Bundle() : new Bundle(mediaItem.mediaMetadata.extras);
+
+            extras.putString(MediaConstants.EXTRAS_KEY_CONTENT_STYLE_GROUP_TITLE, discTitleMap.get(disc));
+
+            var metadata = mediaItem.mediaMetadata.buildUpon().setExtras(extras).build();
+
+            mediaItems.set(i, mediaItem.buildUpon().setMediaMetadata(metadata).build());
+        }
+    }
+
+    static Map<Integer, String> getMultiDiscTitles(Context context, List<DiscTitle> discTitles, List<MediaItem> mediaItems) {
+        var discs = mediaItems.stream()
+                .map(it -> it.mediaMetadata.discNumber)
+                .filter(Objects::nonNull)
+                .distinct()
+                .collect(Collectors.toList());
+
+        if (discs.size() < 2) {
+            return Collections.emptyMap();
+        }
+
+        Map<Integer, String> discTitleMap = new HashMap<>();
+
+        if (discTitles != null && !discTitles.isEmpty()) {
+            discTitles.forEach(it -> {
+                var disc = it.getDisc();
+                var title = it.getTitle();
+
+                if (disc == null || title == null || title.isBlank()) {
+                    return;
+                }
+
+                var discTitle = context.getString(R.string.disc_titlefull, disc.toString(), title);
+
+                discTitleMap.put(disc, discTitle);
+            });
+        }
+
+        discs.forEach(disc -> discTitleMap.computeIfAbsent(disc, it -> context.getString(R.string.disc_titleless, it.toString())));
+
+        return discTitleMap;
     }
 
     public ListenableFuture<LibraryResult<ImmutableList<MediaItem>>> getArtistAlbum(String prefix, String id) {

--- a/app/src/testTempus/java/com/eddyizm/tempus/repository/AutomotiveRepositoryTest.java
+++ b/app/src/testTempus/java/com/eddyizm/tempus/repository/AutomotiveRepositoryTest.java
@@ -1,8 +1,26 @@
 package com.eddyizm.tempus.repository;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import android.content.Context;
+import android.media.browse.MediaBrowser;
+
+import androidx.media3.common.C;
+import androidx.media3.common.MediaItem;
+import androidx.media3.common.MediaMetadata;
+import androidx.media3.session.MediaConstants;
+
+import com.eddyizm.tempus.R;
+import com.eddyizm.tempus.subsonic.models.AlbumWithSongsID3;
+import com.eddyizm.tempus.subsonic.models.Child;
+import com.eddyizm.tempus.subsonic.models.DiscTitle;
 import com.eddyizm.tempus.subsonic.models.InternetRadioStation;
+import com.eddyizm.tempus.util.ConstantsAA;
+import com.eddyizm.tempus.util.MappingUtil;
 
 import org.junit.Test;
 
@@ -19,6 +37,16 @@ public class AutomotiveRepositoryTest {
 
     private static List<String> names(List<InternetRadioStation> stations) {
         return stations.stream().map(InternetRadioStation::getName).collect(Collectors.toList());
+    }
+
+    private static MediaItem mediaItemWithDisc(int disc) {
+        return new MediaItem.Builder()
+                .setMediaId("track-" + disc)
+                .setMediaMetadata(
+                        new MediaMetadata.Builder()
+                                .setDiscNumber(disc)
+                                .build())
+                .build();
     }
 
     @Test
@@ -47,5 +75,63 @@ public class AutomotiveRepositoryTest {
                 Arrays.asList(station(null), station("a")));
 
         assertEquals(Arrays.asList(null, "a", "b"), names(result));
+    }
+
+    @Test
+    public void multiDiscAlbumGroupsTracksByDiscNumber() {
+        List<MediaItem> mediaItems = Arrays.asList(
+                mediaItemWithDisc(1),
+                mediaItemWithDisc(2)
+        );
+
+        Context context = mock(Context.class);
+
+        when(context.getString(R.string.disc_titleless, "1")).thenReturn("Disc 1");
+        when(context.getString(R.string.disc_titleless, "2")).thenReturn("Disc 2");
+
+        var result = AutomotiveRepository.getMultiDiscTitles(context, new ArrayList<>(), mediaItems);
+
+        assertEquals("Disc 1", result.get(1));
+        assertEquals("Disc 2", result.get(2));
+    }
+
+    @Test
+    public void singleDiscAlbumDoesNotGroupTracks() {
+        List<MediaItem> mediaItems = Arrays.asList(
+                mediaItemWithDisc(1),
+                mediaItemWithDisc(1)
+        );
+
+        var result = AutomotiveRepository.getMultiDiscTitles(
+                mock(Context.class),
+                new ArrayList<>(),
+                mediaItems);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    public void multiDiscAlbumUsesDiscTitles() {
+        List<MediaItem> mediaItems = Arrays.asList(
+                mediaItemWithDisc(1),
+                mediaItemWithDisc(2)
+        );
+
+        List<DiscTitle> discTitles = Arrays.asList(
+                new DiscTitle(1, "Dawn to Dusk"),
+                new DiscTitle(2, "Twilight to Starlight")
+        );
+
+        Context context = mock(Context.class);
+
+        when(context.getString(R.string.disc_titlefull, "1", "Dawn to Dusk"))
+                .thenReturn("Disc 1 - Dawn to Dusk");
+        when(context.getString(R.string.disc_titlefull, "2", "Twilight to Starlight"))
+                .thenReturn("Disc 2 - Twilight to Starlight");
+
+        var result = AutomotiveRepository.getMultiDiscTitles(context, discTitles, mediaItems);
+
+        assertEquals("Disc 1 - Dawn to Dusk", result.get(1));
+        assertEquals("Disc 2 - Twilight to Starlight", result.get(2));
     }
 }


### PR DESCRIPTION
Improves multi-disc album browsing in Android Auto by grouping tracks under disc headers.

Disc titles are shown when available, with a fallback to Disc X when no title is provided. Single-disc albums are unchanged.

Includes tests for single-disc, titled multi-disc, and untitled multi-disc albums.

Multidisc - first named disc
<img width="793" height="400" alt="Screenshot_20260912_235619" src="https://github.com/user-attachments/assets/c09253c3-3417-4f4e-9a9a-5d794f13eda5" />

Multidisc - second named disc
<img width="793" height="400" alt="Screenshot_20260912_235549" src="https://github.com/user-attachments/assets/462dcb8e-456e-439b-ba4e-adf35ba21680" />

Multidisc - first unnamed disc
<img width="793" height="401" alt="Screenshot_20260912_235707" src="https://github.com/user-attachments/assets/49506284-a1f4-48b0-b0a7-224ce938dc19" />

Single disc - no disc title at all
<img width="793" height="400" alt="Screenshot_20260912_235644" src="https://github.com/user-attachments/assets/06b1ce62-2667-4fd1-b0b8-23960743688c" />
