### PR TITLE
fix: probe the local server address without switching onto it

### DIFF
--- a/app/src/main/java/com/eddyizm/tempus/App.java
+++ b/app/src/main/java/com/eddyizm/tempus/App.java
@@ -123,6 +123,23 @@ public class App extends Application {
         return new Subsonic(preferences);
     }
 
+    // A client pinned to the local address, so that address can be probed while the app carries on
+    // using the one it is already on. Moving the in use address to probe it pointed every screen at
+    // an address that may not answer.
+    public static Subsonic getSubsonicLocalClientInstance() {
+        SubsonicPreferences preferences = new SubsonicPreferences();
+        preferences.setServerUrl(Preferences.getLocalAddress());
+        preferences.setUsername(Preferences.getUser());
+        preferences.setAuthentication(
+                Preferences.getPassword(),
+                Preferences.getToken(),
+                Preferences.getSalt(),
+                Preferences.isLowScurity()
+        );
+
+        return new Subsonic(preferences);
+    }
+
     public static Github getGithubClientInstance() {
         if (github == null) {
             github = new Github();

--- a/app/src/main/java/com/eddyizm/tempus/App.java
+++ b/app/src/main/java/com/eddyizm/tempus/App.java
@@ -11,6 +11,7 @@ import androidx.preference.PreferenceManager;
 
 import com.eddyizm.tempus.github.Github;
 import com.eddyizm.tempus.helper.ThemeHelper;
+import com.eddyizm.tempus.model.Server;
 import com.eddyizm.tempus.subsonic.Subsonic;
 import com.eddyizm.tempus.subsonic.SubsonicPreferences;
 import com.eddyizm.tempus.ui.crash.CrashActivity;
@@ -123,19 +124,39 @@ public class App extends Application {
         return new Subsonic(preferences);
     }
 
-    // A client pinned to the local address, so that address can be probed while the app carries on
-    // using the one it is already on. Moving the in use address to probe it pointed every screen at
-    // an address that may not answer.
-    public static Subsonic getSubsonicLocalClientInstance() {
-        SubsonicPreferences preferences = new SubsonicPreferences();
-        preferences.setServerUrl(Preferences.getLocalAddress());
-        preferences.setUsername(Preferences.getUser());
-        preferences.setAuthentication(
+    // Pinned to one address instead of the one in use, so an address can be reached without the
+    // app being moved onto it first.
+    public static Subsonic getSubsonicClientInstance(String serverAddress) {
+        return buildSubsonicClient(
+                serverAddress,
+                Preferences.getUser(),
                 Preferences.getPassword(),
                 Preferences.getToken(),
                 Preferences.getSalt(),
                 Preferences.isLowScurity()
         );
+    }
+
+    // For a server the app is not signed in to, so it can be reached before anything about it is
+    // written to the preferences.
+    public static Subsonic getSubsonicClientInstance(Server server) {
+        return buildSubsonicClient(
+                server.getAddress(),
+                server.getUsername(),
+                server.getPassword(),
+                null,
+                null,
+                server.isLowSecurity()
+        );
+    }
+
+    private static Subsonic buildSubsonicClient(String serverAddress, String username,
+                                                String password, String token, String salt,
+                                                boolean isLowSecurity) {
+        SubsonicPreferences preferences = new SubsonicPreferences();
+        preferences.setServerUrl(serverAddress);
+        preferences.setUsername(username);
+        preferences.setAuthentication(password, token, salt, isLowSecurity);
 
         return new Subsonic(preferences);
     }

--- a/app/src/main/java/com/eddyizm/tempus/interfaces/SystemCallback.java
+++ b/app/src/main/java/com/eddyizm/tempus/interfaces/SystemCallback.java
@@ -6,4 +6,10 @@ import androidx.annotation.Keep;
 public interface SystemCallback {
     default void onError(Exception exception) {}
     default void onSuccess(String password, String token, String salt) {}
+
+    // The request failed at the transport. Defaults to onError, so a caller that does not care
+    // which of the two happened behaves as it did before.
+    default void onNetworkFailure(Exception exception) {
+        onError(exception);
+    }
 }

--- a/app/src/main/java/com/eddyizm/tempus/repository/SystemRepository.java
+++ b/app/src/main/java/com/eddyizm/tempus/repository/SystemRepository.java
@@ -13,7 +13,9 @@ import com.eddyizm.tempus.subsonic.base.ApiResponse;
 import com.eddyizm.tempus.subsonic.models.OpenSubsonicExtension;
 import com.eddyizm.tempus.subsonic.models.ResponseStatus;
 import com.eddyizm.tempus.subsonic.models.SubsonicResponse;
+import com.eddyizm.tempus.util.Preferences;
 
+import java.io.IOException;
 import java.util.List;
 
 import retrofit2.Call;
@@ -22,7 +24,12 @@ import retrofit2.Response;
 
 public class SystemRepository {
     public void checkUserCredential(SystemCallback callback) {
-        App.getSubsonicClientInstance(false)
+        checkUserCredential(App.getSubsonicClientInstance(false), callback);
+    }
+
+    // Takes the client so a server can be reached before anything about it is saved.
+    public void checkUserCredential(Subsonic client, SystemCallback callback) {
+        client
                 .getSystemClient()
                 .ping()
                 .enqueue(new Callback<ApiResponse>() {
@@ -47,7 +54,14 @@ public class SystemRepository {
 
                     @Override
                     public void onFailure(@NonNull Call<ApiResponse> call, @NonNull Throwable t) {
-                        callback.onError(new Exception(t.getMessage()));
+                        // Retrofit sends a body it cannot read here too, so a server answering
+                        // something that is not Subsonic would otherwise read as a network fault.
+                        Exception failure = new Exception(t.getMessage());
+                        if (t instanceof IOException) {
+                            callback.onNetworkFailure(failure);
+                        } else {
+                            callback.onError(failure);
+                        }
                     }
                 });
     }
@@ -57,7 +71,7 @@ public class SystemRepository {
     }
 
     public MutableLiveData<SubsonicResponse> pingLocalAddress() {
-        return ping(App.getSubsonicLocalClientInstance());
+        return ping(App.getSubsonicClientInstance(Preferences.getLocalAddress()));
     }
 
     private MutableLiveData<SubsonicResponse> ping(Subsonic client) {

--- a/app/src/main/java/com/eddyizm/tempus/repository/SystemRepository.java
+++ b/app/src/main/java/com/eddyizm/tempus/repository/SystemRepository.java
@@ -8,6 +8,7 @@ import androidx.lifecycle.MutableLiveData;
 import com.eddyizm.tempus.App;
 import com.eddyizm.tempus.github.models.LatestRelease;
 import com.eddyizm.tempus.interfaces.SystemCallback;
+import com.eddyizm.tempus.subsonic.Subsonic;
 import com.eddyizm.tempus.subsonic.base.ApiResponse;
 import com.eddyizm.tempus.subsonic.models.OpenSubsonicExtension;
 import com.eddyizm.tempus.subsonic.models.ResponseStatus;
@@ -52,9 +53,17 @@ public class SystemRepository {
     }
 
     public MutableLiveData<SubsonicResponse> ping() {
+        return ping(App.getSubsonicClientInstance(false));
+    }
+
+    public MutableLiveData<SubsonicResponse> pingLocalAddress() {
+        return ping(App.getSubsonicLocalClientInstance());
+    }
+
+    private MutableLiveData<SubsonicResponse> ping(Subsonic client) {
         MutableLiveData<SubsonicResponse> pingResult = new MutableLiveData<>();
 
-        App.getSubsonicClientInstance(false)
+        client
                 .getSystemClient()
                 .ping()
                 .enqueue(new Callback<ApiResponse>() {

--- a/app/src/main/java/com/eddyizm/tempus/service/BaseMediaService.kt
+++ b/app/src/main/java/com/eddyizm/tempus/service/BaseMediaService.kt
@@ -238,7 +238,14 @@ open class BaseMediaService : MediaLibraryService(), MediaManager.QueueTarget {
 
         // Map off the main thread: mapMediaItems does a blocking lookup per song, so a
         // large saved queue froze the UI on launch (#600).
+        //
+        // Every URL carries the address in force when the mapping ran, so the address is checked
+        // again on the main thread, immediately before the install, and a move starts it over.
         Thread {
+            // Nothing needs the queue until playback starts, so it waits for a tested address.
+            Preferences.awaitPingsAnswered()
+
+            val addressWhenMapped = Preferences.getInUseServerAddress()
             val queueRepository = QueueRepository()
             val storedQueue = queueRepository.media
             if (storedQueue.isNullOrEmpty()) return@Thread
@@ -268,6 +275,10 @@ open class BaseMediaService : MediaLibraryService(), MediaManager.QueueTarget {
                 // the mediaItemCount check below cannot detect a released player, so bail first.
                 if (serviceDestroyed) return@post
                 if (player.mediaItemCount > 0) return@post
+                if (addressWhenMapped != Preferences.getInUseServerAddress()) {
+                    restorePlayerFromQueue(player)
+                    return@post
+                }
                 player.setMediaItems(mediaItems, lastIndex, lastPosition)
                 player.prepare()
                 updateWidget(player)

--- a/app/src/main/java/com/eddyizm/tempus/service/MediaManager.java
+++ b/app/src/main/java/com/eddyizm/tempus/service/MediaManager.java
@@ -207,6 +207,14 @@ public class MediaManager {
                 try {
                     if (mediaBrowserListenableFuture.isDone()) {
                         if (mediaBrowserListenableFuture.get().getMediaItemCount() < 1) {
+                            // The media service restores this same saved queue when it is created,
+                            // and that path waits for the address pings to answer before it builds
+                            // a single URL. This one does not, and it was winning the race with a
+                            // queue built against an address the app was about to leave. Reaching
+                            // a browser at all means the service was created, so its own restore
+                            // is already in flight and nothing is lost by leaving it to it.
+                            if (Preferences.pingsOutstanding()) return;
+
                             List<Child> media = getQueueRepository().getMedia();
                             if (media != null && media.size() >= 1) {
                                 init(mediaBrowserListenableFuture, media);

--- a/app/src/main/java/com/eddyizm/tempus/service/MediaManager.java
+++ b/app/src/main/java/com/eddyizm/tempus/service/MediaManager.java
@@ -207,12 +207,8 @@ public class MediaManager {
                 try {
                     if (mediaBrowserListenableFuture.isDone()) {
                         if (mediaBrowserListenableFuture.get().getMediaItemCount() < 1) {
-                            // The media service restores this same saved queue when it is created,
-                            // and that path waits for the address pings to answer before it builds
-                            // a single URL. This one does not, and it was winning the race with a
-                            // queue built against an address the app was about to leave. Reaching
-                            // a browser at all means the service was created, so its own restore
-                            // is already in flight and nothing is lost by leaving it to it.
+                            // The service restores this same queue and waits for the pings first,
+                            // and reaching a browser means that restore is already in flight.
                             if (Preferences.pingsOutstanding()) return;
 
                             List<Child> media = getQueueRepository().getMedia();

--- a/app/src/main/java/com/eddyizm/tempus/subsonic/api/system/SystemClient.java
+++ b/app/src/main/java/com/eddyizm/tempus/subsonic/api/system/SystemClient.java
@@ -27,9 +27,8 @@ public class SystemClient {
         Log.d(TAG, "ping()");
         int timeoutSeconds = Preferences.getNetworkPingTimeout();
         Call<ApiResponse> pingCall = systemService.ping(subsonic.getParams());
-        // Keyed to the address this client points at, since a local probe now runs on a client of
-        // its own while the in use address is still the public one. A bare prefix test would call
-        // a public http://nas.duckdns.invalid local when the local address is http://nas.
+        // Keyed to the address this client points at, since a probe runs on its own client while
+        // the in use address is still the public one.
         boolean pingingLocalAddress = MusicUtil.isUnderAddress(
                 subsonic.getUrl(), Preferences.getLocalAddress());
 

--- a/app/src/main/java/com/eddyizm/tempus/subsonic/api/system/SystemClient.java
+++ b/app/src/main/java/com/eddyizm/tempus/subsonic/api/system/SystemClient.java
@@ -5,6 +5,7 @@ import android.util.Log;
 import com.eddyizm.tempus.subsonic.RetrofitClient;
 import com.eddyizm.tempus.subsonic.Subsonic;
 import com.eddyizm.tempus.subsonic.base.ApiResponse;
+import com.eddyizm.tempus.util.MusicUtil;
 import com.eddyizm.tempus.util.Preferences;
 
 import java.util.concurrent.TimeUnit;
@@ -26,7 +27,13 @@ public class SystemClient {
         Log.d(TAG, "ping()");
         int timeoutSeconds = Preferences.getNetworkPingTimeout();
         Call<ApiResponse> pingCall = systemService.ping(subsonic.getParams());
-        if (Preferences.isInUseServerAddressLocal()) {
+        // Keyed to the address this client points at, since a local probe now runs on a client of
+        // its own while the in use address is still the public one. A bare prefix test would call
+        // a public http://nas.duckdns.invalid local when the local address is http://nas.
+        boolean pingingLocalAddress = MusicUtil.isUnderAddress(
+                subsonic.getUrl(), Preferences.getLocalAddress());
+
+        if (pingingLocalAddress) {
             pingCall.timeout()
                     .timeout(timeoutSeconds, TimeUnit.SECONDS);
         } else {

--- a/app/src/main/java/com/eddyizm/tempus/subsonic/utils/CacheUtil.java
+++ b/app/src/main/java/com/eddyizm/tempus/subsonic/utils/CacheUtil.java
@@ -39,7 +39,9 @@ public class CacheUtil {
     };
 
 
-    private boolean isConnected() {
+    // Public so a caller can tell an unreachable server from a phone with no network at all. The
+    // offline branch above answers a synthetic 504 in that case, which says nothing on its own.
+    public static boolean isConnected() {
         ConnectivityManager connectivityManager = (ConnectivityManager) App.getContext().getSystemService(Context.CONNECTIVITY_SERVICE);
         if (connectivityManager == null) {
             return false;

--- a/app/src/main/java/com/eddyizm/tempus/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/activity/MainActivity.java
@@ -614,8 +614,7 @@ public class MainActivity extends BaseActivity {
             });
         } else {
             if (outstandingProbe != null) {
-                // A probe is deciding the address, so asking the public one now races it. The
-                // probe falls back to this ping itself when no local address answers.
+                // A probe is deciding the address, and it falls back to this ping when none answers.
                 Preferences.markPingAnswered();
             } else if (Preferences.isServerSwitchable()) {
                 probeLocalAddress();
@@ -639,20 +638,17 @@ public class MainActivity extends BaseActivity {
         }
     }
 
-    // Probed on a client of its own, so the app stays on an address that answers while the probe
-    // is outstanding. Moving the in use address in order to test it is what pointed every screen
-    // and the restored queue at an address that can have no route. A failed probe changes nothing.
+    // Probed on a client of its own, so the app is never moved onto an address that has not
+    // answered. A probe that fails changes nothing.
     private void probeLocalAddress() {
-        // The switch window is deliberately not stamped here. It is saved to disk and outlives the
-        // activity, while the probe dies with it, so an activity recreated before the answer came
-        // back could not probe again for fifteen seconds. It is stamped where the app acts instead.
+        // Not stamped here on purpose. The window outlives the activity and the probe does not, so
+        // stamping at send left a recreated activity unable to probe for fifteen seconds.
         String probedAddress = Preferences.getLocalAddress();
         LiveData<SubsonicResponse> probe = mainViewModel.pingLocalAddress();
         outstandingProbe = probe;
 
         probe.observe(this, subsonicResponse -> {
-            // An answer posted while stopped is held and delivered at the next start, after
-            // onStart has issued the next probe. Only the request's identity separates the two.
+            // A held answer is delivered after onStart has issued the next probe.
             boolean isCurrentProbe = probe == outstandingProbe;
             if (isCurrentProbe) outstandingProbe = null;
 
@@ -662,9 +658,8 @@ public class MainActivity extends BaseActivity {
                     || !probedAddress.equals(Preferences.getLocalAddress())) {
                 Preferences.markPingAnswered();
 
-                // No local address answered, so ask the public one, which this foreground has not
-                // done yet. The window is stamped first, or a probe slower than the window would
-                // send this call into another probe. The ping timeout has no upper bound.
+                // No local address answered, so ask the public one. The window is stamped first, or
+                // a probe slower than the window sends this call into another probe.
                 if (isCurrentProbe && subsonicResponse == null) {
                     Preferences.setServerSwitchableTimer();
                     pingServer();

--- a/app/src/main/java/com/eddyizm/tempus/ui/activity/MainActivity.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/activity/MainActivity.java
@@ -29,6 +29,7 @@ import androidx.core.view.ViewCompat;
 import androidx.core.view.WindowInsetsCompat;
 import androidx.drawerlayout.widget.DrawerLayout;
 import androidx.fragment.app.FragmentManager;
+import androidx.lifecycle.LiveData;
 import androidx.lifecycle.ViewModelProvider;
 import androidx.media3.common.MediaItem;
 import androidx.media3.common.MediaMetadata;
@@ -48,6 +49,7 @@ import com.eddyizm.tempus.helper.ThemeHelper;
 import com.eddyizm.tempus.navigation.NavigationController;
 import com.eddyizm.tempus.navigation.NavigationHelper;
 import com.eddyizm.tempus.service.MediaManager;
+import com.eddyizm.tempus.subsonic.models.SubsonicResponse;
 import com.eddyizm.tempus.ui.activity.base.BaseActivity;
 import com.eddyizm.tempus.navigation.BottomSheetController;
 import com.eddyizm.tempus.navigation.BottomSheetHelper;
@@ -77,6 +79,10 @@ import java.util.concurrent.ExecutionException;
 @UnstableApi
 public class MainActivity extends BaseActivity {
     private static final String TAG = "MainActivityLogs";
+
+    // The probe whose answer is still wanted, identified by the request itself. A flag shared by
+    // every probe cannot tell a held answer from a fresh one, since a held one arrives later.
+    private LiveData<SubsonicResponse> outstandingProbe = null;
 
     public ActivityMainBinding bind;
     private MainViewModel mainViewModel;
@@ -176,6 +182,13 @@ public class MainActivity extends BaseActivity {
         super.onResume();
         pingServer();
         toggleNavigationDrawerLockOnOrientationChange();
+    }
+
+    @Override
+    protected void onStop() {
+        // Abandon the probe, since its answer would be applied on whatever network we come back to.
+        outstandingProbe = null;
+        super.onStop();
     }
 
     @Override
@@ -569,9 +582,16 @@ public class MainActivity extends BaseActivity {
     private void pingServer() {
         if (Preferences.getToken() == null && Preferences.getPassword() == null) return;
 
+        Preferences.markPingIssued();
+
         if (Preferences.isInUseServerAddressLocal()) {
             mainViewModel.ping().observe(this, subsonicResponse -> {
                 if (subsonicResponse == null) {
+                    // onStart and onResume each ping, so two failures arrive for one unreachable
+                    // address, and the toggle below would put the second one straight back on it.
+                    Preferences.markPingAnswered();
+                    if (!Preferences.isInUseServerAddressLocal()) return;
+
                     // Switching only helps when remote and local are different addresses. When
                     // they're equal (issue #242) switchInUseServerAddress() is a no-op, so we'd
                     // re-enter this branch forever (ping/refresh/resetView loop). Treat that case
@@ -588,19 +608,25 @@ public class MainActivity extends BaseActivity {
                         dialog.show(getSupportFragmentManager(), null);
                     }
                 } else {
+                    Preferences.markPingAnswered();
                     Preferences.setOpenSubsonic(subsonicResponse.getOpenSubsonic() != null && subsonicResponse.getOpenSubsonic());
                 }
             });
         } else {
-            if (Preferences.isServerSwitchable()) {
-                Preferences.setServerSwitchableTimer();
-                Preferences.switchInUseServerAddress();
-                App.refreshSubsonicClient();
-                pingServer();
-                resetView();
+            if (outstandingProbe != null) {
+                // A probe is deciding the address, so asking the public one now races it. The
+                // probe falls back to this ping itself when no local address answers.
+                Preferences.markPingAnswered();
+            } else if (Preferences.isServerSwitchable()) {
+                probeLocalAddress();
             } else {
                 mainViewModel.ping().observe(this, subsonicResponse -> {
+                    Preferences.markPingAnswered();
                     if (subsonicResponse == null) {
+                        // A local address answered since, so this failure is stale. It matters
+                        // because one of the dialog's buttons clears the session and the queue.
+                        if (Preferences.isInUseServerAddressLocal() || outstandingProbe != null) return;
+
                         if (Preferences.showServerUnreachableDialog()) {
                             ServerUnreachableDialog dialog = new ServerUnreachableDialog();
                             dialog.show(getSupportFragmentManager(), null);
@@ -611,6 +637,52 @@ public class MainActivity extends BaseActivity {
                 });
             }
         }
+    }
+
+    // Probed on a client of its own, so the app stays on an address that answers while the probe
+    // is outstanding. Moving the in use address in order to test it is what pointed every screen
+    // and the restored queue at an address that can have no route. A failed probe changes nothing.
+    private void probeLocalAddress() {
+        // The switch window is deliberately not stamped here. It is saved to disk and outlives the
+        // activity, while the probe dies with it, so an activity recreated before the answer came
+        // back could not probe again for fifteen seconds. It is stamped where the app acts instead.
+        String probedAddress = Preferences.getLocalAddress();
+        LiveData<SubsonicResponse> probe = mainViewModel.pingLocalAddress();
+        outstandingProbe = probe;
+
+        probe.observe(this, subsonicResponse -> {
+            // An answer posted while stopped is held and delivered at the next start, after
+            // onStart has issued the next probe. Only the request's identity separates the two.
+            boolean isCurrentProbe = probe == outstandingProbe;
+            if (isCurrentProbe) outstandingProbe = null;
+
+            // A server change moves the local address, so a late answer would carry the wrong credentials.
+            if (!isCurrentProbe
+                    || subsonicResponse == null
+                    || !probedAddress.equals(Preferences.getLocalAddress())) {
+                Preferences.markPingAnswered();
+
+                // No local address answered, so ask the public one, which this foreground has not
+                // done yet. The window is stamped first, or a probe slower than the window would
+                // send this call into another probe. The ping timeout has no upper bound.
+                if (isCurrentProbe && subsonicResponse == null) {
+                    Preferences.setServerSwitchableTimer();
+                    pingServer();
+                }
+                return;
+            }
+
+            Preferences.setInUseServerAddress(probedAddress);
+            App.refreshSubsonicClient();
+
+            // Released only once the client points at the new address, or a mapping waking in
+            // between reads the new address and the old client.
+            Preferences.markPingAnswered();
+
+            // The screens were built against the address just left, so they are built again. The
+            // old code did this on every switch, and this runs only when the probe succeeded.
+            resetView();
+        });
     }
 
     private void resetView() {

--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/LoginFragment.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/LoginFragment.java
@@ -177,9 +177,20 @@ public class LoginFragment extends Fragment implements ClickCallback {
     }
 
     private void saveServerPreference(String serverId, String server, String localAddress, String user, String password, boolean isLowSecurity, String clientCert) {
+        // Only when the stored address belongs to some other server, so that a login inherits no
+        // address from the one selected before it. Tapping the same server again has to keep what
+        // onError's switchInUseServerAddress left behind, since that flip is how a second attempt
+        // reaches the local address when the public one has no route from where the user is. The
+        // server id cannot be the test, because onError clears it, so every later tap would look
+        // like a different server and write over the flip.
+        String inUseAddress = Preferences.getInUseServerAddress();
+        boolean addressIsThisServers = java.util.Objects.equals(inUseAddress, server)
+                || java.util.Objects.equals(inUseAddress, localAddress);
+
         Preferences.setServerId(serverId);
         Preferences.setServer(server);
         Preferences.setLocalAddress(localAddress);
+        if (!addressIsThisServers) Preferences.setInUseServerAddress(server);
         Preferences.setUser(user);
         Preferences.setPassword(password);
         Preferences.setLowSecurity(isLowSecurity);

--- a/app/src/main/java/com/eddyizm/tempus/ui/fragment/LoginFragment.java
+++ b/app/src/main/java/com/eddyizm/tempus/ui/fragment/LoginFragment.java
@@ -177,12 +177,9 @@ public class LoginFragment extends Fragment implements ClickCallback {
     }
 
     private void saveServerPreference(String serverId, String server, String localAddress, String user, String password, boolean isLowSecurity, String clientCert) {
-        // Only when the stored address belongs to some other server, so that a login inherits no
-        // address from the one selected before it. Tapping the same server again has to keep what
-        // onError's switchInUseServerAddress left behind, since that flip is how a second attempt
-        // reaches the local address when the public one has no route from where the user is. The
-        // server id cannot be the test, because onError clears it, so every later tap would look
-        // like a different server and write over the flip.
+        // Written only when the stored address belongs to another server. Tapping the same one
+        // again has to keep the flip onError made, which is how a second attempt reaches the local
+        // address. The server id cannot be the test, because onError clears it.
         String inUseAddress = Preferences.getInUseServerAddress();
         boolean addressIsThisServers = java.util.Objects.equals(inUseAddress, server)
                 || java.util.Objects.equals(inUseAddress, localAddress);

--- a/app/src/main/java/com/eddyizm/tempus/ui/login/LoginServerFragment.kt
+++ b/app/src/main/java/com/eddyizm/tempus/ui/login/LoginServerFragment.kt
@@ -16,19 +16,13 @@ import androidx.media3.common.util.UnstableApi
 import com.eddyizm.tempus.App
 import com.eddyizm.tempus.R
 import com.eddyizm.tempus.databinding.FragmentLoginServerBinding
+import com.eddyizm.tempus.interfaces.SystemCallback
 import com.eddyizm.tempus.model.Server
-import com.eddyizm.tempus.subsonic.utils.StringUtil
+import com.eddyizm.tempus.repository.SystemRepository
+import com.eddyizm.tempus.subsonic.utils.CacheUtil
 import com.eddyizm.tempus.ui.activity.MainActivity
 import com.eddyizm.tempus.viewmodel.ServerViewModel
-import okhttp3.Call
-import okhttp3.Callback
 import okhttp3.HttpUrl.Companion.toHttpUrlOrNull
-import okhttp3.OkHttpClient
-import okhttp3.Request
-import okhttp3.Response
-import org.json.JSONObject
-import java.io.IOException
-import java.util.UUID
 
 private const val ARG_SINGLE_PAGE_MODE = "single_page_mode"
 
@@ -390,76 +384,48 @@ class LoginServerFragment : Fragment() {
             Toast.LENGTH_SHORT
         ).show()
 
-        val serverUrl = serverList[selectedServerPosition].address
-        val username = serverList[selectedServerPosition].username
-        val password = serverList[selectedServerPosition].password
-        val clientName = "Tempus"
-        val apiVersion = "1.16.0"
-        val url: String
-
-        if (serverList[selectedServerPosition].isLowSecurity) {
-            url = "$serverUrl/rest/ping.view?u=$username&p=$password&v=$apiVersion&c=$clientName&f=json"
-        } else {
-            val salt = UUID.randomUUID().toString().substring(0, 6)
-            val token = StringUtil.tokenize(password + salt)
-            url = "$serverUrl/rest/ping.view?u=$username&t=$token&s=$salt&v=$apiVersion&c=$clientName&f=json"
-        }
-
-        val client = OkHttpClient()
-        val request = Request.Builder().url(url).build()
-
-        client.newCall(request).enqueue(object : Callback {
-            override fun onFailure(call: Call, e: IOException) {
-                binding.testButton.post {
-                    binding.testButton.isEnabled = true
-                    Toast.makeText(
-                        context,
-                        getString(R.string.la_server_toast_connection_error) + e.localizedMessage,
+        SystemRepository().checkUserCredential(
+            App.getSubsonicClientInstance(serverList[selectedServerPosition]),
+            object : SystemCallback {
+                override fun onNetworkFailure(exception: Exception) {
+                    showTestResult(
+                        R.string.la_server_toast_connection_error,
+                        exception.message,
                         Toast.LENGTH_LONG
-                    ).show()
+                    )
+                }
+
+                override fun onError(exception: Exception) {
+                    // The server answered, so this is not a network fault. With no network at
+                    // all it never answered, and the cache makes a 504 of its own that arrives
+                    // here instead of through onNetworkFailure.
+                    val messageId = if (CacheUtil.isConnected())
+                        R.string.la_server_toast_connection_failure
+                    else
+                        R.string.la_server_toast_connection_error
+
+                    showTestResult(messageId, exception.message, Toast.LENGTH_LONG)
+                }
+
+                override fun onSuccess(password: String?, token: String?, salt: String?) {
+                    showTestResult(
+                        R.string.la_server_toast_connection_success,
+                        null,
+                        Toast.LENGTH_SHORT
+                    )
                 }
             }
+        )
+    }
 
-            override fun onResponse(call: Call, response: Response) {
-                response.use {
-                    var isSubsonicOk = false
+    // The answer can arrive after the screen is gone. The text is resolved past the guard because
+    // getString reaches requireContext, which throws once the fragment is detached.
+    private fun showTestResult(messageId: Int, detail: String?, duration: Int) {
+        val binding = _binding ?: return
+        binding.testButton.isEnabled = true
 
-                    if (response.isSuccessful) {
-                        val responseBody = response.body?.string()
-                        if (responseBody != null) {
-                            try {
-                                val jsonRoot = JSONObject(responseBody)
-                                val subsonicResponse =
-                                    jsonRoot.getJSONObject("subsonic-response")
-                                if (subsonicResponse.getString("status") == "ok") {
-                                    isSubsonicOk = true
-                                }
-                            } catch (e: Exception) {
-                                e.printStackTrace()
-                            }
-                        }
-                    }
-
-                    // Switch back to Main Thread to update UI
-                    binding.testButton.post {
-                        binding.testButton.isEnabled = true
-                        if (isSubsonicOk) {
-                            Toast.makeText(
-                                context,
-                                getString(R.string.la_server_toast_connection_success),
-                                Toast.LENGTH_SHORT
-                            ).show()
-                        } else {
-                            Toast.makeText(
-                                context,
-                                getString(R.string.la_server_toast_connection_failure),
-                                Toast.LENGTH_LONG
-                            ).show()
-                        }
-                    }
-                }
-            }
-        })
+        val message = getString(messageId) + if (detail == null) "" else "\n" + detail
+        Toast.makeText(context, message, duration).show()
     }
 
     companion object {

--- a/app/src/main/java/com/eddyizm/tempus/util/MusicUtil.java
+++ b/app/src/main/java/com/eddyizm/tempus/util/MusicUtil.java
@@ -83,6 +83,19 @@ public class MusicUtil {
         return getStreamUri(id, 0);
     }
 
+    // A prefix test on its own is not enough, since a local address of http://nas is a prefix of
+    // the public http://nas.duckdns.invalid, and matching those would call one server the other. The
+    // character after the address has to be a path separator. Pure, so a test can reach it.
+    public static boolean isUnderAddress(String url, String address) {
+        if (url == null || address == null || address.isEmpty()) return false;
+
+        String base = address;
+        while (base.endsWith("/")) base = base.substring(0, base.length() - 1);
+        if (base.isEmpty() || !url.startsWith(base)) return false;
+
+        return url.length() == base.length() || url.charAt(base.length()) == '/';
+    }
+
     public static Uri updateStreamUri(Uri uri) {
         if (uri == null) return null;
 

--- a/app/src/main/java/com/eddyizm/tempus/util/MusicUtil.java
+++ b/app/src/main/java/com/eddyizm/tempus/util/MusicUtil.java
@@ -83,8 +83,7 @@ public class MusicUtil {
         return getStreamUri(id, 0);
     }
 
-    // A prefix test on its own is not enough, since a local address of http://nas is a prefix of
-    // the public http://nas.duckdns.invalid, and matching those would call one server the other. The
+    // A local address of http://nas is a prefix of the public http://nas.duckdns.invalid, so the
     // character after the address has to be a path separator. Pure, so a test can reach it.
     public static boolean isUnderAddress(String url, String address) {
         if (url == null || address == null || address.isEmpty()) return false;

--- a/app/src/main/java/com/eddyizm/tempus/util/Preferences.kt
+++ b/app/src/main/java/com/eddyizm/tempus/util/Preferences.kt
@@ -316,21 +316,14 @@ object Preferences {
             ?: getServer()
     }
 
-    // The play queue's stream URLs carry whichever server address was in force when the queue was
-    // built, and on a cold start away from the local network that saved address has not been tested
-    // yet. This lets the media service hold the queue back while the app is still finding out which
-    // address it is on, which costs nothing, since nothing needs the queue until playback starts.
-    //
-    // Counted, not latched. The media service is created and destroyed several times inside one
-    // process, so anything that can only fire once lets every later start through, which is what a
-    // CountDownLatch did here and it built the second cold start's queue against a stale address.
+    // The queue's stream URLs carry the address in force when it was built, so the media service
+    // holds the queue back until a ping answers. Counted, since the service starts several times.
     private val pingsInFlight = AtomicInteger(0)
 
     @Volatile
     private var lastPingIssuedAt = 0L
 
-    // The wait has to outlast the ping it is waiting on, and that ping's timeout is a user
-    // setting with no upper bound, so it is read instead of fixed.
+    // The ping timeout is a user setting with no upper bound, so the wait is read from it.
     private fun pingWaitMs(): Long = getNetworkPingTimeout() * 1000L + 1_000L
 
     @JvmStatic
@@ -344,10 +337,8 @@ object Preferences {
         pingsInFlight.updateAndGet { if (it > 0) it - 1 else 0 }
     }
 
-    // True while a recently issued ping has not answered. The age test is what stops a ping that
-    // never answers, an activity torn down while its request was out, from holding the queue back
-    // for the life of the process. A media button or Android Auto start with no activity behind
-    // it sees nothing outstanding and never waits.
+    // The age test stops a ping that never answers, an activity torn down mid request, from holding
+    // the queue for the life of the process. A start with no activity behind it never waits.
     @JvmStatic
     fun pingsOutstanding(): Boolean {
         return pingsInFlight.get() > 0 &&

--- a/app/src/main/java/com/eddyizm/tempus/util/Preferences.kt
+++ b/app/src/main/java/com/eddyizm/tempus/util/Preferences.kt
@@ -1,11 +1,13 @@
 package com.eddyizm.tempus.util
 
+import android.os.SystemClock
 import android.util.Log
 import androidx.core.content.edit
 import androidx.media3.common.Player
 import com.eddyizm.tempus.App
 import com.eddyizm.tempus.model.HomeSector
 import com.eddyizm.tempus.subsonic.models.OpenSubsonicExtension
+import java.util.concurrent.atomic.AtomicInteger
 import com.google.gson.Gson
 
 
@@ -312,6 +314,56 @@ object Preferences {
         return App.getInstance().preferences.getString(IN_USE_SERVER_ADDRESS, null)
             ?.takeIf { it.isNotBlank() }
             ?: getServer()
+    }
+
+    // The play queue's stream URLs carry whichever server address was in force when the queue was
+    // built, and on a cold start away from the local network that saved address has not been tested
+    // yet. This lets the media service hold the queue back while the app is still finding out which
+    // address it is on, which costs nothing, since nothing needs the queue until playback starts.
+    //
+    // Counted, not latched. The media service is created and destroyed several times inside one
+    // process, so anything that can only fire once lets every later start through, which is what a
+    // CountDownLatch did here and it built the second cold start's queue against a stale address.
+    private val pingsInFlight = AtomicInteger(0)
+
+    @Volatile
+    private var lastPingIssuedAt = 0L
+
+    // The wait has to outlast the ping it is waiting on, and that ping's timeout is a user
+    // setting with no upper bound, so it is read instead of fixed.
+    private fun pingWaitMs(): Long = getNetworkPingTimeout() * 1000L + 1_000L
+
+    @JvmStatic
+    fun markPingIssued() {
+        lastPingIssuedAt = SystemClock.elapsedRealtime()
+        pingsInFlight.incrementAndGet()
+    }
+
+    @JvmStatic
+    fun markPingAnswered() {
+        pingsInFlight.updateAndGet { if (it > 0) it - 1 else 0 }
+    }
+
+    // True while a recently issued ping has not answered. The age test is what stops a ping that
+    // never answers, an activity torn down while its request was out, from holding the queue back
+    // for the life of the process. A media button or Android Auto start with no activity behind
+    // it sees nothing outstanding and never waits.
+    @JvmStatic
+    fun pingsOutstanding(): Boolean {
+        return pingsInFlight.get() > 0 &&
+                SystemClock.elapsedRealtime() - lastPingIssuedAt < pingWaitMs()
+    }
+
+    @JvmStatic
+    fun awaitPingsAnswered() {
+        while (pingsOutstanding()) {
+            Thread.sleep(25)
+        }
+    }
+
+    @JvmStatic
+    fun setInUseServerAddress(address: String?) {
+        App.getInstance().preferences.edit().putString(IN_USE_SERVER_ADDRESS, address).apply()
     }
 
     @JvmStatic

--- a/app/src/main/java/com/eddyizm/tempus/viewmodel/MainViewModel.java
+++ b/app/src/main/java/com/eddyizm/tempus/viewmodel/MainViewModel.java
@@ -59,6 +59,10 @@ public class MainViewModel extends AndroidViewModel {
         return systemRepository.ping();
     }
 
+    public LiveData<SubsonicResponse> pingLocalAddress() {
+        return systemRepository.pingLocalAddress();
+    }
+
     public LiveData<List<OpenSubsonicExtension>> getOpenSubsonicExtensions() {
         return systemRepository.getOpenSubsonicExtensions();
     }

--- a/app/src/test/java/com/eddyizm/tempus/util/MusicUtilAddressTest.java
+++ b/app/src/test/java/com/eddyizm/tempus/util/MusicUtilAddressTest.java
@@ -1,0 +1,48 @@
+package com.eddyizm.tempus.util;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class MusicUtilAddressTest {
+
+    // One address being a text prefix of the other is not the same as sitting under it. This
+    // decides which timeout a ping gets, and a bare prefix test gave the public nas.duckdns.invalid
+    // the shorter one meant for a local address.
+    @Test
+    public void treatsANeighboringHostnameAsADifferentServer() {
+        assertFalse(MusicUtil.isUnderAddress("http://nas.duckdns.invalid/rest/ping", "http://nas"));
+    }
+
+    @Test
+    public void matchesAnAddressAndAnythingUnderIt() {
+        assertTrue(MusicUtil.isUnderAddress("http://nas/rest/ping", "http://nas"));
+        assertTrue(MusicUtil.isUnderAddress("http://nas", "http://nas"));
+    }
+
+    @Test
+    public void toleratesATrailingSlash() {
+        assertTrue(MusicUtil.isUnderAddress("http://nas/rest/ping", "http://nas/"));
+    }
+
+    // A server behind a reverse proxy is reached at a subpath, and that subpath is part of the
+    // address.
+    @Test
+    public void matchesAnAddressThatCarriesAPath() {
+        assertTrue(MusicUtil.isUnderAddress(
+                "https://example.invalid/navidrome/rest/ping", "https://example.invalid/navidrome"));
+        assertFalse(MusicUtil.isUnderAddress(
+                "https://example.invalid/other/rest/ping", "https://example.invalid/navidrome"));
+    }
+
+    @Test
+    public void handlesAMissingAddress() {
+        assertFalse(MusicUtil.isUnderAddress("http://nas/rest/ping", null));
+        assertFalse(MusicUtil.isUnderAddress("http://nas/rest/ping", ""));
+        assertFalse(MusicUtil.isUnderAddress(null, "http://nas"));
+    }
+}


### PR DESCRIPTION
### What is broken

Tempus lets you set a local network address next to the public one, and it picks between them by switching onto the local address and pinging it there. Everything the app is doing in that moment is aimed at an address that may have no route, including the saved play queue it rebuilds at launch. Start the app away from home and the whole restored queue points at your home network, so play and next do nothing while shuffle all works. When the ping fails the app switches back and reloads every screen.

The local address is now tested on a connection of its own, while the app carries on using the address it is already on. A test that gets no answer changes nothing, and the screens are reloaded only when one succeeds. The queue restore waits for that first answer, so no link is built from an address nothing has tried. Logging in also records which of a server's two addresses is in use, which it did not do before, so a login no longer inherits the address the previous server left behind.

### Tested

On a phone, both directions. At home every link in the restored queue is built on the local address. Away from home the local address times out, the app moves to the public one, the queue is built there and playback starts. Also tested with a long ping timeout. Unit tests cover the address matching.
